### PR TITLE
Fix expedition reset reverting creature levels to 1

### DIFF
--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -159,6 +159,10 @@ function handleFileUpload(event: Event) {
 function handleReset() {
   if (window.confirm('Reset all expedition parties and creature levels?')) {
     resetAllExpeditions()
+    autoFilledCreatures.clear()
+    for (const [id, level] of Object.entries(collectionLevels.value)) {
+      updateCreatureLevel(id, level)
+    }
   }
 }
 


### PR DESCRIPTION
## Description

The "Reset All" button in Expeditions was resetting owned creature levels back to 1 instead of restoring them to their Bestiary collection levels. This happened because the reset cleared the expedition creature levels map but never re-applied the levels from the collection, and the auto-fill watchEffect was blocked by a stale tracking Set.

## Summary
- Clear the `autoFilledCreatures` Set on reset so the auto-fill mechanism can re-process creatures
- Directly re-apply all owned creature levels from the Bestiary collection after resetting expedition state