### PR TITLE
Fix configs page edit crash from structuredClone on reactive proxies

### DIFF
--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -11,7 +11,7 @@ import {
   Plus,
   X,
 } from 'lucide-vue-next'
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, toRaw } from 'vue'
 
 import LevelPlannerCreaturePicker from '@/components/level-planner/LevelPlannerCreaturePicker.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
@@ -70,18 +70,18 @@ function startEditing(section: EditableSection) {
   switch (section) {
     case 'exclusions':
       sectionSnapshot = {
-        sanctuaryCreatureIds: structuredClone(sanctuaryCreatureIds.value),
-        helperCreatureIds: structuredClone(helperCreatureIds.value),
-        machineCreatureIds: structuredClone(machineCreatureIds.value),
+        sanctuaryCreatureIds: structuredClone(toRaw(sanctuaryCreatureIds.value)),
+        helperCreatureIds: structuredClone(toRaw(helperCreatureIds.value)),
+        machineCreatureIds: structuredClone(toRaw(machineCreatureIds.value)),
       }
       break
     case 'garden':
-      sectionSnapshot = structuredClone(gardenFlowers.value)
+      sectionSnapshot = structuredClone(toRaw(gardenFlowers.value))
       break
     case 'awaken':
       sectionSnapshot = {
-        awakenGatherUpgrades: structuredClone(awakenGatherUpgrades.value),
-        awakenSpeedTiers: structuredClone(awakenSpeedTiers.value),
+        awakenGatherUpgrades: structuredClone(toRaw(awakenGatherUpgrades.value)),
+        awakenSpeedTiers: structuredClone(toRaw(awakenSpeedTiers.value)),
       }
       break
   }


### PR DESCRIPTION
## Description

The configs page edit functionality was broken — clicking edit on any section threw a `DataCloneError` because `structuredClone` cannot clone Vue reactive proxy objects. This wraps each reactive `.value` with `toRaw()` before cloning.

## Summary
- Add `toRaw` import from Vue in ConfigsView
- Wrap all `structuredClone` calls in `startEditing()` with `toRaw()` to unwrap reactive proxies before cloning