### PR TITLE
Fix planner steps view crash on awakening steps

### DIFF
--- a/src/components/level-planner/PartyPlannerResults.vue
+++ b/src/components/level-planner/PartyPlannerResults.vue
@@ -135,11 +135,9 @@ const sortedIndices = computed(() => {
     const timeA = props.plan.steps[a].startTime ?? 0
     const timeB = props.plan.steps[b].startTime ?? 0
     if (timeA !== timeB) return timeA - timeB
-    return props.plan.steps[a].expedition.id.localeCompare(
-      props.plan.steps[b].expedition.id,
-      undefined,
-      { numeric: true },
-    )
+    const idA = props.plan.steps[a].expedition?.id ?? ''
+    const idB = props.plan.steps[b].expedition?.id ?? ''
+    return idA.localeCompare(idB, undefined, { numeric: true })
   })
 })
 


### PR DESCRIPTION
## Description

The Steps view in the party level planner crashes with a `TypeError: localeCompare` error when the plan includes an awakening step. Awakening steps are created with an empty expedition object (`{} as Expedition`), so `expedition.id` is `undefined`. The `sortedIndices` comparator accessed it without guarding.

## Summary
- Add optional chaining and empty string fallback for `expedition.id` in the `sortedIndices` sort comparator in PartyPlannerResults
- Only affects users whose plan includes an awakening step (leveling past pre-awaken max with a non-awakened creature)