### PR TITLE
Add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
## Description

Adds a root `.editorconfig` file so contributors with different editor/formatter defaults (e.g., Prettier on-save defaulting to CRLF) get consistent formatting without adding any dependencies. Every major editor supports EditorConfig natively, and oxc's formatter also reads it directly.

Closes #43

## Summary
- Add root `.editorconfig` with LF line endings, UTF-8 charset, 2-space indentation, final newline, and trailing whitespace trimming
- Eliminates contributor environment mismatches at the editor level with zero dependencies