### PR TITLE
Fix expedition list order to match in-game sort

### DIFF
--- a/src/composables/useExpeditions.ts
+++ b/src/composables/useExpeditions.ts
@@ -46,9 +46,9 @@ export function useExpeditions(creatures: Creature[]) {
         return matchesSearch && matchesBiome
       })
       .toSorted((a, b) => {
-        const aNum = parseInt(a.id.replace(/\D/g, ''), 10) || 0
-        const bNum = parseInt(b.id.replace(/\D/g, ''), 10) || 0
-        return aNum - bNum
+        const diff = a.requiredExpeditionCompletions - b.requiredExpeditionCompletions
+        if (diff !== 0) return diff
+        return a.baseRating - b.baseRating
       })
   })
 


### PR DESCRIPTION
## Description

The wiki displayed expeditions sorted by their ID number, but the game sorts them by `requiredExpeditionCompletions`. This caused "Rescue Lost Creatures" (type-14, 300 completions) to appear after "Tracking Rare Creature" instead of after "Supply Delivery" (also 300 completions) where it belongs in-game.

## Summary
- Update `filteredExpeditions` sort in `useExpeditions.ts` to order by `requiredExpeditionCompletions` instead of numeric ID
- Use `baseRating` as tiebreaker for expeditions with the same completion requirement