### PR TITLE
Fix expedition ordering in planner steps

### DIFF
--- a/src/components/level-planner/PartyPlannerResults.vue
+++ b/src/components/level-planner/PartyPlannerResults.vue
@@ -135,9 +135,12 @@ const sortedIndices = computed(() => {
     const timeA = props.plan.steps[a].startTime ?? 0
     const timeB = props.plan.steps[b].startTime ?? 0
     if (timeA !== timeB) return timeA - timeB
-    const idA = props.plan.steps[a].expedition?.id ?? ''
-    const idB = props.plan.steps[b].expedition?.id ?? ''
-    return idA.localeCompare(idB, undefined, { numeric: true })
+    const expA = props.plan.steps[a].expedition
+    const expB = props.plan.steps[b].expedition
+    const completionDiff =
+      (expA?.requiredExpeditionCompletions ?? 0) - (expB?.requiredExpeditionCompletions ?? 0)
+    if (completionDiff !== 0) return completionDiff
+    return (expA?.baseRating ?? 0) - (expB?.baseRating ?? 0)
   })
 })
 


### PR DESCRIPTION
## Description

The planner's step view was sorting expeditions within the same wave by expedition ID string comparison, which didn't match the in-game sort order used on the expeditions page. This updates the sort to use `requiredExpeditionCompletions` then `baseRating`, consistent with the expeditions page.

## Summary
- Update `PartyPlannerResults.vue` sortedIndices tiebreaker to sort by `requiredExpeditionCompletions` (ascending) then `baseRating` (ascending) instead of `expedition.id` string comparison