### PR TITLE
Add creature stat columns to Bestiary table view

### DIFF
--- a/e2e/beastiary.spec.ts
+++ b/e2e/beastiary.spec.ts
@@ -450,7 +450,7 @@ test.describe('table view', () => {
 
   test('trait column shows abbreviated names', async ({ page }) => {
     // Search for a creature with a long trait to verify abbreviation
-    await page.getByPlaceholder('Search').fill('Cinder')
+    await page.getByPlaceholder('Search').fill('Sunny')
     const traitCell = page.locator('tbody tr .trait-chip')
     const traitText = await traitCell.first().textContent()
     // "heat-resistance" should be abbreviated to "Heat Res"

--- a/e2e/beastiary.spec.ts
+++ b/e2e/beastiary.spec.ts
@@ -388,10 +388,10 @@ test.describe('table view', () => {
     const nameTh = page.locator('th', { has: page.getByRole('button', { name: /Name/ }) })
     await expect(nameTh).toHaveAttribute('aria-sort', 'ascending')
 
-    const firstCell = page.locator('tbody tr:first-child td:first-child')
-    const secondCell = page.locator('tbody tr:nth-child(2) td:first-child')
-    const first = await firstCell.textContent()
-    const second = await secondCell.textContent()
+    const firstName = page.locator('tbody tr:first-child td:first-child .font-semibold')
+    const secondName = page.locator('tbody tr:nth-child(2) td:first-child .font-semibold')
+    const first = await firstName.textContent()
+    const second = await secondName.textContent()
     expect(first!.localeCompare(second!)).toBeLessThanOrEqual(0)
   })
 
@@ -435,14 +435,15 @@ test.describe('table view', () => {
     await expect(totalButtons).toHaveCount(2)
 
     // Click the first Total (stat total) to sort
-    await totalButtons.first().click()
-    const totalTh = page.locator('th', { has: totalButtons.first() })
-    await expect(totalTh).toHaveAttribute('aria-sort', 'ascending')
+    const statTotalBtn = totalButtons.nth(0)
+    await statTotalBtn.click()
+    const statTotalTh = statTotalBtn.locator('..')
+    await expect(statTotalTh).toHaveAttribute('aria-sort', 'ascending')
   })
 
   test('tier badge is shown on creature images', async ({ page }) => {
-    // Tier badges should be visible in the name column (no separate Tier column)
-    const tierBadges = page.locator('tbody td:first-child span', { hasText: /^T\d$/ })
+    // Tier badges are absolute-positioned spans inside the creature image container
+    const tierBadges = page.locator('tbody td:first-child span.absolute', { hasText: /T\d/ })
     const count = await tierBadges.count()
     expect(count).toBe(120)
   })

--- a/e2e/beastiary.spec.ts
+++ b/e2e/beastiary.spec.ts
@@ -404,6 +404,58 @@ test.describe('table view', () => {
     await expect(nameTh).toHaveAttribute('aria-sort', 'descending')
   })
 
+  test('clicking same header three times clears sort', async ({ page }) => {
+    const nameBtn = page.getByRole('button', { name: /Name/ })
+    await nameBtn.click()
+    await nameBtn.click()
+    await nameBtn.click()
+
+    const nameTh = page.locator('th', { has: page.getByRole('button', { name: /Name/ }) })
+    await expect(nameTh).toHaveAttribute('aria-sort', 'none')
+  })
+
+  test('stat columns are visible and sortable', async ({ page }) => {
+    // Verify stat column headers exist
+    await expect(page.getByRole('button', { name: /POW/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /GRT/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /AGI/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /SMT/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /LOT/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /LCK/ })).toBeVisible()
+
+    // Click POW to sort ascending
+    await page.getByRole('button', { name: /POW/ }).click()
+    const powTh = page.locator('th', { has: page.getByRole('button', { name: /POW/ }) })
+    await expect(powTh).toHaveAttribute('aria-sort', 'ascending')
+  })
+
+  test('stat total column is visible and sortable', async ({ page }) => {
+    // There are two "Total" buttons (stat total and job total)
+    const totalButtons = page.getByRole('button', { name: /^Total/ })
+    await expect(totalButtons).toHaveCount(2)
+
+    // Click the first Total (stat total) to sort
+    await totalButtons.first().click()
+    const totalTh = page.locator('th', { has: totalButtons.first() })
+    await expect(totalTh).toHaveAttribute('aria-sort', 'ascending')
+  })
+
+  test('tier badge is shown on creature images', async ({ page }) => {
+    // Tier badges should be visible in the name column (no separate Tier column)
+    const tierBadges = page.locator('tbody td:first-child span', { hasText: /^T\d$/ })
+    const count = await tierBadges.count()
+    expect(count).toBe(120)
+  })
+
+  test('trait column shows abbreviated names', async ({ page }) => {
+    // Search for a creature with a long trait to verify abbreviation
+    await page.getByPlaceholder('Search').fill('Cinder')
+    const traitCell = page.locator('tbody tr .trait-chip')
+    const traitText = await traitCell.first().textContent()
+    // "heat-resistance" should be abbreviated to "Heat Res"
+    expect(traitText!.trim()).toBe('Heat Res')
+  })
+
   test('search filters table rows', async ({ page }) => {
     await page.getByPlaceholder('Search').fill('Moss')
     const rows = page.locator('tbody tr')

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -11,6 +11,7 @@ import {
   getLoopXpBonus,
   getRecommendedCreatures,
   levelFromXp,
+  traitAbbreviations,
   xpForLevel,
 } from '@/utils/formulas'
 
@@ -632,5 +633,27 @@ describe('creature fit affects expedition performance', () => {
     const badXpRate = xpPerCreature / badDuration
 
     expect(goodXpRate).toBeGreaterThan(badXpRate)
+  })
+})
+
+// ── Trait abbreviations ─────────────────────────────────────────────
+
+describe('traitAbbreviations', () => {
+  test('covers every trait in creatures data', () => {
+    const allTraits = new Set(creatures.map((c) => c.trait))
+    for (const trait of allTraits) {
+      expect(traitAbbreviations).toHaveProperty(trait)
+    }
+  })
+
+  test('all abbreviations are shorter than or equal to their full trait name', () => {
+    for (const [trait, abbrev] of Object.entries(traitAbbreviations)) {
+      expect(abbrev.length).toBeLessThanOrEqual(trait.length)
+    }
+  })
+
+  test('no duplicate abbreviations', () => {
+    const values = Object.values(traitAbbreviations)
+    expect(new Set(values).size).toBe(values.length)
   })
 })

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -21,6 +21,22 @@ export const statAbbreviations: Record<keyof CreatureStats, string> = {
   luck: 'LCK',
 }
 
+export const traitAbbreviations: Record<string, string> = {
+  'cold-resistance': 'Cold Res',
+  'heat-resistance': 'Heat Res',
+  'poison-resistance': 'Poison Res',
+  'water-breathing': 'Water Brt',
+  'hard-shell': 'Hard Shell',
+  'night-vision': 'Night Vis',
+  camouflage: 'Camo',
+  gatherer: 'Gatherer',
+  learner: 'Learner',
+  lucky: 'Lucky',
+  regeneration: 'Regen',
+  scouting: 'Scouting',
+  tracking: 'Tracking',
+}
+
 export const jobLabels: Record<keyof Creature['jobs'], string> = {
   chopping: 'Chopping',
   mining: 'Mining',

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -275,7 +275,7 @@ type SortKey =
   | 'jobTotal'
   | keyof CreatureStats
   | keyof Jobs
-const tableSortKey = ref<SortKey>('name')
+const tableSortKey = ref<SortKey | null>(null)
 const tableSortDirection = ref<'asc' | 'desc'>('asc')
 
 
@@ -292,11 +292,12 @@ const statEntries = computed(() => Object.entries(statLabels) as [keyof Creature
 
 
 const sortedCreatures = computed(() => {
+  const key = tableSortKey.value
+  if (key === null) return displayCreatures.value
+
   const list = [...displayCreatures.value]
   list.sort((a, b) => {
     let result = 0
-
-    const key = tableSortKey.value
     if (key === 'name') result = a.name.localeCompare(b.name)
     else if (key === 'type') result = (a.types[0] ?? '').localeCompare(b.types[0] ?? '')
     else if (key === 'trait') result = a.trait.localeCompare(b.trait)
@@ -324,7 +325,12 @@ function totalJobs(creature: Creature): number {
 
 function sortBy(key: SortKey) {
   if (tableSortKey.value === key) {
-    tableSortDirection.value = tableSortDirection.value === 'asc' ? 'desc' : 'asc'
+    if (tableSortDirection.value === 'asc') {
+      tableSortDirection.value = 'desc'
+    } else {
+      tableSortKey.value = null
+      tableSortDirection.value = 'asc'
+    }
     return
   }
   tableSortKey.value = key

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -14,6 +14,7 @@ import { toTitleCase, typeColor, typeColorVar } from '@/utils/format'
 import {
   jobColors,
   jobLabels,
+  statAbbreviations,
   statLabels,
   getBestExpeditionsForCreature,
   maxLevelForState,
@@ -265,7 +266,15 @@ function removeFilter(key: string) {
 const selectedCreature = ref<Creature | null>(null)
 
 
-type SortKey = 'name' | 'tier' | 'type' | 'trait' | 'jobTotal' | keyof Jobs
+type SortKey =
+  | 'name'
+  | 'tier'
+  | 'type'
+  | 'trait'
+  | 'statTotal'
+  | 'jobTotal'
+  | keyof CreatureStats
+  | keyof Jobs
 const tableSortKey = ref<SortKey>('tier')
 const tableSortDirection = ref<'asc' | 'desc'>('asc')
 
@@ -292,13 +301,21 @@ const sortedCreatures = computed(() => {
     else if (key === 'tier') result = a.tier - b.tier
     else if (key === 'type') result = (a.types[0] ?? '').localeCompare(b.types[0] ?? '')
     else if (key === 'trait') result = a.trait.localeCompare(b.trait)
+    else if (key === 'statTotal') result = totalStats(a) - totalStats(b)
     else if (key === 'jobTotal') result = totalJobs(a) - totalJobs(b)
-    else result = a.jobs[key] - b.jobs[key]
+    else if (key in statLabels)
+      result = a.stats[key as keyof CreatureStats] - b.stats[key as keyof CreatureStats]
+    else result = a.jobs[key as keyof Jobs] - b.jobs[key as keyof Jobs]
 
     return tableSortDirection.value === 'asc' ? result : -result
   })
   return list
 })
+
+
+function totalStats(creature: Creature): number {
+  return Object.values(creature.stats).reduce((sum, value) => sum + value, 0)
+}
 
 
 function totalJobs(creature: Creature): number {
@@ -814,6 +831,48 @@ const maxJobLevel = 10
                   </button>
                 </th>
                 <th
+                  v-for="[statKey] in statEntries"
+                  :key="statKey"
+                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  :aria-sort="
+                    tableSortKey === statKey
+                      ? tableSortDirection === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  "
+                >
+                  <button
+                    class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
+                    @click="sortBy(statKey)"
+                  >
+                    {{ statAbbreviations[statKey] }}
+                    <span :class="tableSortKey === statKey ? 'text-primary' : 'opacity-0'">{{
+                      tableSortDirection === 'asc' ? '▲' : '▼'
+                    }}</span>
+                  </button>
+                </th>
+                <th
+                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  :aria-sort="
+                    tableSortKey === 'statTotal'
+                      ? tableSortDirection === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : 'none'
+                  "
+                >
+                  <button
+                    class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
+                    @click="sortBy('statTotal')"
+                  >
+                    Total
+                    <span :class="tableSortKey === 'statTotal' ? 'text-primary' : 'opacity-0'">{{
+                      tableSortDirection === 'asc' ? '▲' : '▼'
+                    }}</span>
+                  </button>
+                </th>
+                <th
                   v-for="[jobKey, jobName] in jobEntries"
                   :key="jobKey"
                   class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
@@ -943,6 +1002,16 @@ const maxJobLevel = 10
                 </td>
                 <td class="px-2 py-2.5">
                   <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
+                </td>
+                <td
+                  v-for="[statKey] in statEntries"
+                  :key="statKey"
+                  class="px-2 py-2.5 font-mono text-xs text-muted-foreground"
+                >
+                  {{ creature.stats[statKey] }}
+                </td>
+                <td class="px-2 py-2.5 font-mono text-xs font-semibold text-foreground">
+                  {{ totalStats(creature) }}
                 </td>
                 <td v-for="[jobKey] in jobEntries" :key="jobKey" class="px-2 py-2.5">
                   <div class="flex items-center gap-2">

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -832,9 +832,10 @@ const maxJobLevel = 10
                   </button>
                 </th>
                 <th
-                  v-for="[statKey] in statEntries"
+                  v-for="([statKey], index) in statEntries"
                   :key="statKey"
-                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  :class="{ 'border-l border-border/40': index === 0 }"
                   :aria-sort="
                     tableSortKey === statKey
                       ? tableSortDirection === 'asc'
@@ -854,7 +855,7 @@ const maxJobLevel = 10
                   </button>
                 </th>
                 <th
-                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
                   :aria-sort="
                     tableSortKey === 'statTotal'
                       ? tableSortDirection === 'asc'
@@ -874,9 +875,10 @@ const maxJobLevel = 10
                   </button>
                 </th>
                 <th
-                  v-for="[jobKey, jobName] in jobEntries"
+                  v-for="([jobKey, jobName], index) in jobEntries"
                   :key="jobKey"
-                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  :class="{ 'border-l border-border/40': index === 0 }"
                   :aria-sort="
                     tableSortKey === jobKey
                       ? tableSortDirection === 'asc'
@@ -908,7 +910,7 @@ const maxJobLevel = 10
                   </button>
                 </th>
                 <th
-                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
+                  class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
                   :aria-sort="
                     tableSortKey === 'jobTotal'
                       ? tableSortDirection === 'asc'
@@ -1007,16 +1009,24 @@ const maxJobLevel = 10
                   }}</span>
                 </td>
                 <td
-                  v-for="[statKey] in statEntries"
+                  v-for="([statKey], index) in statEntries"
                   :key="statKey"
-                  class="px-2 py-2.5 font-mono text-xs text-muted-foreground"
+                  class="px-2 py-2.5 text-center font-mono text-xs text-muted-foreground [font-variant-numeric:tabular-nums]"
+                  :class="{ 'border-l border-border/40': index === 0 }"
                 >
                   {{ creature.stats[statKey] }}
                 </td>
-                <td class="px-2 py-2.5 font-mono text-xs font-semibold text-foreground">
+                <td
+                  class="px-2 py-2.5 text-center font-mono text-xs font-semibold text-foreground [font-variant-numeric:tabular-nums]"
+                >
                   {{ totalStats(creature) }}
                 </td>
-                <td v-for="[jobKey] in jobEntries" :key="jobKey" class="px-2 py-2.5">
+                <td
+                  v-for="([jobKey], index) in jobEntries"
+                  :key="jobKey"
+                  class="px-2 py-2.5"
+                  :class="{ 'border-l border-border/40': index === 0 }"
+                >
                   <div class="flex items-center gap-2">
                     <div class="relative h-2 w-10 overflow-hidden rounded-full bg-muted/60">
                       <div
@@ -1028,12 +1038,14 @@ const maxJobLevel = 10
                       />
                     </div>
                     <span
-                      class="w-4 text-right font-mono text-xs font-semibold text-muted-foreground"
+                      class="w-4 text-right font-mono text-xs font-semibold text-muted-foreground [font-variant-numeric:tabular-nums]"
                       >{{ creature.jobs[jobKey] }}</span
                     >
                   </div>
                 </td>
-                <td class="px-2 py-2.5 font-mono text-xs font-semibold text-foreground">
+                <td
+                  class="px-2 py-2.5 text-center font-mono text-xs font-semibold text-foreground [font-variant-numeric:tabular-nums]"
+                >
                   {{ totalJobs(creature) }}
                 </td>
               </tr>

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -16,6 +16,7 @@ import {
   jobLabels,
   statAbbreviations,
   statLabels,
+  traitAbbreviations,
   getBestExpeditionsForCreature,
   maxLevelForState,
 } from '@/utils/formulas'
@@ -1000,8 +1001,10 @@ const maxJobLevel = 10
                     </span>
                   </div>
                 </td>
-                <td class="px-2 py-2.5">
-                  <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
+                <td class="whitespace-nowrap px-2 py-2.5">
+                  <span class="trait-chip">{{
+                    traitAbbreviations[creature.trait] ?? toTitleCase(creature.trait)
+                  }}</span>
                 </td>
                 <td
                   v-for="[statKey] in statEntries"

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -269,14 +269,13 @@ const selectedCreature = ref<Creature | null>(null)
 
 type SortKey =
   | 'name'
-  | 'tier'
   | 'type'
   | 'trait'
   | 'statTotal'
   | 'jobTotal'
   | keyof CreatureStats
   | keyof Jobs
-const tableSortKey = ref<SortKey>('tier')
+const tableSortKey = ref<SortKey>('name')
 const tableSortDirection = ref<'asc' | 'desc'>('asc')
 
 
@@ -299,7 +298,6 @@ const sortedCreatures = computed(() => {
 
     const key = tableSortKey.value
     if (key === 'name') result = a.name.localeCompare(b.name)
-    else if (key === 'tier') result = a.tier - b.tier
     else if (key === 'type') result = (a.types[0] ?? '').localeCompare(b.types[0] ?? '')
     else if (key === 'trait') result = a.trait.localeCompare(b.trait)
     else if (key === 'statTotal') result = totalStats(a) - totalStats(b)
@@ -774,26 +772,6 @@ const maxJobLevel = 10
                 <th
                   class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
                   :aria-sort="
-                    tableSortKey === 'tier'
-                      ? tableSortDirection === 'asc'
-                        ? 'ascending'
-                        : 'descending'
-                      : 'none'
-                  "
-                >
-                  <button
-                    class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                    @click="sortBy('tier')"
-                  >
-                    Tier
-                    <span :class="tableSortKey === 'tier' ? 'text-primary' : 'opacity-0'">{{
-                      tableSortDirection === 'asc' ? '▲' : '▼'
-                    }}</span>
-                  </button>
-                </th>
-                <th
-                  class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-                  :aria-sort="
                     tableSortKey === 'type'
                       ? tableSortDirection === 'asc'
                         ? 'ascending'
@@ -954,7 +932,7 @@ const maxJobLevel = 10
                 >
                   <div class="flex items-center gap-3">
                     <div
-                      class="inline-flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border text-xs font-bold text-muted-foreground"
+                      class="relative inline-flex size-10 shrink-0 items-center justify-center overflow-visible rounded-lg border border-border text-xs font-bold text-muted-foreground"
                       :style="{
                         backgroundColor: 'hsl(' + typeColorVar(creature.types[0]) + ' / 0.1)',
                       }"
@@ -967,6 +945,11 @@ const maxJobLevel = 10
                         loading="lazy"
                       />
                       <span v-else>{{ creature.name.charAt(0) }}</span>
+                      <span
+                        class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-[9px] font-bold text-muted-foreground shadow-sm"
+                      >
+                        T{{ creature.tier + 1 }}
+                      </span>
                     </div>
                     <span
                       class="font-semibold"
@@ -984,9 +967,6 @@ const maxJobLevel = 10
                       >★</span
                     >
                   </div>
-                </td>
-                <td class="px-2 py-2.5 font-mono text-xs text-muted-foreground">
-                  T{{ creature.tier + 1 }}
                 </td>
                 <td class="px-2 py-2.5">
                   <div class="flex flex-wrap gap-1">


### PR DESCRIPTION
## Description

The Bestiary table view previously showed Name, Tier, Type, Trait, and Job columns but no creature stats. This adds stat columns with sorting, improves number readability, abbreviates long trait names, replaces the Tier column with a compact image badge, and introduces a 3-state sort toggle across all sortable headers.

Closes #87

## Summary
- Add 6 stat columns (POW, GRT, AGI, SMT, LOT, LCK) and a Stat Total column using the existing `statEntries` computed property and `statAbbreviations` labels
- Add `traitAbbreviations` map in `formulas.ts` to shorten long trait names (e.g. "heat-resistance" → "Heat Res") with a `toTitleCase` fallback for unknown traits
- Center-align stat/job numeric columns with `tabular-nums` for consistent digit widths, and add vertical border separators between column groups
- Replace the Tier column with a dog-ear badge on the creature thumbnail, matching the grid view's tier badge style
- Add 3-state sort toggle: clicking a header cycles ascending → descending → unsorted (default order)
- Add e2e tests for stat columns, sort toggle, tier badge, and trait abbreviations; add unit tests for `traitAbbreviations` coverage