### PR TITLE
Add alternative expedition routes to single-mode level planner

### DIFF
--- a/e2e/planner.spec.ts
+++ b/e2e/planner.spec.ts
@@ -533,3 +533,134 @@ test.describe('level up - expedition filter', () => {
     await expect(expSection.getByText('Filtered')).toBeHidden()
   })
 })
+
+// ── Level Up — alternative routes ─────────────────────────────────
+
+test.describe('level up - alternative routes', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('./planner?tab=levelup')
+    await page.evaluate(() => localStorage.clear())
+    await seedCreatures(page)
+  })
+
+  test('expanding a step shows Alternative Routes when multiple expeditions available', async ({
+    page,
+  }) => {
+    // Include all expeditions so alternatives appear
+    await page.goto('./planner?tab=levelup&creature=moss&target=70')
+    await page.locator('h1', { hasText: 'Moss Leveling' }).waitFor()
+
+    // Expand expedition filter and include all
+    await page.getByText('Expeditions', { exact: true }).first().click()
+    await page.getByRole('button', { name: 'Include All' }).click()
+    await expect(page.getByText('20 of 20 included')).toBeVisible()
+
+    // Wait for plan to recalculate, then expand first step
+    await page.locator('button[aria-expanded]').first().waitFor()
+    await page.locator('button[aria-expanded="false"]').first().click()
+
+    // Alternative Routes header should be visible
+    await expect(page.getByText('Alternative Routes')).toBeVisible()
+  })
+
+  test('clicking an alternative replans and shows Override badge', async ({ page }) => {
+    // Include all expeditions so alternatives appear
+    await page.goto('./planner?tab=levelup&creature=moss&target=70')
+    await page.locator('h1', { hasText: 'Moss Leveling' }).waitFor()
+
+    await page.getByText('Expeditions', { exact: true }).first().click()
+    await page.getByRole('button', { name: 'Include All' }).click()
+    await expect(page.getByText('20 of 20 included')).toBeVisible()
+
+    // Expand first step
+    await page.locator('button[aria-expanded]').first().waitFor()
+    await page.locator('button[aria-expanded="false"]').first().click()
+    await page.getByText('Alternative Routes').waitFor()
+
+    // Click the first alternative route button
+    const altSection = page.locator('div', { hasText: 'Alternative Routes' }).last()
+    const altButton = altSection.locator('button').first()
+    if ((await altButton.count()) > 0) {
+      await altButton.click()
+
+      // Override badge should appear
+      await expect(page.getByText('Override').first()).toBeVisible({ timeout: 10000 })
+    }
+  })
+})
+
+// ── Level Up — prestige mode ──────────────────────────────────────
+
+test.describe('level up - prestige mode', () => {
+  test('awakened creature at max level shows prestige step instead of max message', async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'creature-collection',
+        JSON.stringify({ moss: { owned: true, level: 120, awakened: true } }),
+      )
+    })
+    await page.goto('./planner?tab=levelup&creature=moss&target=120')
+    await page.locator('h1', { hasText: 'Moss Leveling' }).waitFor()
+
+    // Should show Prestige step, not "Already at max level"
+    await expect(page.getByText('Prestige Creature')).toBeVisible()
+    await expect(page.getByText('Already at max level!')).toBeHidden()
+  })
+
+  test('prestige step shows correct level range 120→1', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'creature-collection',
+        JSON.stringify({ moss: { owned: true, level: 120, awakened: true } }),
+      )
+    })
+    await page.goto('./planner?tab=levelup&creature=moss&target=120')
+    await page.locator('h1', { hasText: 'Moss Leveling' }).waitFor()
+
+    // Should show LVL 120→1
+    await expect(page.getByText('LVL 120→1')).toBeVisible()
+  })
+})
+
+// ── Level Up — creature grid selector ─────────────────────────────
+
+test.describe('level up - creature grid selector', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('./planner?tab=levelup')
+    await page.evaluate(() => localStorage.clear())
+    await seedCreatures(page)
+  })
+
+  test('creature grid is visible in single mode', async ({ page }) => {
+    await page.goto('./planner?tab=levelup')
+    await page.locator('h1', { hasText: 'Level Up Planner' }).waitFor()
+
+    // Creature grid should show owned creature names
+    await expect(page.getByText('Moss').first()).toBeVisible()
+    await expect(page.getByText('Scoots').first()).toBeVisible()
+  })
+
+  test('clicking a creature tile selects it and shows plan', async ({ page }) => {
+    await page.goto('./planner?tab=levelup')
+    await page.locator('h1', { hasText: 'Level Up Planner' }).waitFor()
+
+    // Click on Moss tile
+    await page.locator('button', { hasText: 'Moss' }).first().click()
+
+    // Heading should update and plan should show
+    await page.locator('h1', { hasText: 'Moss Leveling' }).waitFor()
+    await expect(page.getByText(/\d+ step/).first()).toBeVisible()
+  })
+
+  test('summary shows creature name and image', async ({ page }) => {
+    await page.goto('./planner?tab=levelup&creature=moss&target=70')
+    await page.locator('h1', { hasText: 'Moss Leveling' }).waitFor()
+
+    // Summary card contains "Leveling Plan" text
+    const summary = page.locator('.surface-card', { hasText: 'Leveling Plan' })
+    await expect(summary.getByText('Moss')).toBeVisible()
+    await expect(summary.getByText('Leveling Plan')).toBeVisible()
+  })
+})

--- a/src/components/level-planner/LevelPlannerResults.vue
+++ b/src/components/level-planner/LevelPlannerResults.vue
@@ -9,6 +9,16 @@ import LevelPlannerTimelineStep from './LevelPlannerTimelineStep.vue'
 const props = defineProps<{
   plan: LevelingPlan
   creatureName: string
+  creatureImage?: string
+  overriddenFromLevels?: Set<number>
+  hasRouteOverrides?: boolean
+}>()
+
+
+const emit = defineEmits<{
+  selectAlternative: [fromLevel: number, toLevel: number, expeditionId: string, tier: number]
+  resetOverride: [fromLevel: number]
+  resetAllOverrides: []
 }>()
 
 
@@ -35,7 +45,15 @@ const timePercents = computed(() =>
 
 <template>
   <div class="space-y-4">
-    <LevelPlannerSummary :plan="plan" :from-level="fromLevel" :to-level="toLevel" />
+    <LevelPlannerSummary
+      :plan="plan"
+      :from-level="fromLevel"
+      :to-level="toLevel"
+      :creature-name="creatureName"
+      :creature-image="creatureImage"
+      :has-route-overrides="hasRouteOverrides"
+      @reset-all-overrides="emit('resetAllOverrides')"
+    />
 
     <div>
       <LevelPlannerTimelineStep
@@ -48,7 +66,10 @@ const timePercents = computed(() =>
         :is-last="index === plan.steps.length - 1"
         :expanded="expandedIndex === index"
         :time-percent="timePercents[index]"
+        :has-override="overriddenFromLevels?.has(step.fromLevel)"
         @toggle="toggleExpand(index)"
+        @select-alternative="(...args) => emit('selectAlternative', ...args)"
+        @reset-override="(...args) => emit('resetOverride', ...args)"
       />
     </div>
   </div>

--- a/src/components/level-planner/LevelPlannerSummary.vue
+++ b/src/components/level-planner/LevelPlannerSummary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Clock3, Zap, Repeat, Layers, Flag } from 'lucide-vue-next'
+import { Clock3, Zap, Repeat, Layers, Flag, RotateCcw } from 'lucide-vue-next'
 import { computed } from 'vue'
 
 import { formatDuration } from '@/utils/format'
@@ -9,6 +9,14 @@ const props = defineProps<{
   plan: LevelingPlan
   fromLevel: number
   toLevel: number
+  creatureName?: string
+  creatureImage?: string
+  hasRouteOverrides?: boolean
+}>()
+
+
+defineEmits<{
+  resetAllOverrides: []
 }>()
 
 
@@ -33,6 +41,29 @@ function segmentColor(status: 'advantage' | 'disadvantage' | 'neutral'): string 
 
 <template>
   <div class="surface-card space-y-3 px-4 py-3">
+    <!-- Creature title -->
+    <div v-if="creatureName" class="flex items-center gap-3">
+      <img
+        v-if="creatureImage"
+        :src="creatureImage"
+        :alt="creatureName"
+        class="size-14 rounded-xl border border-border object-cover sm:size-16"
+        loading="lazy"
+      />
+      <div>
+        <p class="text-sm font-bold text-foreground">{{ creatureName }}</p>
+        <p class="text-xs text-muted-foreground">Leveling Plan</p>
+      </div>
+      <button
+        v-if="hasRouteOverrides"
+        class="focus-ring ml-auto flex shrink-0 items-center gap-1.5 rounded-lg border border-border/60 px-3 py-1.5 text-xs font-semibold text-muted-foreground transition hover:border-primary/40 hover:text-primary"
+        @click="$emit('resetAllOverrides')"
+      >
+        <RotateCcw class="size-3" />
+        Reset Routes
+      </button>
+    </div>
+
     <!-- Stats row -->
     <div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm font-semibold">
       <span class="inline-flex items-center gap-1.5" style="color: var(--color-green)">

--- a/src/components/level-planner/LevelPlannerTimelineStep.vue
+++ b/src/components/level-planner/LevelPlannerTimelineStep.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
-import { Clock3, Zap, Users, ChevronRight, Repeat, ExternalLink } from 'lucide-vue-next'
+import {
+  Clock3,
+  Zap,
+  Users,
+  ChevronRight,
+  Repeat,
+  ExternalLink,
+  ArrowRightLeft,
+  RotateCcw,
+} from 'lucide-vue-next'
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { formatDuration } from '@/utils/format'
-import { getLoopXpBonus } from '@/utils/formulas'
 import { expeditionTierIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 import type { PlanStep } from '@/utils/levelPlanner'
@@ -33,12 +41,15 @@ defineProps<{
   hideGutter?: boolean
   scoreRatioMet?: boolean
   highlightCreatureId?: string
+  hasOverride?: boolean
 }>()
 
 
 defineEmits<{
   toggle: []
   viewInExpeditions: []
+  selectAlternative: [fromLevel: number, toLevel: number, expeditionId: string, tier: number]
+  resetOverride: [fromLevel: number]
 }>()
 
 
@@ -46,6 +57,14 @@ function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
   if (status === 'advantage') return 'var(--color-green)'
   if (status === 'disadvantage') return 'var(--color-destructive)'
   return 'hsl(var(--primary))'
+}
+
+
+function formatDelta(value: number): string {
+  const percent = Math.round(value * 100)
+  if (percent > 0) return `+${percent}%`
+  if (percent < 0) return `${percent}%`
+  return '0%'
 }
 </script>
 
@@ -106,16 +125,22 @@ function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
                   class="size-5 shrink-0 object-contain"
                   loading="lazy"
                 />
-                <p class="text-sm font-semibold text-pink-400">Awaken Creature</p>
+                <p class="text-sm font-semibold text-pink-400">
+                  {{ step.fromLevel > 70 ? 'Prestige Creature' : 'Awaken Creature' }}
+                </p>
               </div>
               <span
                 class="shrink-0 rounded-full bg-pink-500/15 px-2 py-0.5 text-xs font-semibold text-pink-400"
               >
-                LVL 70&rarr;1
+                LVL {{ step.fromLevel }}&rarr;{{ step.toLevel }}
               </span>
             </div>
             <p class="mt-1.5 text-xs text-muted-foreground">
-              Awaken {{ creatureName }} to continue past level 70
+              {{
+                step.fromLevel > 70
+                  ? `Prestige ${creatureName} to restart from level 1`
+                  : `Awaken ${creatureName} to continue past level 70`
+              }}
             </p>
           </div>
         </div>
@@ -124,7 +149,10 @@ function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
 
     <!-- Step card -->
     <div v-else class="mb-2 min-w-0 flex-1 pb-1">
-      <div class="surface-card overflow-hidden">
+      <div
+        class="surface-card overflow-hidden"
+        :class="hasOverride ? 'ring-1 ring-primary/40' : ''"
+      >
         <button
           class="focus-ring w-full text-left transition hover:bg-muted/20"
           :aria-expanded="expanded"
@@ -160,6 +188,9 @@ function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
                   class="shrink-0 text-[10px] font-semibold text-primary"
                 >
                   Trait Match
+                </span>
+                <span v-if="hasOverride" class="shrink-0 text-[10px] font-semibold text-primary">
+                  Override
                 </span>
               </div>
 
@@ -343,24 +374,99 @@ function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
 
         <!-- Expanded details -->
         <div v-if="expanded" class="border-t border-border/40 px-3 py-2.5 sm:px-4">
-          <div class="grid grid-cols-2 gap-4 text-xs sm:grid-cols-3">
+          <!-- Alternative Routes -->
+          <template v-if="step.alternatives && step.alternatives.length > 0">
             <div>
-              <p class="font-semibold text-muted-foreground">Duration per run</p>
-              <p class="mt-0.5 font-mono text-foreground">
-                {{ formatDuration(step.durationPerRun) }}
-              </p>
+              <div class="mb-2 flex items-center justify-between">
+                <p class="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground">
+                  <ArrowRightLeft class="size-3" />
+                  Alternative Routes
+                </p>
+                <button
+                  v-if="hasOverride"
+                  class="focus-ring flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground transition hover:bg-muted/30 hover:text-foreground"
+                  @click.stop="$emit('resetOverride', step.fromLevel)"
+                >
+                  <RotateCcw class="size-3" />
+                  Reset to optimal
+                </button>
+              </div>
+
+              <div class="space-y-1.5">
+                <button
+                  v-for="alt in step.alternatives"
+                  :key="`${alt.expedition.id}-${alt.tier}`"
+                  class="focus-ring flex w-full items-center gap-1.5 rounded-lg px-2 py-1.5 text-left text-sm transition hover:bg-muted/20"
+                  @click.stop="
+                    $emit(
+                      'selectAlternative',
+                      step.fromLevel,
+                      step.toLevel,
+                      alt.expedition.id,
+                      alt.tier,
+                    )
+                  "
+                >
+                  <!-- Left: reward icon + name + tier -->
+                  <img
+                    v-if="
+                      alt.expedition.rewards.length > 0 &&
+                      getItemImage({ id: alt.expedition.rewards[0].itemId })
+                    "
+                    :src="getItemImage({ id: alt.expedition.rewards[0].itemId })"
+                    :alt="alt.expedition.rewards[0].itemId"
+                    loading="lazy"
+                    class="size-4 shrink-0 object-contain"
+                  />
+                  <span class="min-w-0 truncate font-semibold text-foreground">
+                    {{ alt.expedition.name }}
+                  </span>
+                  <img
+                    v-if="alt.tier > 0"
+                    :src="expeditionTierIcons[alt.tier]"
+                    :alt="`Tier ${alt.tier}`"
+                    class="size-4 shrink-0 object-contain"
+                    loading="lazy"
+                  />
+
+                  <!-- Right: time chip · xp/s chip -->
+                  <div class="ml-auto flex shrink-0 items-center gap-1.5">
+                    <span
+                      class="inline-flex items-center gap-1 rounded-lg border border-border bg-muted/35 px-2 py-0.5 font-mono text-xs font-semibold"
+                      :style="{
+                        color:
+                          alt.timeDeltaPercent <= 0
+                            ? 'var(--color-green)'
+                            : 'var(--color-destructive)',
+                      }"
+                    >
+                      <Clock3 class="size-3" />
+                      {{ formatDuration(alt.timeSeconds) }}
+                      <span class="opacity-60">{{ formatDelta(alt.timeDeltaPercent) }}</span>
+                    </span>
+                    <span
+                      class="inline-flex items-center gap-1 rounded-lg border border-border bg-muted/35 px-2 py-0.5 font-mono text-xs font-semibold"
+                      :style="{
+                        color:
+                          alt.xpPerMinuteDeltaPercent >= 0
+                            ? 'var(--color-green)'
+                            : 'var(--color-destructive)',
+                      }"
+                    >
+                      <Zap class="size-3" />
+                      {{
+                        (alt.xpPerMinute / 60).toLocaleString(undefined, {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })
+                      }}
+                      <span class="opacity-60">{{ formatDelta(alt.xpPerMinuteDeltaPercent) }}</span>
+                    </span>
+                  </div>
+                </button>
+              </div>
             </div>
-            <div>
-              <p class="font-semibold text-muted-foreground">Levels</p>
-              <p class="mt-0.5 font-mono text-foreground">{{ step.toLevel - step.fromLevel }}</p>
-            </div>
-            <div>
-              <p class="font-semibold text-muted-foreground">Loop bonus</p>
-              <p class="mt-0.5 font-mono text-foreground">
-                +{{ Math.round(getLoopXpBonus(step.runs) * 100) }}%
-              </p>
-            </div>
-          </div>
+          </template>
         </div>
       </div>
     </div>

--- a/src/components/level-planner/PartyCreatureFilter.vue
+++ b/src/components/level-planner/PartyCreatureFilter.vue
@@ -11,21 +11,34 @@ import { computed, ref } from 'vue'
 import PartyCreatureTile from '@/components/level-planner/PartyCreatureTile.vue'
 import type { Creature } from '@/types'
 
-const props = defineProps<{
-  creatures: Creature[]
-  globalExcludedIds: Set<string>
-  plannerExcluded: Set<string>
-  plannerIncluded: Set<string>
-  getLevel: (id: string) => number
-  isAwakened: (id: string) => boolean
-  hasOverrides: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    creatures: Creature[]
+    globalExcludedIds?: Set<string>
+    plannerExcluded?: Set<string>
+    plannerIncluded?: Set<string>
+    getLevel: (id: string) => number
+    isAwakened: (id: string) => boolean
+    hasOverrides?: boolean
+    /** Single-select mode: clicking a tile selects instead of toggling include/exclude */
+    selectMode?: boolean
+    /** Currently selected creature ID (only used in selectMode) */
+    selectedId?: string
+  }>(),
+  {
+    globalExcludedIds: () => new Set<string>(),
+    plannerExcluded: () => new Set<string>(),
+    plannerIncluded: () => new Set<string>(),
+    hasOverrides: false,
+  },
+)
 
 
 const emit = defineEmits<{
   toggle: [id: string]
   'toggle-tier': [ids: string[], include: boolean]
   reset: []
+  select: [id: string]
 }>()
 
 
@@ -66,14 +79,24 @@ function isAllIncluded(creatures: Creature[]): boolean {
 }
 
 
-type ChipState = 'included' | 'excluded' | 'force-included'
+type ChipState = 'included' | 'excluded' | 'force-included' | 'selected'
 
 
 function chipState(id: string): ChipState {
+  if (props.selectMode) return id === props.selectedId ? 'selected' : 'included'
   if (props.plannerExcluded.has(id)) return 'excluded'
   if (props.plannerIncluded.has(id)) return 'force-included'
   if (props.globalExcludedIds.has(id)) return 'excluded'
   return 'included'
+}
+
+
+function handleTileClick(id: string) {
+  if (props.selectMode) {
+    emit('select', id)
+  } else {
+    emit('toggle', id)
+  }
 }
 
 
@@ -83,7 +106,9 @@ const includedCount = computed(
 
 
 const normalCreatures = computed(() =>
-  props.creatures.filter((c) => !props.globalExcludedIds.has(c.id)),
+  props.selectMode
+    ? props.creatures
+    : props.creatures.filter((c) => !props.globalExcludedIds.has(c.id)),
 )
 
 
@@ -131,17 +156,20 @@ function groupByTier(list: Creature[]): { tier: number; creatures: Creature[] }[
         class="pointer-events-none text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70"
         >Creatures</label
       >
-      <span class="text-xs text-muted-foreground">
-        {{ includedCount }} of {{ creatures.length }} included
-      </span>
-      <span
-        v-if="hasOverrides"
-        class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-bold text-primary"
-      >
-        Filtered
-      </span>
+      <template v-if="!selectMode">
+        <span class="text-xs text-muted-foreground">
+          {{ includedCount }} of {{ creatures.length }} included
+        </span>
+        <span
+          v-if="hasOverrides"
+          class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-bold text-primary"
+        >
+          Filtered
+        </span>
+      </template>
       <div class="ml-auto flex items-center gap-2">
         <button
+          v-if="!selectMode"
           class="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-semibold transition"
           :class="
             hasOverrides
@@ -230,6 +258,7 @@ function groupByTier(list: Creature[]): { tier: number; creatures: Creature[] }[
                 Tier {{ group.tier + 1 }}
               </p>
               <button
+                v-if="!selectMode"
                 class="focus-ring inline-flex items-center rounded-md border px-2 py-0.5 text-[10px] font-semibold transition"
                 :class="
                   isAllIncluded(group.creatures)
@@ -255,7 +284,7 @@ function groupByTier(list: Creature[]): { tier: number; creatures: Creature[] }[
                 :chip-state="chipState(c.id)"
                 :level="getLevel(c.id)"
                 :awakened="isAwakened(c.id)"
-                @toggle="emit('toggle', c.id)"
+                @toggle="handleTileClick(c.id)"
               />
             </div>
           </div>
@@ -270,12 +299,12 @@ function groupByTier(list: Creature[]): { tier: number; creatures: Creature[] }[
             :chip-state="chipState(c.id)"
             :level="getLevel(c.id)"
             :awakened="isAwakened(c.id)"
-            @toggle="emit('toggle', c.id)"
+            @toggle="handleTileClick(c.id)"
           />
         </div>
 
         <!-- Global excluded separator + creatures -->
-        <template v-if="filteredExcluded.length > 0">
+        <template v-if="filteredExcluded.length > 0 && !selectMode">
           <div class="my-3 flex items-center gap-2">
             <div class="h-px flex-1 bg-border/40" />
             <span
@@ -293,7 +322,7 @@ function groupByTier(list: Creature[]): { tier: number; creatures: Creature[] }[
               :level="getLevel(c.id)"
               :awakened="isAwakened(c.id)"
               title-suffix=" (config excluded)"
-              @toggle="emit('toggle', c.id)"
+              @toggle="handleTileClick(c.id)"
             />
           </div>
         </template>

--- a/src/components/level-planner/PartyCreatureTile.vue
+++ b/src/components/level-planner/PartyCreatureTile.vue
@@ -2,7 +2,7 @@
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 
-type ChipState = 'included' | 'excluded' | 'force-included'
+type ChipState = 'included' | 'excluded' | 'force-included' | 'selected'
 
 
 const props = defineProps<{
@@ -21,6 +21,7 @@ defineEmits<{
 
 function tileBorderClass(): string {
   if (props.chipState === 'excluded') return 'border-border/40 opacity-40 grayscale'
+  if (props.chipState === 'selected') return 'border-primary/60 ring-2 ring-primary/40'
   if (props.chipState === 'force-included') return 'border-primary/60 ring-1 ring-primary/30'
   if (props.awakened) return 'border-pink-500/40 ring-1 ring-pink-500/20 hover:border-pink-500/60'
   return 'border-border bg-card/50 hover:border-primary/50'
@@ -29,6 +30,7 @@ function tileBorderClass(): string {
 
 function nameClass(): string {
   if (props.chipState === 'excluded') return 'text-white/60 line-through'
+  if (props.chipState === 'selected') return 'text-primary'
   if (props.chipState === 'force-included') return 'text-primary'
   if (props.awakened) return 'text-pink-400'
   return 'text-white'
@@ -37,6 +39,7 @@ function nameClass(): string {
 
 function levelBadgeClass(): string {
   if (props.chipState === 'excluded') return 'text-muted-foreground'
+  if (props.chipState === 'selected') return 'text-primary'
   if (props.chipState === 'force-included') return 'text-primary'
   if (props.awakened) return 'text-pink-400'
   return 'text-foreground'

--- a/src/composables/useLevelPlanner.ts
+++ b/src/composables/useLevelPlanner.ts
@@ -1,4 +1,4 @@
-import { computed, type Ref } from 'vue'
+import { computed, ref, watch, type Ref } from 'vue'
 
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
@@ -23,15 +23,27 @@ export function useLevelPlanner(
 
   const startLevel = computed(() => (creature.value ? getLevel(creature.value.id) : 1))
 
+  /** True when awakened creature is at max level — treated as prestige (re-awaken from level 1) */
+  const isPrestige = computed(() => awakened.value && startLevel.value >= creatureMaxLevel.value)
+
   const isMaxLevel = computed(
-    () => startLevel.value >= creatureMaxLevel.value && targetLevel.value <= startLevel.value,
+    () =>
+      !isPrestige.value &&
+      startLevel.value >= creatureMaxLevel.value &&
+      targetLevel.value <= startLevel.value,
   )
 
   /** True when the target exceeds the creature's current cap (needs awaken mid-plan) */
   const needsAwaken = computed(() => !awakened.value && targetLevel.value > PRE_AWAKEN_MAX)
 
+  /** The effective start level used for planning (1 for prestige creatures) */
+  const effectiveStartLevel = computed(() => (isPrestige.value ? 1 : startLevel.value))
+
   const totalXpNeeded = computed(() => {
     if (!creature.value) return 0
+    if (isPrestige.value) {
+      return Math.max(0, xpForLevel(targetLevel.value) - xpForLevel(1))
+    }
     if (needsAwaken.value) {
       // XP to reach 70 + XP from 1 to target (post-awaken resets to level 1)
       const preXp = Math.max(0, xpForLevel(PRE_AWAKEN_MAX) - xpForLevel(startLevel.value))
@@ -41,17 +53,54 @@ export function useLevelPlanner(
     return Math.max(0, xpForLevel(targetLevel.value) - xpForLevel(startLevel.value))
   })
 
+  // Step overrides for alternative route selection (keyed by fromLevel)
+  const stepOverrides = ref(
+    new Map<number, { expeditionId: string; tier: number; toLevel: number }>(),
+  )
+
+  const hasOverrides = computed(() => stepOverrides.value.size > 0)
+
+  function selectAlternative(
+    fromLevel: number,
+    toLevel: number,
+    expeditionId: string,
+    tier: number,
+  ) {
+    const next = new Map(stepOverrides.value)
+    next.set(fromLevel, { expeditionId, tier, toLevel })
+    stepOverrides.value = next
+  }
+
+  function resetOverride(fromLevel: number) {
+    const next = new Map(stepOverrides.value)
+    next.delete(fromLevel)
+    stepOverrides.value = next
+  }
+
+  function resetAllOverrides() {
+    stepOverrides.value = new Map()
+  }
+
+  // Clear overrides when inputs change
+  watch([creatureId, targetLevel], () => {
+    if (hasOverrides.value) resetAllOverrides()
+  })
+
   const plan = computed<LevelingPlan | null>(() => {
     if (!creature.value || isMaxLevel.value) return null
     return planLevelingPath({
       creature: creature.value,
-      startLevel: startLevel.value,
+      startLevel: effectiveStartLevel.value,
       targetLevel: targetLevel.value,
       isAwakened: awakened.value,
+      isPrestige: isPrestige.value,
       swordXpMultiplier: expeditionToolXpBonus.value,
       expeditionTierSelections: expeditionTierSelections?.value,
+      stepOverrides: stepOverrides.value.size > 0 ? stepOverrides.value : undefined,
     })
   })
+
+  const overriddenFromLevels = computed(() => new Set(stepOverrides.value.keys()))
 
   return {
     creature,
@@ -62,5 +111,10 @@ export function useLevelPlanner(
     totalXpNeeded,
     isMaxLevel,
     creatureMaxLevel,
+    selectAlternative,
+    resetOverride,
+    resetAllOverrides,
+    hasOverrides,
+    overriddenFromLevels,
   }
 }

--- a/src/utils/__tests__/levelPlanner.test.ts
+++ b/src/utils/__tests__/levelPlanner.test.ts
@@ -1,7 +1,7 @@
 import creaturesData from '@/data/creatures.json'
 import expeditionsData from '@/data/expeditions.json'
 import type { Creature, Expedition } from '@/types'
-import { planLevelingPath } from '@/utils/levelPlanner'
+import { planLevelingPath, type AlternativeRoute } from '@/utils/levelPlanner'
 
 const creatures = creaturesData as Creature[]
 const expeditions = expeditionsData as Expedition[]
@@ -227,5 +227,280 @@ describe('planLevelingPath — expeditionTierSelections filtering', () => {
         expect(step.tier).toBeGreaterThanOrEqual(4)
       }
     }
+  })
+})
+
+describe('planLevelingPath — alternative routes', () => {
+  test('steps include alternatives for a multi-level plan', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    const stepsWithAlts = plan.steps.filter((s) => s.alternatives && s.alternatives.length > 0)
+    expect(stepsWithAlts.length).toBeGreaterThan(0)
+  })
+
+  test('alternatives do not include the chosen expedition+tier', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    for (const step of plan.steps) {
+      if (!step.alternatives) continue
+      for (const alt of step.alternatives) {
+        const isSame = alt.expedition.id === step.expedition.id && alt.tier === step.tier
+        expect(isSame).toBe(false)
+      }
+    }
+  })
+
+  test('alternatives have at most 5 entries per step', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 50,
+      isAwakened: false,
+    })
+
+    for (const step of plan.steps) {
+      if (!step.alternatives) continue
+      expect(step.alternatives.length).toBeLessThanOrEqual(5)
+    }
+  })
+
+  test('alternatives have valid time and XP delta values', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    for (const step of plan.steps) {
+      if (!step.alternatives) continue
+      for (const alt of step.alternatives) {
+        expect(alt.timeSeconds).toBeGreaterThan(0)
+        expect(alt.runs).toBeGreaterThan(0)
+        expect(alt.xpPerMinute).toBeGreaterThan(0)
+        expect(typeof alt.timeDeltaPercent).toBe('number')
+        expect(typeof alt.xpPerMinuteDeltaPercent).toBe('number')
+      }
+    }
+  })
+
+  test('alternatives are sorted by time (fastest first)', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    for (const step of plan.steps) {
+      if (!step.alternatives || step.alternatives.length < 2) continue
+      for (let i = 1; i < step.alternatives.length; i++) {
+        expect(step.alternatives[i].timeSeconds).toBeGreaterThanOrEqual(
+          step.alternatives[i - 1].timeSeconds,
+        )
+      }
+    }
+  })
+
+  test('awakening steps have no alternatives', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 120,
+      isAwakened: false,
+    })
+
+    const awakeningSteps = plan.steps.filter((s) => s.isAwakeningStep)
+    expect(awakeningSteps.length).toBeGreaterThan(0)
+    for (const step of awakeningSteps) {
+      expect(step.alternatives).toBeUndefined()
+    }
+  })
+})
+
+describe('planLevelingPath — step overrides', () => {
+  test('overriding a step changes the expedition at that level', () => {
+    const basePlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    // Find a step with alternatives to override
+    const stepWithAlts = basePlan.steps.find((s) => s.alternatives && s.alternatives.length > 0)
+    if (!stepWithAlts || !stepWithAlts.alternatives) return
+
+    const alt = stepWithAlts.alternatives[0]
+    const overrides = new Map<number, { expeditionId: string; tier: number; toLevel: number }>()
+    overrides.set(stepWithAlts.fromLevel, {
+      expeditionId: alt.expedition.id,
+      tier: alt.tier,
+      toLevel: stepWithAlts.toLevel,
+    })
+
+    const overriddenPlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+      stepOverrides: overrides,
+    })
+
+    // The overridden step should use the alternative's expedition
+    const overriddenStep = overriddenPlan.steps.find((s) => s.fromLevel === stepWithAlts.fromLevel)
+    expect(overriddenStep).toBeDefined()
+    expect(overriddenStep!.expedition.id).toBe(alt.expedition.id)
+    expect(overriddenStep!.tier).toBe(alt.tier)
+  })
+
+  test('override covers the full step level range', () => {
+    const basePlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    const stepWithAlts = basePlan.steps.find((s) => s.alternatives && s.alternatives.length > 0)
+    if (!stepWithAlts || !stepWithAlts.alternatives) return
+
+    const alt = stepWithAlts.alternatives[0]
+    const overrides = new Map<number, { expeditionId: string; tier: number; toLevel: number }>()
+    overrides.set(stepWithAlts.fromLevel, {
+      expeditionId: alt.expedition.id,
+      tier: alt.tier,
+      toLevel: stepWithAlts.toLevel,
+    })
+
+    const overriddenPlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+      stepOverrides: overrides,
+    })
+
+    // The overridden step should cover the same level range as the original
+    const overriddenStep = overriddenPlan.steps.find((s) => s.fromLevel === stepWithAlts.fromLevel)
+    expect(overriddenStep).toBeDefined()
+    expect(overriddenStep!.expedition.id).toBe(alt.expedition.id)
+    expect(overriddenStep!.toLevel).toBe(stepWithAlts.toLevel)
+  })
+
+  test('overridden step time matches alternative predicted time', () => {
+    const basePlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+    })
+
+    const stepWithAlts = basePlan.steps.find((s) => s.alternatives && s.alternatives.length > 0)
+    if (!stepWithAlts || !stepWithAlts.alternatives) return
+
+    const alt = stepWithAlts.alternatives[0]
+    const overrides = new Map<number, { expeditionId: string; tier: number; toLevel: number }>()
+    overrides.set(stepWithAlts.fromLevel, {
+      expeditionId: alt.expedition.id,
+      tier: alt.tier,
+      toLevel: stepWithAlts.toLevel,
+    })
+
+    const overriddenPlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 30,
+      isAwakened: false,
+      stepOverrides: overrides,
+    })
+
+    const overriddenStep = overriddenPlan.steps.find((s) => s.fromLevel === stepWithAlts.fromLevel)
+    expect(overriddenStep).toBeDefined()
+    // The step's actual time should match the alternative's predicted time
+    expect(overriddenStep!.timeSeconds).toBe(alt.timeSeconds)
+    expect(overriddenStep!.runs).toBe(alt.runs)
+  })
+
+  test('overriding with same expedition as optimal produces same plan', () => {
+    const basePlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 20,
+      isAwakened: false,
+    })
+
+    const firstStep = basePlan.steps[0]
+    const overrides = new Map<number, { expeditionId: string; tier: number; toLevel: number }>()
+    overrides.set(firstStep.fromLevel, {
+      expeditionId: firstStep.expedition.id,
+      tier: firstStep.tier,
+      toLevel: firstStep.toLevel,
+    })
+
+    const overriddenPlan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 20,
+      isAwakened: false,
+      stepOverrides: overrides,
+    })
+
+    expect(overriddenPlan.totalTimeSeconds).toBe(basePlan.totalTimeSeconds)
+    expect(overriddenPlan.totalRuns).toBe(basePlan.totalRuns)
+  })
+})
+
+describe('planLevelingPath — prestige mode', () => {
+  test('prestige plan starts with an awakening step', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 70,
+      isAwakened: true,
+      isPrestige: true,
+    })
+
+    expect(plan.steps.length).toBeGreaterThan(1)
+    expect(plan.steps[0].isAwakeningStep).toBe(true)
+    expect(plan.steps[0].fromLevel).toBe(120)
+    expect(plan.steps[0].toLevel).toBe(1)
+  })
+
+  test('prestige plan generates valid leveling steps after the awakening step', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 50,
+      isAwakened: true,
+      isPrestige: true,
+    })
+
+    const levelingSteps = plan.steps.filter((s) => !s.isAwakeningStep)
+    expect(levelingSteps.length).toBeGreaterThan(0)
+    expect(levelingSteps[0].fromLevel).toBe(1)
+    expect(plan.totalRuns).toBeGreaterThan(0)
+    expect(plan.totalTimeSeconds).toBeGreaterThan(0)
+  })
+
+  test('prestige plan without prestige flag does not prepend awakening step', () => {
+    const plan = planLevelingPath({
+      creature,
+      startLevel: 1,
+      targetLevel: 50,
+      isAwakened: true,
+    })
+
+    expect(plan.steps[0].isAwakeningStep).toBeFalsy()
   })
 })

--- a/src/utils/levelPlanner.ts
+++ b/src/utils/levelPlanner.ts
@@ -15,8 +15,30 @@ export interface LevelPlannerInput {
   startLevel: number
   targetLevel: number
   isAwakened: boolean
+  /** Prestige mode: creature is at max level and re-awakening from level 1 */
+  isPrestige?: boolean
   swordXpMultiplier?: number
   expeditionTierSelections?: Record<string, number[]>
+  /** Force specific expedition+tier for a level range (keyed by fromLevel of merged step) */
+  stepOverrides?: Map<number, { expeditionId: string; tier: number; toLevel: number }>
+}
+
+export interface AlternativeRoute {
+  expedition: Expedition
+  tier: number
+  biomeName: string
+  traitMatch: boolean
+  biomeStatus: 'advantage' | 'disadvantage' | 'neutral'
+  /** XP/min at loop count 0 for the level range of this merged step */
+  xpPerMinute: number
+  /** Total runs across the level range */
+  runs: number
+  /** Total time in seconds across the level range */
+  timeSeconds: number
+  /** Relative time difference vs the chosen step (positive = slower) */
+  timeDeltaPercent: number
+  /** Relative XP/min difference vs the chosen step (negative = worse) */
+  xpPerMinuteDeltaPercent: number
 }
 
 export interface PlanStep {
@@ -36,6 +58,7 @@ export interface PlanStep {
   biomeStatus: 'advantage' | 'disadvantage' | 'neutral'
   partyTip?: string
   isAwakeningStep?: boolean
+  alternatives?: AlternativeRoute[]
 }
 
 export interface LevelingPlan {
@@ -47,6 +70,9 @@ export interface LevelingPlan {
 
 /** Minimum improvement required to justify switching expedition+tier (accounts for loop bonus loss) */
 const SWITCH_THRESHOLD = 0.15
+
+/** Maximum number of alternative routes to surface per step */
+const MAX_ALTERNATIVES = 5
 
 function getBiomeStatus(
   creature: Creature,
@@ -83,6 +109,34 @@ interface EvalResult {
   timeForLevel: number
 }
 
+type EvaluateComboFn = (
+  expedition: Expedition,
+  biome: Biome | undefined,
+  tier: number,
+  level: number,
+  loopCount: number,
+) => EvalResult | null
+
+function makeAwakeningStep(fromLevel: number): PlanStep {
+  return {
+    expedition: {} as Expedition,
+    tier: 0,
+    fromLevel,
+    toLevel: 1,
+    runs: 0,
+    timeSeconds: 0,
+    xpPerRun: 0,
+    durationPerRun: 0,
+    xpPerMinute: 0,
+    startXpPerMinute: 0,
+    endXpPerMinute: 0,
+    biomeName: '',
+    traitMatch: false,
+    biomeStatus: 'neutral',
+    isAwakeningStep: true,
+  }
+}
+
 /**
  * Build an optimal leveling plan. At each level:
  * 1. Evaluate continuing the current expedition+tier (with accumulated loop bonus)
@@ -99,6 +153,7 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
   const tierSelections = expeditionTierSelections ?? {}
   const hasTierRestrictions = Object.keys(tierSelections).length > 0
   const allTiers = [1, 2, 3, 4, 5]
+  const stepOverrides = settings.stepOverrides
 
   const candidates: ExpeditionWithBiome[] = expeditions
     .filter((exp) => !hasTierRestrictions || (tierSelections[exp.id] ?? allTiers).length > 0)
@@ -137,6 +192,7 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
   /**
    * Plan optimal steps for a contiguous level range.
    * Mutates rawSteps in place and returns the final combo/loop state.
+   * Also populates levelAlternatives with per-level alternative EvalResults.
    */
   function planLevelRange(
     from: number,
@@ -144,11 +200,21 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
     rawSteps: PlanStep[],
     initialCombo: ComboKey | null,
     initialLoopCount: number,
+    levelAlternatives: Map<number, EvalResult[]>,
   ): { currentCombo: ComboKey | null; loopCount: number } {
     let currentCombo = initialCombo
     let loopCount = initialLoopCount
+    let activeOverride: { expeditionId: string; tier: number; toLevel: number } | null = null
 
     for (let level = from; level < to; level++) {
+      // Check for new user override at this level, or deactivate expired one
+      const newOverride = stepOverrides?.get(level)
+      if (newOverride) {
+        activeOverride = newOverride
+      } else if (activeOverride && level >= activeOverride.toLevel) {
+        activeOverride = null
+      }
+
       // Evaluate current combo with accumulated loop bonus
       let currentResult: EvalResult | null = null
       if (currentCombo) {
@@ -164,18 +230,24 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
         }
       }
 
+      // Collect all fresh results for alternatives tracking
+      const allFreshResults: EvalResult[] = []
+
       // Find the absolute best option (all combos at loop count 0)
       let bestFresh: EvalResult | null = null
       for (const { expedition, biome } of candidates) {
         const tiers = tierSelections[expedition.id] ?? allTiers
         for (const tier of tiers) {
           const result = evaluateCombo(expedition, biome, tier, level, 0)
+          if (!result) continue
+
+          allFreshResults.push(result)
+
           if (
-            result &&
-            (!bestFresh ||
-              result.timeForLevel < bestFresh.timeForLevel ||
-              (result.timeForLevel === bestFresh.timeForLevel &&
-                result.xpPerMinute > bestFresh.xpPerMinute))
+            !bestFresh ||
+            result.timeForLevel < bestFresh.timeForLevel ||
+            (result.timeForLevel === bestFresh.timeForLevel &&
+              result.xpPerMinute > bestFresh.xpPerMinute)
           ) {
             bestFresh = result
           }
@@ -195,7 +267,24 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
 
       // Decide: stick with current or switch?
       let chosen: EvalResult | null
-      if (!currentResult) {
+
+      if (activeOverride) {
+        // User override active: use the overridden combo with accumulated loop bonus
+        if (
+          currentCombo &&
+          currentCombo.expeditionId === activeOverride.expeditionId &&
+          currentCombo.tier === activeOverride.tier
+        ) {
+          // Already running the override combo — keep it with loop bonus
+          chosen = currentResult
+        } else {
+          // First level of override — start fresh at loop count 0
+          const cand = candidates.find((c) => c.expedition.id === activeOverride!.expeditionId)
+          chosen = cand
+            ? evaluateCombo(cand.expedition, cand.biome, activeOverride!.tier, level, 0)
+            : (bestFresh ?? currentResult)
+        }
+      } else if (!currentResult) {
         // No current combo — pick the best fresh option
         chosen = bestFresh
       } else if (!bestFresh) {
@@ -218,6 +307,23 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
       }
 
       if (!chosen) break
+
+      // Store alternatives for this level (excluding chosen expedition, best tier per expedition)
+      const sortedFresh = allFreshResults
+        .filter((r) => r.expedition.id !== chosen.expedition.id)
+        .toSorted((a, b) => a.timeForLevel - b.timeForLevel || b.xpPerMinute - a.xpPerMinute)
+      // Keep only the best tier per expedition
+      const seenExpeditions = new Set<string>()
+      const alternatives: EvalResult[] = []
+      for (const r of sortedFresh) {
+        if (seenExpeditions.has(r.expedition.id)) continue
+        seenExpeditions.add(r.expedition.id)
+        alternatives.push(r)
+        if (alternatives.length >= MAX_ALTERNATIVES) break
+      }
+      if (alternatives.length > 0) {
+        levelAlternatives.set(level, alternatives)
+      }
 
       // Track combo switches
       const chosenCombo: ComboKey = { expeditionId: chosen.expedition.id, tier: chosen.tier }
@@ -254,37 +360,28 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
   }
 
   const rawSteps: PlanStep[] = []
+  const levelAlternatives = new Map<number, EvalResult[]>()
+
+  // Prestige: creature is at max level, re-awakening from level 1
+  if (settings.isPrestige) {
+    rawSteps.push(makeAwakeningStep(120))
+  }
+
   // Effective cap: unawakened creatures must awaken at 70 before continuing
   const effectiveTarget = !isAwakened ? Math.min(targetLevel, PRE_AWAKEN_MAX) : targetLevel
 
-  planLevelRange(startLevel, effectiveTarget, rawSteps, null, 0)
+  planLevelRange(startLevel, effectiveTarget, rawSteps, null, 0, levelAlternatives)
 
   // Insert awakening step and plan remaining levels if needed
   if (!isAwakened && targetLevel > PRE_AWAKEN_MAX && startLevel <= PRE_AWAKEN_MAX) {
-    rawSteps.push({
-      expedition: {} as Expedition,
-      tier: 0,
-      fromLevel: PRE_AWAKEN_MAX,
-      toLevel: 1,
-      runs: 0,
-      timeSeconds: 0,
-      xpPerRun: 0,
-      durationPerRun: 0,
-      xpPerMinute: 0,
-      startXpPerMinute: 0,
-      endXpPerMinute: 0,
-      biomeName: '',
-      traitMatch: false,
-      biomeStatus: 'neutral',
-      isAwakeningStep: true,
-    })
+    rawSteps.push(makeAwakeningStep(PRE_AWAKEN_MAX))
 
     // Plan from 1 → target after awakening (level resets to 1 on awaken)
-    planLevelRange(1, targetLevel, rawSteps, null, 0)
+    planLevelRange(1, targetLevel, rawSteps, null, 0, levelAlternatives)
   }
 
-  // Merge consecutive steps using the same expedition+tier
-  const steps = mergeSteps(rawSteps)
+  // Merge consecutive steps using the same expedition+tier, aggregating alternatives
+  const steps = mergeStepsWithAlternatives(rawSteps, levelAlternatives, evaluateCombo, creature)
 
   // Add party tips to merged steps
   for (const step of steps) {
@@ -320,20 +417,32 @@ export function planLevelingPath(settings: LevelPlannerInput): LevelingPlan {
   return { steps, totalTimeSeconds: totalTime, totalRuns, xpPerMinute }
 }
 
-function mergeSteps(steps: PlanStep[]): PlanStep[] {
+/**
+ * Merge consecutive raw steps using the same expedition+tier,
+ * and aggregate per-level alternatives into step-level alternatives.
+ */
+function mergeStepsWithAlternatives(
+  steps: PlanStep[],
+  levelAlternatives: Map<number, EvalResult[]>,
+  evaluateCombo: EvaluateComboFn,
+  creature: Creature,
+): PlanStep[] {
   if (steps.length === 0) return []
 
   const merged: PlanStep[] = []
   let current = { ...steps[0] }
   let currentXpEarned = current.runs * current.xpPerRun
+  let currentLevelRange = [current.fromLevel]
 
   for (let i = 1; i < steps.length; i++) {
     const step = steps[i]
     // Never merge awakening steps with adjacent steps
     if (step.isAwakeningStep || current.isAwakeningStep) {
+      attachAlternatives(current, currentLevelRange, levelAlternatives, evaluateCombo, creature)
       merged.push(current)
       current = { ...step }
       currentXpEarned = current.runs * current.xpPerRun
+      currentLevelRange = [current.fromLevel]
     } else if (step.expedition.id === current.expedition.id && step.tier === current.tier) {
       current.toLevel = step.toLevel
       current.runs += step.runs
@@ -342,12 +451,102 @@ function mergeSteps(steps: PlanStep[]): PlanStep[] {
       current.xpPerMinute =
         current.timeSeconds > 0 ? (currentXpEarned / current.timeSeconds) * 60 : 0
       current.endXpPerMinute = step.xpPerMinute
+      currentLevelRange.push(step.fromLevel)
     } else {
+      attachAlternatives(current, currentLevelRange, levelAlternatives, evaluateCombo, creature)
       merged.push(current)
       current = { ...step }
       currentXpEarned = current.runs * current.xpPerRun
+      currentLevelRange = [current.fromLevel]
     }
   }
+  attachAlternatives(current, currentLevelRange, levelAlternatives, evaluateCombo, creature)
   merged.push(current)
   return merged
+}
+
+/**
+ * Aggregate per-level alternatives into a merged step's alternatives.
+ * Re-evaluates each unique alternative combo across the full level range.
+ */
+function attachAlternatives(
+  step: PlanStep,
+  levelRange: number[],
+  levelAlternatives: Map<number, EvalResult[]>,
+  evaluateCombo: EvaluateComboFn,
+  creature: Creature,
+): void {
+  if (step.isAwakeningStep) return
+
+  // Collect unique alternative expeditions (best tier per expedition) across the range
+  const altCombos = new Map<
+    string,
+    { expedition: Expedition; biome: Biome | undefined; tier: number }
+  >()
+  for (const level of levelRange) {
+    const alts = levelAlternatives.get(level)
+    if (!alts) continue
+    for (const alt of alts) {
+      // Key by expedition ID — first seen is the best tier (alternatives are pre-sorted)
+      if (!altCombos.has(alt.expedition.id)) {
+        altCombos.set(alt.expedition.id, {
+          expedition: alt.expedition,
+          biome: alt.biome,
+          tier: alt.tier,
+        })
+      }
+    }
+  }
+
+  if (altCombos.size === 0) return
+
+  // Re-evaluate each alternative across the full level range, simulating loop bonus
+  const alternatives: AlternativeRoute[] = []
+  for (const [, combo] of altCombos) {
+    let totalTime = 0
+    let totalRuns = 0
+    let totalXpEarned = 0
+    let loopCount = 0
+    let valid = true
+
+    for (let level = step.fromLevel; level < step.toLevel; level++) {
+      const result = evaluateCombo(combo.expedition, combo.biome, combo.tier, level, loopCount)
+      if (!result) {
+        valid = false
+        break
+      }
+      totalTime += result.timeForLevel
+      totalRuns += result.runsForLevel
+      totalXpEarned += result.xpPerRun * result.runsForLevel
+      loopCount += result.runsForLevel
+    }
+
+    if (!valid || totalTime <= 0) continue
+
+    const xpPerMinute = (totalXpEarned / totalTime) * 60
+    const timeDeltaPercent = step.timeSeconds > 0 ? totalTime / step.timeSeconds - 1 : 0
+    const xpPerMinuteDeltaPercent = step.xpPerMinute > 0 ? xpPerMinute / step.xpPerMinute - 1 : 0
+
+    const biomeStatus = combo.biome ? getBiomeStatus(creature, combo.biome) : ('neutral' as const)
+
+    alternatives.push({
+      expedition: combo.expedition,
+      tier: combo.tier,
+      biomeName: combo.biome?.name ?? combo.expedition.biome,
+      traitMatch: creature.trait === combo.expedition.trait,
+      biomeStatus,
+      xpPerMinute,
+      runs: totalRuns,
+      timeSeconds: totalTime,
+      timeDeltaPercent,
+      xpPerMinuteDeltaPercent,
+    })
+  }
+
+  if (alternatives.length > 0) {
+    // Sort by total time (fastest first), keep top N
+    step.alternatives = alternatives
+      .toSorted((a, b) => a.timeSeconds - b.timeSeconds || b.xpPerMinute - a.xpPerMinute)
+      .slice(0, MAX_ALTERNATIVES)
+  }
 }

--- a/src/views/LevelPlannerView.vue
+++ b/src/views/LevelPlannerView.vue
@@ -4,7 +4,6 @@ import { Clock3, Play, RefreshCw, Users, User, Zap } from 'lucide-vue-next'
 import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import LevelPlannerCreaturePicker from '@/components/level-planner/LevelPlannerCreaturePicker.vue'
 import LevelPlannerResults from '@/components/level-planner/LevelPlannerResults.vue'
 import PartyCreatureFilter from '@/components/level-planner/PartyCreatureFilter.vue'
 import PartyExpeditionFilter from '@/components/level-planner/PartyExpeditionFilter.vue'
@@ -20,6 +19,7 @@ import { useGameConfig } from '@/composables/useGameConfig'
 import { useLevelPlanner } from '@/composables/useLevelPlanner'
 import { usePartyPlanner } from '@/composables/usePartyPlanner'
 import type { PlannerStrategy, PlannerTimeBudget } from '@/types'
+import { getCreatureImage } from '@/utils/creatureImages'
 import { maxLevelForState } from '@/utils/formulas'
 import { toolIcons } from '@/utils/icons'
 import { expeditions as allExpeditions } from '@/utils/precomputedTables'
@@ -54,11 +54,19 @@ const singleCreatureMax = computed(() =>
 const singleTargetPresets = [70, 120]
 
 
-const { creature, startLevel, plan, needsAwaken, totalXpNeeded, isMaxLevel } = useLevelPlanner(
-  creatureId,
-  targetLevel,
-  effectiveExpeditionTierSelections,
-)
+const {
+  creature,
+  startLevel,
+  plan,
+  needsAwaken,
+  totalXpNeeded,
+  isMaxLevel,
+  selectAlternative,
+  resetOverride,
+  resetAllOverrides: resetRouteOverrides,
+  hasOverrides: hasRouteOverrides,
+  overriddenFromLevels,
+} = useLevelPlanner(creatureId, targetLevel, effectiveExpeditionTierSelections)
 
 
 // Party mode state — auto-computed from owned creatures
@@ -379,11 +387,16 @@ const partyBestCompleteTime = computed(() => partyProgress.value?.bestCompleteTi
 
     <!-- ===== SINGLE MODE ===== -->
     <template v-if="mode === 'single'">
-      <PlannerToolbar picker-label="Creature">
-        <template #picker>
-          <LevelPlannerCreaturePicker v-model="creatureId" :party-mode="false" />
-        </template>
+      <PartyCreatureFilter
+        :creatures="overrideableCreatures"
+        :get-level="getLevel"
+        :is-awakened="isAwakened"
+        :select-mode="true"
+        :selected-id="creatureId"
+        @select="creatureId = $event"
+      />
 
+      <PlannerToolbar>
         <template #controls>
           <div class="flex items-center gap-2">
             <label class="text-xs font-semibold text-muted-foreground">Target</label>
@@ -474,6 +487,12 @@ const partyBestCompleteTime = computed(() => partyProgress.value?.bestCompleteTi
         v-else-if="plan && plan.steps.length > 0"
         :plan="plan"
         :creature-name="creature?.name ?? ''"
+        :creature-image="creature ? getCreatureImage(creature) : undefined"
+        :overridden-from-levels="overriddenFromLevels"
+        :has-route-overrides="hasRouteOverrides"
+        @select-alternative="selectAlternative"
+        @reset-override="resetOverride"
+        @reset-all-overrides="resetRouteOverrides()"
       />
     </template>
 


### PR DESCRIPTION
## Description

When planning multiple creatures independently in single mode, two creatures can end up assigned to the same expedition at overlapping levels. This PR surfaces the top alternative expedition routes per step so users can manually pick a different route, avoiding conflicts without switching to party mode. Selecting an alternative triggers a full replan from that step forward with accurate loop-bonus-adjusted time predictions.

## Summary
- Add alternative route computation to the level planner algorithm with per-expedition deduplication, loop bonus simulation, and up to 5 ranked alternatives per merged step
- Support step overrides that stick for the full level range and replan downstream steps accordingly
- Add prestige mode for awakened creatures at max level, treating them as re-awakening from level 1
- Render alternative routes as one-liner rows with time/XP chips in the expanded step details
- Replace the dropdown creature picker with the party-style creature grid selector in single mode
- Add creature image and name to the plan summary card with a Reset Routes button
- Add unit tests for alternatives, overrides, and prestige; add e2e tests for route selection, prestige rendering, and creature grid

Closes #53