### PR TITLE
Add dungeons page with party planner

### DIFF
--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -5,6 +5,7 @@ import {
   ChevronsRight,
   Cog,
   Compass,
+  Swords,
   FileCog,
   GitBranch,
   Github,
@@ -52,6 +53,7 @@ const navGroups = [
     items: [
       { label: 'Beastiary', to: '/', icon: BookOpen },
       { label: 'Items', to: '/items', icon: Package },
+      { label: 'Dungeons', to: '/dungeons', icon: Swords },
       { label: 'Expeditions', to: '/expeditions', icon: Compass },
     ],
   },

--- a/src/composables/useDungeons.ts
+++ b/src/composables/useDungeons.ts
@@ -1,0 +1,255 @@
+import { useLocalStorage } from '@vueuse/core'
+import { ref, computed, watch, type Ref } from 'vue'
+
+import dungeonData from '@/data/dungeons.json'
+import type {
+  Creature,
+  DungeonConfig,
+  DungeonFocus,
+  DungeonGradeLetter,
+  GatheringSubFocus,
+  ExpeditionStatWeights,
+} from '@/types'
+import {
+  calculateDungeonCreatureScore,
+  calculateDungeonPartyScore,
+  getDungeonGrade,
+  getDungeonScaledRewards,
+  getRecommendedDungeonCreatures,
+} from '@/utils/formulas'
+
+import { useGameConfig } from './useGameConfig'
+
+const config = dungeonData as DungeonConfig
+
+const GRADE_COLORS: Record<DungeonGradeLetter, { text: string; bg: string; border: string }> = {
+  S: {
+    text: 'text-amber-600 dark:text-amber-300',
+    bg: 'bg-amber-100 dark:bg-amber-500/15',
+    border: 'border-amber-300 dark:border-amber-500/40',
+  },
+  A: {
+    text: 'text-emerald-700 dark:text-emerald-400',
+    bg: 'bg-emerald-100 dark:bg-emerald-500/15',
+    border: 'border-emerald-300 dark:border-emerald-500/40',
+  },
+  B: {
+    text: 'text-sky-700 dark:text-sky-400',
+    bg: 'bg-sky-100 dark:bg-sky-500/15',
+    border: 'border-sky-300 dark:border-sky-500/40',
+  },
+  C: {
+    text: 'text-orange-700 dark:text-orange-400',
+    bg: 'bg-orange-100 dark:bg-orange-500/15',
+    border: 'border-orange-300 dark:border-orange-500/40',
+  },
+  F: {
+    text: 'text-red-700 dark:text-red-400',
+    bg: 'bg-red-100 dark:bg-red-500/15',
+    border: 'border-red-300 dark:border-red-500/40',
+  },
+}
+
+const GATHERING_SUB_FOCUSES: GatheringSubFocus[] = [
+  'Chopping',
+  'Mining',
+  'Digging',
+  'Farming',
+  'Fishing',
+  'Exploring',
+]
+
+export function useDungeons(creatures: Creature[], collectionLevels?: Ref<Record<string, number>>) {
+  const { excludedCreatureIds } = useGameConfig()
+  const showExcludedCreatures = ref(false)
+
+  const selectedTier = useLocalStorage<number>('dungeon-tier', 1)
+  const selectedFocus = useLocalStorage<DungeonFocus>('dungeon-focus', 'combat')
+  const selectedSubFocus = useLocalStorage<GatheringSubFocus>('dungeon-sub-focus', 'Mining')
+  const dungeonParty = useLocalStorage<string[]>('dungeon-party', [])
+  const creatureLevels = useLocalStorage<Record<string, number>>('dungeon-creature-levels', {})
+
+  // Merge collection levels as defaults behind dungeon-specific levels
+  const effectiveLevels = computed<Record<string, number>>(() => {
+    if (!collectionLevels?.value) return creatureLevels.value
+    return { ...collectionLevels.value, ...creatureLevels.value }
+  })
+
+  const partySlots = ref<(Creature | null)[]>([null, null, null])
+  const activeSlotIndex = ref<number | null>(null)
+
+  // Restore party from localStorage on init
+  const restoreParty = () => {
+    const ids = dungeonParty.value
+    partySlots.value = Array(config.maxPartySize)
+      .fill(null)
+      .map((_, i) => {
+        const id = ids[i]
+        return id ? (creatures.find((c) => c.id === id) ?? null) : null
+      })
+  }
+  restoreParty()
+
+  // Persist party changes
+  watch(
+    partySlots,
+    (slots) => {
+      dungeonParty.value = slots.map((s) => s?.id ?? '').filter((id) => id !== '')
+    },
+    { deep: true },
+  )
+
+  const activeStatWeights = computed<ExpeditionStatWeights>(() => {
+    return config.statWeights[selectedFocus.value]
+  })
+
+  const currentTierConfig = computed(() => {
+    return config.tiers.find((t) => t.tier === selectedTier.value) ?? config.tiers[0]
+  })
+
+  const partyCreatureIds = computed(() => {
+    return new Set(partySlots.value.filter(Boolean).map((c) => c!.id))
+  })
+
+  const partyScore = computed(() => {
+    return calculateDungeonPartyScore(
+      partySlots.value,
+      activeStatWeights.value,
+      effectiveLevels.value,
+    )
+  })
+
+  const currentGrade = computed(() => {
+    if (partySlots.value.every((s) => s === null)) return null
+    return getDungeonGrade(partyScore.value, currentTierConfig.value.baseRating, config.grades)
+  })
+
+  const gradeClasses = computed(() => {
+    if (!currentGrade.value) return undefined
+    return GRADE_COLORS[currentGrade.value.grade]
+  })
+
+  const scoreRatio = computed(() => {
+    const base = currentTierConfig.value.baseRating
+    if (base <= 0 || partyScore.value <= 0) return null
+    return partyScore.value / base
+  })
+
+  const predictedXP = computed(() => {
+    if (!currentGrade.value) return null
+    return currentTierConfig.value.xpReward
+  })
+
+  const baseRewards = computed(() => {
+    const tier = String(selectedTier.value)
+    if (selectedFocus.value === 'combat') {
+      return config.combatRewards[tier] ?? []
+    }
+    const subFocusRewards = config.gatheringRewards[selectedSubFocus.value]
+    return subFocusRewards?.[tier] ?? []
+  })
+
+  const predictedRewards = computed(() => {
+    if (!currentGrade.value) return []
+    return getDungeonScaledRewards(baseRewards.value, currentGrade.value.multiplier)
+  })
+
+  const recommendedCreatures = computed(() => {
+    const pool = creatures.filter(
+      (c) =>
+        !partyCreatureIds.value.has(c.id) &&
+        (showExcludedCreatures.value || !excludedCreatureIds.value.has(c.id)),
+    )
+    const base = getRecommendedDungeonCreatures(
+      pool,
+      activeStatWeights.value,
+      effectiveLevels.value,
+    )
+    const remainingScore = currentTierConfig.value.baseRating - partyScore.value
+    return base.map((entry) => {
+      let weightedStatSum = 0
+      for (const [stat, weight] of Object.entries(activeStatWeights.value) as [
+        keyof typeof entry.creature.stats,
+        number,
+      ][]) {
+        if (weight > 0) {
+          weightedStatSum += entry.creature.stats[stat] * weight
+        }
+      }
+      let suggestedLevel: number | null = null
+      if (weightedStatSum > 0) {
+        suggestedLevel = Math.max(1, Math.min(120, Math.ceil(remainingScore / weightedStatSum)))
+      }
+      return { ...entry, suggestedLevel }
+    })
+  })
+
+  const assignCreatureToSlot = (creature: Creature) => {
+    const slots = partySlots.value
+    if (
+      activeSlotIndex.value !== null &&
+      activeSlotIndex.value < slots.length &&
+      !slots[activeSlotIndex.value]
+    ) {
+      slots[activeSlotIndex.value] = creature
+      activeSlotIndex.value = null
+      return
+    }
+    const emptyIndex = slots.findIndex((s) => s === null)
+    if (emptyIndex !== -1) {
+      slots[emptyIndex] = creature
+      activeSlotIndex.value = null
+    }
+  }
+
+  const removeCreatureFromSlot = (index: number) => {
+    if (index >= 0 && index < partySlots.value.length) {
+      partySlots.value[index] = null
+    }
+  }
+
+  const setActiveSlot = (index: number) => {
+    if (activeSlotIndex.value === index) {
+      activeSlotIndex.value = null
+    } else {
+      activeSlotIndex.value = index
+    }
+  }
+
+  const getCreatureSlotScore = (creature: Creature) => {
+    const level = effectiveLevels.value[creature.id] || 1
+    return calculateDungeonCreatureScore(creature, activeStatWeights.value, level)
+  }
+
+  const updateCreatureLevel = (creatureId: string, level: number) => {
+    creatureLevels.value[creatureId] = Math.max(1, Math.min(120, level))
+  }
+
+  return {
+    config,
+    selectedTier,
+    selectedFocus,
+    selectedSubFocus,
+    partySlots,
+    activeSlotIndex,
+    creatureLevels,
+    effectiveLevels,
+    activeStatWeights,
+    currentTierConfig,
+    partyScore,
+    currentGrade,
+    gradeClasses,
+    scoreRatio,
+    predictedXP,
+    predictedRewards,
+    recommendedCreatures,
+    showExcludedCreatures,
+    assignCreatureToSlot,
+    removeCreatureFromSlot,
+    setActiveSlot,
+    getCreatureSlotScore,
+    updateCreatureLevel,
+    GRADE_COLORS,
+    GATHERING_SUB_FOCUSES,
+  }
+}

--- a/src/data/dungeons.json
+++ b/src/data/dungeons.json
@@ -1,0 +1,547 @@
+{
+  "duration": 900,
+  "maxPartySize": 3,
+  "requiresItem": "armor-set",
+  "tierLevelRequirements": {
+    "combat": {
+      "1": 0,
+      "2": 20,
+      "3": 40,
+      "4": 60,
+      "5": 80
+    },
+    "gathering": {
+      "1": 0,
+      "2": 15,
+      "3": 40,
+      "4": 60,
+      "5": 80
+    }
+  },
+  "tiers": [
+    {
+      "tier": 1,
+      "baseRating": 2000,
+      "xpReward": 450
+    },
+    {
+      "tier": 2,
+      "baseRating": 4000,
+      "xpReward": 900
+    },
+    {
+      "tier": 3,
+      "baseRating": 6000,
+      "xpReward": 1350
+    },
+    {
+      "tier": 4,
+      "baseRating": 8000,
+      "xpReward": 1800
+    },
+    {
+      "tier": 5,
+      "baseRating": 10000,
+      "xpReward": 2250
+    }
+  ],
+  "grades": [
+    {
+      "grade": "S",
+      "minRatio": 2,
+      "multiplier": 2
+    },
+    {
+      "grade": "A",
+      "minRatio": 1,
+      "multiplier": 1.5
+    },
+    {
+      "grade": "B",
+      "minRatio": 0.6,
+      "multiplier": 1
+    },
+    {
+      "grade": "C",
+      "minRatio": 0.3,
+      "multiplier": 0.5
+    },
+    {
+      "grade": "F",
+      "minRatio": 0,
+      "multiplier": 0.25
+    }
+  ],
+  "statWeights": {
+    "combat": {
+      "power": 0.25,
+      "grit": 0.25,
+      "agility": 0.25,
+      "smarts": 0.25,
+      "looting": 0,
+      "luck": 0
+    },
+    "gathering": {
+      "power": 0,
+      "grit": 0,
+      "agility": 0,
+      "smarts": 0.33,
+      "looting": 0.33,
+      "luck": 0.34
+    }
+  },
+  "combatRewards": {
+    "1": [
+      {
+        "itemId": "dungeon-rune",
+        "amount": 2
+      },
+      {
+        "itemId": "hide",
+        "amount": 5
+      },
+      {
+        "itemId": "meat",
+        "amount": 10
+      },
+      {
+        "itemId": "egg",
+        "amount": 5
+      }
+    ],
+    "2": [
+      {
+        "itemId": "dungeon-rune",
+        "amount": 4
+      },
+      {
+        "itemId": "hide",
+        "amount": 10
+      },
+      {
+        "itemId": "meat",
+        "amount": 20
+      },
+      {
+        "itemId": "egg",
+        "amount": 4
+      }
+    ],
+    "3": [
+      {
+        "itemId": "dungeon-rune",
+        "amount": 6
+      },
+      {
+        "itemId": "hide",
+        "amount": 20
+      },
+      {
+        "itemId": "meat",
+        "amount": 30
+      },
+      {
+        "itemId": "egg",
+        "amount": 6
+      }
+    ],
+    "4": [
+      {
+        "itemId": "dungeon-rune",
+        "amount": 8
+      },
+      {
+        "itemId": "hide",
+        "amount": 40
+      },
+      {
+        "itemId": "meat",
+        "amount": 40
+      },
+      {
+        "itemId": "egg",
+        "amount": 10
+      }
+    ],
+    "5": [
+      {
+        "itemId": "dungeon-rune",
+        "amount": 12
+      },
+      {
+        "itemId": "hide",
+        "amount": 60
+      },
+      {
+        "itemId": "meat",
+        "amount": 50
+      },
+      {
+        "itemId": "egg",
+        "amount": 15
+      }
+    ]
+  },
+  "gatheringRewards": {
+    "Chopping": {
+      "1": [
+        {
+          "itemId": "twig",
+          "amount": 100
+        },
+        {
+          "itemId": "pine-log",
+          "amount": 95
+        },
+        {
+          "itemId": "birch-log",
+          "amount": 90
+        }
+      ],
+      "2": [
+        {
+          "itemId": "oak-log",
+          "amount": 85
+        },
+        {
+          "itemId": "maple-log",
+          "amount": 80
+        },
+        {
+          "itemId": "cedar-log",
+          "amount": 75
+        }
+      ],
+      "3": [
+        {
+          "itemId": "ash-log",
+          "amount": 70
+        },
+        {
+          "itemId": "spruce-log",
+          "amount": 65
+        }
+      ],
+      "4": [
+        {
+          "itemId": "willow-log",
+          "amount": 60
+        },
+        {
+          "itemId": "runic-log",
+          "amount": 55
+        }
+      ],
+      "5": [
+        {
+          "itemId": "elder-log",
+          "amount": 50
+        },
+        {
+          "itemId": "arcanum-log",
+          "amount": 45
+        }
+      ]
+    },
+    "Mining": {
+      "1": [
+        {
+          "itemId": "stone",
+          "amount": 70
+        },
+        {
+          "itemId": "copper-ore",
+          "amount": 65
+        },
+        {
+          "itemId": "tin-ore",
+          "amount": 60
+        }
+      ],
+      "2": [
+        {
+          "itemId": "coal",
+          "amount": 55
+        },
+        {
+          "itemId": "iron-ore",
+          "amount": 50
+        },
+        {
+          "itemId": "silver-ore",
+          "amount": 45
+        }
+      ],
+      "3": [
+        {
+          "itemId": "gold-ore",
+          "amount": 40
+        },
+        {
+          "itemId": "platinum-ore",
+          "amount": 35
+        }
+      ],
+      "4": [
+        {
+          "itemId": "adamantite-ore",
+          "amount": 30
+        },
+        {
+          "itemId": "runic-ore",
+          "amount": 25
+        }
+      ],
+      "5": [
+        {
+          "itemId": "solarite-ore",
+          "amount": 20
+        },
+        {
+          "itemId": "arcanum-ore",
+          "amount": 15
+        }
+      ]
+    },
+    "Digging": {
+      "1": [
+        {
+          "itemId": "stone",
+          "amount": 100
+        },
+        {
+          "itemId": "clay",
+          "amount": 95
+        },
+        {
+          "itemId": "sand",
+          "amount": 90
+        }
+      ],
+      "2": [
+        {
+          "itemId": "mud",
+          "amount": 85
+        },
+        {
+          "itemId": "ice",
+          "amount": 80
+        },
+        {
+          "itemId": "obsidian",
+          "amount": 75
+        }
+      ],
+      "3": [
+        {
+          "itemId": "gravel",
+          "amount": 70
+        },
+        {
+          "itemId": "fossil",
+          "amount": 65
+        }
+      ],
+      "4": [
+        {
+          "itemId": "dungeon-dust",
+          "amount": 60
+        },
+        {
+          "itemId": "runestone",
+          "amount": 55
+        }
+      ],
+      "5": [
+        {
+          "itemId": "volcanic-rock",
+          "amount": 50
+        },
+        {
+          "itemId": "key-fragment",
+          "amount": 45
+        }
+      ]
+    },
+    "Farming": {
+      "1": [
+        {
+          "itemId": "grass",
+          "amount": 100
+        },
+        {
+          "itemId": "wheat",
+          "amount": 95
+        },
+        {
+          "itemId": "carrot",
+          "amount": 90
+        }
+      ],
+      "2": [
+        {
+          "itemId": "tomato",
+          "amount": 85
+        },
+        {
+          "itemId": "lettuce",
+          "amount": 80
+        },
+        {
+          "itemId": "potato",
+          "amount": 75
+        }
+      ],
+      "3": [
+        {
+          "itemId": "corn",
+          "amount": 70
+        },
+        {
+          "itemId": "eggplant",
+          "amount": 65
+        }
+      ],
+      "4": [
+        {
+          "itemId": "onion",
+          "amount": 60
+        },
+        {
+          "itemId": "pepper",
+          "amount": 55
+        }
+      ],
+      "5": [
+        {
+          "itemId": "pineapple",
+          "amount": 50
+        },
+        {
+          "itemId": "mango",
+          "amount": 45
+        }
+      ]
+    },
+    "Fishing": {
+      "1": [
+        {
+          "itemId": "minnow",
+          "amount": 100
+        },
+        {
+          "itemId": "trout",
+          "amount": 95
+        },
+        {
+          "itemId": "bass",
+          "amount": 90
+        }
+      ],
+      "2": [
+        {
+          "itemId": "walleye",
+          "amount": 85
+        },
+        {
+          "itemId": "salmon",
+          "amount": 80
+        },
+        {
+          "itemId": "snail",
+          "amount": 75
+        }
+      ],
+      "3": [
+        {
+          "itemId": "carp",
+          "amount": 70
+        },
+        {
+          "itemId": "magical-carp",
+          "amount": 65
+        }
+      ],
+      "4": [
+        {
+          "itemId": "crab",
+          "amount": 60
+        },
+        {
+          "itemId": "redfish",
+          "amount": 55
+        }
+      ],
+      "5": [
+        {
+          "itemId": "rainbow-fish",
+          "amount": 50
+        },
+        {
+          "itemId": "emberfish",
+          "amount": 45
+        }
+      ]
+    },
+    "Exploring": {
+      "1": [
+        {
+          "itemId": "berry",
+          "amount": 100
+        },
+        {
+          "itemId": "butterfly",
+          "amount": 95
+        },
+        {
+          "itemId": "shell",
+          "amount": 90
+        }
+      ],
+      "2": [
+        {
+          "itemId": "horn",
+          "amount": 85
+        },
+        {
+          "itemId": "reed",
+          "amount": 80
+        },
+        {
+          "itemId": "lichen",
+          "amount": 75
+        }
+      ],
+      "3": [
+        {
+          "itemId": "mushroom",
+          "amount": 70
+        },
+        {
+          "itemId": "memory-orb",
+          "amount": 65
+        }
+      ],
+      "4": [
+        {
+          "itemId": "vine",
+          "amount": 60
+        },
+        {
+          "itemId": "geode",
+          "amount": 55
+        }
+      ],
+      "5": [
+        {
+          "itemId": "snow",
+          "amount": 50
+        },
+        {
+          "itemId": "legacy-fragment",
+          "amount": 45
+        }
+      ]
+    }
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,6 +31,12 @@ export const router = createRouter({
       meta: { title: 'Items' },
     },
     {
+      path: '/dungeons',
+      name: 'dungeons',
+      component: () => import('../views/DungeonsView.vue'),
+      meta: { title: 'Dungeons' },
+    },
+    {
       path: '/expeditions',
       name: 'expeditions',
       component: () => import('../views/ExpeditionsView.vue'),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,46 @@ export interface Expedition {
   rewards: { itemId: string; amount: number }[]
 }
 
+// Dungeon types
+export type DungeonFocus = 'combat' | 'gathering'
+export type DungeonGradeLetter = 'S' | 'A' | 'B' | 'C' | 'F'
+export type GatheringSubFocus =
+  | 'Chopping'
+  | 'Mining'
+  | 'Digging'
+  | 'Farming'
+  | 'Fishing'
+  | 'Exploring'
+
+export interface DungeonTier {
+  tier: number
+  baseRating: number
+  xpReward: number
+}
+
+export interface DungeonGrade {
+  grade: DungeonGradeLetter
+  minRatio: number
+  multiplier: number
+}
+
+export interface DungeonReward {
+  itemId: string
+  amount: number
+}
+
+export interface DungeonConfig {
+  duration: number
+  maxPartySize: number
+  requiresItem: string
+  tierLevelRequirements: Record<DungeonFocus, Record<string, number>>
+  tiers: DungeonTier[]
+  grades: DungeonGrade[]
+  statWeights: Record<DungeonFocus, ExpeditionStatWeights>
+  combatRewards: Record<string, DungeonReward[]>
+  gatheringRewards: Record<GatheringSubFocus, Record<string, DungeonReward[]>>
+}
+
 export interface Biome {
   id: string
   name: string

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -1,8 +1,11 @@
 import creaturesData from '@/data/creatures.json'
-import type { Biome, Creature, Expedition } from '@/types'
+import dungeonData from '@/data/dungeons.json'
+import type { Biome, Creature, DungeonConfig, Expedition } from '@/types'
 import {
   biomeMultiplier,
   calculateCreatureRating,
+  calculateDungeonCreatureScore,
+  calculateDungeonPartyScore,
   calculateDuration,
   calculateExpeditionXp,
   calculatePartyScore,
@@ -10,6 +13,7 @@ import {
   getBestExpeditionsForLeveling,
   getLoopXpBonus,
   getRecommendedCreatures,
+  getRecommendedDungeonCreatures,
   levelFromXp,
   traitAbbreviations,
   xpForLevel,
@@ -655,5 +659,155 @@ describe('traitAbbreviations', () => {
   test('no duplicate abbreviations', () => {
     const values = Object.values(traitAbbreviations)
     expect(new Set(values).size).toBe(values.length)
+  })
+})
+
+// ── Dungeon formulas ──────────────────────────────────────────────────
+
+const dungeonConfig = dungeonData as DungeonConfig
+const combatWeights = dungeonConfig.statWeights.combat
+const gatheringWeights = dungeonConfig.statWeights.gathering
+
+describe('calculateDungeonCreatureScore', () => {
+  test('weights stats correctly at level 1', () => {
+    const creature = makeCreature({
+      stats: { power: 10, grit: 10, agility: 10, smarts: 10, looting: 0, luck: 0 },
+    })
+    // combat: 10*0.25 + 10*0.25 + 10*0.25 + 10*0.25 = 10
+    expect(calculateDungeonCreatureScore(creature, combatWeights)).toBe(10)
+  })
+
+  test('scales linearly with level', () => {
+    const creature = makeCreature({
+      stats: { power: 10, grit: 10, agility: 10, smarts: 10, looting: 0, luck: 0 },
+    })
+    expect(calculateDungeonCreatureScore(creature, combatWeights, 5)).toBe(50)
+  })
+
+  test('uses gathering weights (smarts/looting/luck only)', () => {
+    const creature = makeCreature({
+      stats: { power: 100, grit: 100, agility: 100, smarts: 10, looting: 10, luck: 10 },
+    })
+    // gathering: 10*0.33 + 10*0.33 + 10*0.34 = 10
+    expect(calculateDungeonCreatureScore(creature, gatheringWeights)).toBe(10)
+  })
+
+  test('does not apply biome or trait bonuses', () => {
+    const creature = makeCreature({
+      stats: { power: 10, grit: 10, agility: 10, smarts: 10, looting: 0, luck: 0 },
+      types: ['Fire'],
+      trait: 'learner',
+    })
+    expect(calculateDungeonCreatureScore(creature, combatWeights)).toBe(10)
+  })
+
+  test('zero-weight stats are excluded', () => {
+    const creature = makeCreature({
+      stats: { power: 0, grit: 0, agility: 0, smarts: 0, looting: 100, luck: 100 },
+    })
+    expect(calculateDungeonCreatureScore(creature, combatWeights)).toBe(0)
+  })
+
+  test('defaults to level 1', () => {
+    const creature = makeCreature({
+      stats: { power: 20, grit: 20, agility: 20, smarts: 20, looting: 0, luck: 0 },
+    })
+    expect(calculateDungeonCreatureScore(creature, combatWeights)).toBe(20)
+  })
+})
+
+describe('calculateDungeonPartyScore', () => {
+  test('sums scores of all creatures', () => {
+    const c1 = makeCreature({
+      id: 'a',
+      stats: { ...zeroStats, power: 10, grit: 10, agility: 10, smarts: 10 },
+    })
+    const c2 = makeCreature({
+      id: 'b',
+      stats: { ...zeroStats, power: 20, grit: 20, agility: 20, smarts: 20 },
+    })
+    expect(calculateDungeonPartyScore([c1, c2], combatWeights, {})).toBe(30)
+  })
+
+  test('skips null slots', () => {
+    const c1 = makeCreature({
+      id: 'a',
+      stats: { ...zeroStats, power: 10, grit: 10, agility: 10, smarts: 10 },
+    })
+    expect(calculateDungeonPartyScore([c1, null, null], combatWeights, {})).toBe(10)
+  })
+
+  test('applies per-creature level from levels map', () => {
+    const c1 = makeCreature({
+      id: 'a',
+      stats: { ...zeroStats, power: 10, grit: 10, agility: 10, smarts: 10 },
+    })
+    expect(calculateDungeonPartyScore([c1], combatWeights, { a: 3 })).toBe(30)
+  })
+
+  test('defaults to level 1 when creature not in levels map', () => {
+    const c1 = makeCreature({
+      id: 'a',
+      stats: { ...zeroStats, power: 10, grit: 10, agility: 10, smarts: 10 },
+    })
+    expect(calculateDungeonPartyScore([c1], combatWeights, {})).toBe(10)
+  })
+
+  test('returns 0 for all-null party', () => {
+    expect(calculateDungeonPartyScore([null, null, null], combatWeights, {})).toBe(0)
+  })
+})
+
+describe('getRecommendedDungeonCreatures', () => {
+  test('returns an entry for each creature', () => {
+    const subset = creatures.slice(0, 3)
+    const results = getRecommendedDungeonCreatures(subset, combatWeights)
+    expect(results.length).toBe(3)
+  })
+
+  test('results are sorted by score descending', () => {
+    const results = getRecommendedDungeonCreatures(creatures, combatWeights)
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score)
+    }
+  })
+
+  test('each entry has creature, score, and level', () => {
+    const results = getRecommendedDungeonCreatures(creatures.slice(0, 1), combatWeights)
+    expect(results[0]).toHaveProperty('creature')
+    expect(results[0]).toHaveProperty('score')
+    expect(results[0]).toHaveProperty('level')
+  })
+
+  test('uses provided levels map', () => {
+    const c = creatures[0]
+    const results = getRecommendedDungeonCreatures([c], combatWeights, { [c.id]: 10 })
+    expect(results[0].level).toBe(10)
+  })
+
+  test('defaults to level 1 when not in levels map', () => {
+    const c = creatures[0]
+    const results = getRecommendedDungeonCreatures([c], combatWeights, {})
+    expect(results[0].level).toBe(1)
+  })
+
+  test('returns empty array for empty creature list', () => {
+    expect(getRecommendedDungeonCreatures([], combatWeights)).toEqual([])
+  })
+
+  test('gathering weights rank smarts/looting/luck creatures higher', () => {
+    const smartCreature = makeCreature({
+      id: 'smart',
+      stats: { ...zeroStats, smarts: 50, looting: 50, luck: 50 },
+    })
+    const strongCreature = makeCreature({
+      id: 'strong',
+      stats: { ...zeroStats, power: 50, grit: 50, agility: 50 },
+    })
+    const results = getRecommendedDungeonCreatures(
+      [smartCreature, strongCreature],
+      gatheringWeights,
+    )
+    expect(results[0].creature.id).toBe('smart')
   })
 })

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -939,3 +939,60 @@ describe('dungeon grade and reward relationships', () => {
     }
   })
 })
+
+describe('dungeons.json data integrity', () => {
+  test('has 5 tiers', () => {
+    expect(dungeonConfig.tiers).toHaveLength(5)
+  })
+
+  test('has 5 grades (S/A/B/C/F)', () => {
+    expect(dungeonConfig.grades).toHaveLength(5)
+    expect(dungeonConfig.grades.map((g) => g.grade)).toEqual(['S', 'A', 'B', 'C', 'F'])
+  })
+
+  test('grades are sorted by minRatio descending', () => {
+    for (let i = 1; i < dungeonConfig.grades.length; i++) {
+      expect(dungeonConfig.grades[i - 1].minRatio).toBeGreaterThan(dungeonConfig.grades[i].minRatio)
+    }
+  })
+
+  test('combat stat weights sum to 1', () => {
+    const sum = Object.values(dungeonConfig.statWeights.combat).reduce((a, b) => a + b, 0)
+    expect(sum).toBeCloseTo(1.0)
+  })
+
+  test('gathering stat weights sum to 1', () => {
+    const sum = Object.values(dungeonConfig.statWeights.gathering).reduce((a, b) => a + b, 0)
+    expect(sum).toBeCloseTo(1.0)
+  })
+
+  test('combat rewards exist for all 5 tiers', () => {
+    for (let t = 1; t <= 5; t++) {
+      expect(dungeonConfig.combatRewards[String(t)]).toBeDefined()
+      expect(dungeonConfig.combatRewards[String(t)].length).toBeGreaterThan(0)
+    }
+  })
+
+  test('gathering rewards exist for all 6 sub-focuses and 5 tiers', () => {
+    const subFocuses = ['Chopping', 'Mining', 'Digging', 'Farming', 'Fishing', 'Exploring'] as const
+    for (const sub of subFocuses) {
+      expect(dungeonConfig.gatheringRewards[sub]).toBeDefined()
+      for (let t = 1; t <= 5; t++) {
+        expect(dungeonConfig.gatheringRewards[sub][String(t)]).toBeDefined()
+        expect(dungeonConfig.gatheringRewards[sub][String(t)].length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test('duration is 900 seconds', () => {
+    expect(dungeonConfig.duration).toBe(900)
+  })
+
+  test('max party size is 3', () => {
+    expect(dungeonConfig.maxPartySize).toBe(3)
+  })
+
+  test('requires armor-set', () => {
+    expect(dungeonConfig.requiresItem).toBe('armor-set')
+  })
+})

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -1,6 +1,6 @@
 import creaturesData from '@/data/creatures.json'
 import dungeonData from '@/data/dungeons.json'
-import type { Biome, Creature, DungeonConfig, Expedition } from '@/types'
+import type { Biome, Creature, DungeonConfig, DungeonGrade, Expedition } from '@/types'
 import {
   biomeMultiplier,
   calculateCreatureRating,
@@ -11,6 +11,8 @@ import {
   calculatePartyScore,
   getBestExpeditionsForCreature,
   getBestExpeditionsForLeveling,
+  getDungeonGrade,
+  getDungeonScaledRewards,
   getLoopXpBonus,
   getRecommendedCreatures,
   getRecommendedDungeonCreatures,
@@ -809,5 +811,131 @@ describe('getRecommendedDungeonCreatures', () => {
       gatheringWeights,
     )
     expect(results[0].creature.id).toBe('smart')
+  })
+})
+
+describe('getDungeonGrade', () => {
+  const grades = dungeonConfig.grades
+
+  test('returns S for ratio >= 2.0', () => {
+    expect(getDungeonGrade(4000, 2000, grades).grade).toBe('S')
+    expect(getDungeonGrade(5000, 2000, grades).grade).toBe('S')
+  })
+
+  test('returns A for ratio >= 1.0 but < 2.0', () => {
+    expect(getDungeonGrade(2000, 2000, grades).grade).toBe('A')
+    expect(getDungeonGrade(3999, 2000, grades).grade).toBe('A')
+  })
+
+  test('returns B for ratio >= 0.6 but < 1.0', () => {
+    expect(getDungeonGrade(1200, 2000, grades).grade).toBe('B')
+    expect(getDungeonGrade(1999, 2000, grades).grade).toBe('B')
+  })
+
+  test('returns C for ratio >= 0.3 but < 0.6', () => {
+    expect(getDungeonGrade(600, 2000, grades).grade).toBe('C')
+    expect(getDungeonGrade(1199, 2000, grades).grade).toBe('C')
+  })
+
+  test('returns F for ratio < 0.3', () => {
+    expect(getDungeonGrade(0, 2000, grades).grade).toBe('F')
+    expect(getDungeonGrade(599, 2000, grades).grade).toBe('F')
+  })
+
+  test('returns correct multiplier for each grade', () => {
+    expect(getDungeonGrade(4000, 2000, grades).multiplier).toBe(2.0)
+    expect(getDungeonGrade(2000, 2000, grades).multiplier).toBe(1.5)
+    expect(getDungeonGrade(1200, 2000, grades).multiplier).toBe(1.0)
+    expect(getDungeonGrade(600, 2000, grades).multiplier).toBe(0.5)
+    expect(getDungeonGrade(0, 2000, grades).multiplier).toBe(0.25)
+  })
+
+  test('returns F when baseRating is 0', () => {
+    expect(getDungeonGrade(100, 0, grades).grade).toBe('F')
+  })
+
+  test('works across all tiers', () => {
+    for (const tier of dungeonConfig.tiers) {
+      const sGrade = getDungeonGrade(tier.baseRating * 2, tier.baseRating, grades)
+      expect(sGrade.grade).toBe('S')
+      const fGrade = getDungeonGrade(0, tier.baseRating, grades)
+      expect(fGrade.grade).toBe('F')
+    }
+  })
+})
+
+describe('getDungeonScaledRewards', () => {
+  const baseRewards = [
+    { itemId: 'dungeon-rune', amount: 2 },
+    { itemId: 'hide', amount: 5 },
+  ]
+
+  test('scales amounts by multiplier', () => {
+    const scaled = getDungeonScaledRewards(baseRewards, 2.0)
+    expect(scaled[0].amount).toBe(4)
+    expect(scaled[1].amount).toBe(10)
+  })
+
+  test('floors scaled amounts', () => {
+    const scaled = getDungeonScaledRewards(baseRewards, 0.5)
+    expect(scaled[0].amount).toBe(1)
+    expect(scaled[1].amount).toBe(2)
+  })
+
+  test('enforces minimum of 1', () => {
+    const scaled = getDungeonScaledRewards(baseRewards, 0.25)
+    expect(scaled[0].amount).toBeGreaterThanOrEqual(1)
+    expect(scaled[1].amount).toBeGreaterThanOrEqual(1)
+  })
+
+  test('preserves item IDs', () => {
+    const scaled = getDungeonScaledRewards(baseRewards, 1.0)
+    expect(scaled[0].itemId).toBe('dungeon-rune')
+    expect(scaled[1].itemId).toBe('hide')
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(getDungeonScaledRewards([], 2.0)).toEqual([])
+  })
+})
+
+describe('dungeon grade and reward relationships', () => {
+  const grades = dungeonConfig.grades
+
+  test('higher party score produces better grade', () => {
+    const gradeF = getDungeonGrade(0, 2000, grades)
+    const gradeC = getDungeonGrade(600, 2000, grades)
+    const gradeB = getDungeonGrade(1200, 2000, grades)
+    const gradeA = getDungeonGrade(2000, 2000, grades)
+    const gradeS = getDungeonGrade(4000, 2000, grades)
+
+    expect(gradeF.multiplier).toBeLessThan(gradeC.multiplier)
+    expect(gradeC.multiplier).toBeLessThan(gradeB.multiplier)
+    expect(gradeB.multiplier).toBeLessThan(gradeA.multiplier)
+    expect(gradeA.multiplier).toBeLessThan(gradeS.multiplier)
+  })
+
+  test('higher grade gives more rewards', () => {
+    const baseRewards = dungeonConfig.combatRewards['1']
+    const rewardsB = getDungeonScaledRewards(baseRewards, 1.0)
+    const rewardsS = getDungeonScaledRewards(baseRewards, 2.0)
+
+    for (let i = 0; i < baseRewards.length; i++) {
+      expect(rewardsS[i].amount).toBeGreaterThanOrEqual(rewardsB[i].amount)
+    }
+  })
+
+  test('XP reward scales with tier', () => {
+    const tiers = dungeonConfig.tiers
+    for (let i = 1; i < tiers.length; i++) {
+      expect(tiers[i].xpReward).toBeGreaterThan(tiers[i - 1].xpReward)
+    }
+  })
+
+  test('base rating scales with tier', () => {
+    const tiers = dungeonConfig.tiers
+    for (let i = 1; i < tiers.length; i++) {
+      expect(tiers[i].baseRating).toBeGreaterThan(tiers[i - 1].baseRating)
+    }
   })
 })

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -1,6 +1,13 @@
 import biomesData from '@/data/biomes.json'
 import expeditionsData from '@/data/expeditions.json'
-import type { Creature, Expedition, Biome, CreatureStats, ExpeditionStatKey } from '@/types'
+import type {
+  Creature,
+  Expedition,
+  Biome,
+  CreatureStats,
+  ExpeditionStatKey,
+  ExpeditionStatWeights,
+} from '@/types'
 
 // Consolidated stat labels & abbreviations (creature and expedition stats share the same keys)
 export const statLabels: Record<keyof CreatureStats, string> = {
@@ -346,4 +353,52 @@ export function getRecommendedCreatures(
       }
     })
     .toSorted((a, b) => b.rating - a.rating)
+}
+
+// ── Dungeon formulas ──────────────────────────────────────────────────
+
+export function calculateDungeonCreatureScore(
+  creature: Creature,
+  statWeights: ExpeditionStatWeights,
+  level: number = 1,
+): number {
+  let weightedStatSum = 0
+  for (const [stat, weight] of Object.entries(statWeights) as [ExpeditionStatKey, number][]) {
+    if (weight > 0) {
+      weightedStatSum += creature.stats[stat] * weight
+    }
+  }
+  return Math.floor(weightedStatSum * level)
+}
+
+export function calculateDungeonPartyScore(
+  creatures: (Creature | null)[],
+  statWeights: ExpeditionStatWeights,
+  levels: Record<string, number>,
+): number {
+  let total = 0
+  for (const creature of creatures) {
+    if (creature) {
+      const level = levels[creature.id] || 1
+      total += calculateDungeonCreatureScore(creature, statWeights, level)
+    }
+  }
+  return total
+}
+
+export function getRecommendedDungeonCreatures(
+  creatures: Creature[],
+  statWeights: ExpeditionStatWeights,
+  levels: Record<string, number> = {},
+): { creature: Creature; score: number; level: number }[] {
+  return creatures
+    .map((creature) => {
+      const level = levels[creature.id] || 1
+      return {
+        creature,
+        score: calculateDungeonCreatureScore(creature, statWeights, level),
+        level,
+      }
+    })
+    .toSorted((a, b) => b.score - a.score)
 }

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -7,6 +7,8 @@ import type {
   CreatureStats,
   ExpeditionStatKey,
   ExpeditionStatWeights,
+  DungeonGrade,
+  DungeonReward,
 } from '@/types'
 
 // Consolidated stat labels & abbreviations (creature and expedition stats share the same keys)
@@ -384,6 +386,30 @@ export function calculateDungeonPartyScore(
     }
   }
   return total
+}
+
+export function getDungeonGrade(
+  partyScore: number,
+  baseRating: number,
+  grades: DungeonGrade[],
+): DungeonGrade {
+  const ratio = baseRating > 0 ? partyScore / baseRating : 0
+  for (const grade of grades) {
+    if (ratio >= grade.minRatio) {
+      return grade
+    }
+  }
+  return grades[grades.length - 1]
+}
+
+export function getDungeonScaledRewards(
+  baseRewards: DungeonReward[],
+  multiplier: number,
+): DungeonReward[] {
+  return baseRewards.map((reward) => ({
+    itemId: reward.itemId,
+    amount: Math.max(1, Math.floor(reward.amount * multiplier)),
+  }))
 }
 
 export function getRecommendedDungeonCreatures(

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -1,0 +1,1088 @@
+<script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
+import { ChevronDown, Info, Minus, Plus, Swords, X } from 'lucide-vue-next'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import summonedIcon from '@/assets/icons/summoned.webp'
+import ActiveFilters from '@/components/shared/ActiveFilters.vue'
+import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatures } from '@/composables/useCreatures'
+import { useDungeons } from '@/composables/useDungeons'
+import { useGameConfig } from '@/composables/useGameConfig'
+import type { Creature, ElementType, ExpeditionStatKey, GatheringSubFocus } from '@/types'
+import { getCreatureImage } from '@/utils/creatureImages'
+import { toTitleCase } from '@/utils/format'
+import { statAbbreviations, statLabels } from '@/utils/formulas'
+import { sanctuaryIcon, helpersIcon, machinesIcon, jobIcons } from '@/utils/icons'
+import { getItemImage } from '@/utils/itemImages'
+
+const route = useRoute()
+const router = useRouter()
+const isDesktop = useMediaQuery('(min-width: 1024px)')
+
+
+const { creatures } = useCreatures()
+const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds } = useGameConfig()
+const { isOwned, isAwakened, collectionLevels } = useCreatureCollection()
+
+
+const {
+  config,
+  selectedTier,
+  selectedFocus,
+  selectedSubFocus,
+  partySlots,
+  activeSlotIndex,
+  effectiveLevels,
+  activeStatWeights,
+  currentTierConfig,
+  partyScore,
+  currentGrade,
+  gradeClasses,
+  scoreRatio,
+  predictedXP,
+  predictedRewards,
+  recommendedCreatures,
+  showExcludedCreatures,
+  assignCreatureToSlot,
+  removeCreatureFromSlot,
+  setActiveSlot,
+  getCreatureSlotScore,
+  updateCreatureLevel,
+  GRADE_COLORS,
+  GATHERING_SUB_FOCUSES,
+} = useDungeons(creatures.value, collectionLevels)
+
+
+const TIER_LABELS = ['I', 'II', 'III', 'IV', 'V']
+
+
+// ── Mobile section handling ──
+type MobileSection = 'config' | 'details' | 'creature'
+
+
+function normalizeSection(value: unknown): MobileSection {
+  if (value === 'details') return 'details'
+  if (value === 'creature') return 'creature'
+  return 'config'
+}
+
+
+const mobileSection = computed<MobileSection>({
+  get() {
+    return normalizeSection(route.query.section)
+  },
+  set(value) {
+    router.replace({ query: { ...route.query, section: value } })
+  },
+})
+
+
+// ── Creature filters ──
+const creatureSearch = ref('')
+const selectedCreatureType = ref<ElementType | 'all'>('all')
+const selectedCreatureTiers = ref<number[]>([])
+const ownedOnly = ref(true)
+const showMoreCreatureFilters = ref(false)
+const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
+
+
+function typeColor(type: ElementType): string {
+  if (type === 'Fire') return 'hsl(var(--type-fire))'
+  if (type === 'Water') return 'hsl(var(--type-water))'
+  if (type === 'Wind') return 'hsl(var(--type-wind))'
+  return 'hsl(var(--type-earth))'
+}
+
+
+const weightedStats = computed<[ExpeditionStatKey, number][]>(() => {
+  return (Object.entries(activeStatWeights.value) as [ExpeditionStatKey, number][]).filter(
+    ([, w]) => w > 0,
+  )
+})
+
+
+function statBar(creature: Creature, statKey: ExpeditionStatKey): number {
+  return Math.min(100, creature.stats[statKey])
+}
+
+
+const hasEmptySlot = computed(() => partySlots.value.some((s) => s === null))
+
+
+const creatureTierOptions = computed(() => {
+  const tiers = new Set(creatures.value.map((c) => c.tier))
+  return Array.from(tiers).toSorted((a, b) => a - b)
+})
+
+
+const allCreatureTiersSelected = computed(() => {
+  return (
+    creatureTierOptions.value.length > 0 &&
+    creatureTierOptions.value.every((tier) => selectedCreatureTiers.value.includes(tier))
+  )
+})
+
+
+watch(
+  creatureTierOptions,
+  (tiers) => {
+    const preserved = selectedCreatureTiers.value.filter((tier) => tiers.includes(tier))
+    selectedCreatureTiers.value = preserved.length ? preserved : [...tiers]
+  },
+  { immediate: true },
+)
+
+
+const hasSecondaryCreatureFilters = computed(
+  () => selectedCreatureType.value !== 'all' || !allCreatureTiersSelected.value,
+)
+
+
+const filteredRecommended = computed(() => {
+  return recommendedCreatures.value.filter(({ creature }) => {
+    const query = creatureSearch.value.toLowerCase()
+    const matchesSearch =
+      creature.name.toLowerCase().includes(query) || creature.trait.toLowerCase().includes(query)
+    const matchesType =
+      selectedCreatureType.value === 'all' || creature.types.includes(selectedCreatureType.value)
+    const matchesTier =
+      selectedCreatureTiers.value.length === 0 ||
+      selectedCreatureTiers.value.includes(creature.tier)
+    return matchesSearch && matchesType && matchesTier
+  })
+})
+
+
+const displayRecommended = computed(() => {
+  if (!ownedOnly.value) return filteredRecommended.value
+  return filteredRecommended.value.filter(({ creature }) => isOwned(creature.id))
+})
+
+
+const activeCreatureFilters = computed<ActiveFilter[]>(() => {
+  const filters: ActiveFilter[] = []
+  if (creatureSearch.value)
+    filters.push({
+      key: 'search',
+      group: 'Search',
+      label:
+        creatureSearch.value.length > 20
+          ? `${creatureSearch.value.slice(0, 20)}…`
+          : creatureSearch.value,
+    })
+  if (selectedCreatureType.value !== 'all')
+    filters.push({
+      key: 'type',
+      group: 'Type',
+      label: selectedCreatureType.value,
+      color: typeColor(selectedCreatureType.value),
+    })
+  if (!allCreatureTiersSelected.value) {
+    for (const tier of selectedCreatureTiers.value) {
+      filters.push({ key: `tier:${tier}`, group: 'Tier', label: `T${tier + 1}` })
+    }
+  }
+  if (!ownedOnly.value)
+    filters.push({ key: 'ownedOnly', group: 'Summoned', label: 'Showing All', image: summonedIcon })
+  if (showExcludedCreatures.value)
+    filters.push({ key: 'showExcluded', group: 'Excluded', label: 'Showing' })
+  return filters
+})
+
+
+function removeCreatureFilter(key: string) {
+  if (key === 'search') {
+    creatureSearch.value = ''
+    return
+  }
+  if (key === 'ownedOnly') {
+    ownedOnly.value = true
+    return
+  }
+  if (key === 'showExcluded') {
+    showExcludedCreatures.value = false
+    return
+  }
+  if (key === 'type') {
+    selectedCreatureType.value = 'all'
+    return
+  }
+  if (key.startsWith('tier:')) {
+    const tier = Number(key.slice(5))
+    if (selectedCreatureTiers.value.length === 1) {
+      selectedCreatureTiers.value = [...creatureTierOptions.value]
+    } else {
+      selectedCreatureTiers.value = selectedCreatureTiers.value.filter((t) => t !== tier)
+    }
+  }
+}
+
+
+function clearCreatureFilters() {
+  creatureSearch.value = ''
+  selectedCreatureType.value = 'all'
+  selectedCreatureTiers.value = [...creatureTierOptions.value]
+  ownedOnly.value = true
+  showExcludedCreatures.value = false
+}
+
+
+function chooseCreature(creature: Creature) {
+  if (!hasEmptySlot.value) return
+  assignCreatureToSlot(creature)
+  if (!isDesktop.value) {
+    mobileSection.value = 'details'
+  }
+}
+
+
+function clampLevel(level: number): number {
+  if (Number.isNaN(level)) return 1
+  return Math.max(1, Math.min(120, Math.round(level)))
+}
+
+
+function stepCreatureLevel(creatureId: string, currentLevel: number, delta: number) {
+  updateCreatureLevel(creatureId, clampLevel(currentLevel + delta))
+}
+
+
+function normalizeLevelOnBlur(creatureId: string, currentLevel: number, event: FocusEvent) {
+  const target = event.target as HTMLInputElement
+  if (!target.value.trim()) {
+    updateCreatureLevel(creatureId, currentLevel)
+    return
+  }
+  const parsed = Number(target.value)
+  if (Number.isNaN(parsed)) {
+    updateCreatureLevel(creatureId, currentLevel)
+    return
+  }
+  updateCreatureLevel(creatureId, clampLevel(parsed))
+}
+
+
+function toggleCreatureType(type: ElementType) {
+  selectedCreatureType.value = selectedCreatureType.value === type ? 'all' : type
+}
+
+
+function toggleCreatureTier(tier: number) {
+  if (allCreatureTiersSelected.value) {
+    selectedCreatureTiers.value = [tier]
+    return
+  }
+  if (selectedCreatureTiers.value.includes(tier)) {
+    if (selectedCreatureTiers.value.length === 1) {
+      selectedCreatureTiers.value = [...creatureTierOptions.value]
+      return
+    }
+    selectedCreatureTiers.value = selectedCreatureTiers.value.filter(
+      (selected) => selected !== tier,
+    )
+  } else {
+    selectedCreatureTiers.value = [...selectedCreatureTiers.value, tier]
+  }
+}
+
+
+const tierLevelReq = computed(() => {
+  const reqs = config.tierLevelRequirements[selectedFocus.value]
+  return reqs?.[String(selectedTier.value)] ?? 0
+})
+</script>
+
+<template>
+  <section class="space-y-5 lg:space-y-6">
+    <!-- Mobile tabs -->
+    <div class="surface-card p-2 lg:hidden">
+      <div class="grid grid-cols-3 gap-2">
+        <button
+          class="focus-ring rounded-lg px-3 py-2 text-xs font-semibold"
+          :class="
+            mobileSection === 'config'
+              ? 'bg-primary text-primary-foreground shadow-glow'
+              : 'bg-muted/45 text-muted-foreground'
+          "
+          @click="mobileSection = 'config'"
+        >
+          Config
+        </button>
+        <button
+          class="focus-ring rounded-lg px-3 py-2 text-xs font-semibold"
+          :class="
+            mobileSection === 'details'
+              ? 'bg-primary text-primary-foreground shadow-glow'
+              : 'bg-muted/45 text-muted-foreground'
+          "
+          @click="mobileSection = 'details'"
+        >
+          Details
+        </button>
+        <button
+          class="focus-ring rounded-lg px-3 py-2 text-xs font-semibold"
+          :class="
+            mobileSection === 'creature'
+              ? 'bg-primary text-primary-foreground shadow-glow'
+              : 'bg-muted/45 text-muted-foreground'
+          "
+          @click="mobileSection = 'creature'"
+        >
+          Creature
+        </button>
+      </div>
+    </div>
+
+    <!-- 3-column grid -->
+    <div
+      class="grid grid-cols-1 gap-4 lg:h-[calc(100vh-12rem)] lg:grid-cols-[minmax(260px,0.9fr)_minmax(320px,1fr)_minmax(320px,1fr)] lg:grid-rows-[minmax(0,1fr)]"
+    >
+      <!-- LEFT: Dungeon Config -->
+      <section
+        class="surface-card flex flex-col overflow-hidden"
+        :class="!isDesktop && mobileSection !== 'config' ? 'hidden' : ''"
+      >
+        <div class="border-b border-border/70 px-4 py-3">
+          <h2 class="text-base font-bold">Dungeon Config</h2>
+        </div>
+
+        <div
+          class="max-h-[62vh] animate-fade-in space-y-4 overflow-y-auto p-4 lg:max-h-none lg:min-h-0 lg:flex-1"
+        >
+          <!-- Focus Mode -->
+          <div class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Focus Mode
+            </h4>
+            <div class="inline-flex rounded-lg border border-border bg-muted/45 p-1">
+              <button
+                class="focus-ring rounded-md px-3 py-1.5 text-xs font-semibold transition"
+                :class="
+                  selectedFocus === 'combat'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                "
+                @click="selectedFocus = 'combat'"
+              >
+                Combat
+              </button>
+              <button
+                class="focus-ring rounded-md px-3 py-1.5 text-xs font-semibold transition"
+                :class="
+                  selectedFocus === 'gathering'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                "
+                @click="selectedFocus = 'gathering'"
+              >
+                Gathering
+              </button>
+            </div>
+          </div>
+
+          <!-- Sub-Focus (gathering only) -->
+          <div v-if="selectedFocus === 'gathering'" class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Gathering Skill
+            </h4>
+            <div class="flex flex-wrap gap-1.5">
+              <button
+                v-for="sub in GATHERING_SUB_FOCUSES"
+                :key="sub"
+                class="focus-ring inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-semibold transition"
+                :class="
+                  selectedSubFocus === sub
+                    ? 'border-primary bg-primary/15 text-primary'
+                    : 'border-border bg-muted/35 text-muted-foreground hover:text-foreground'
+                "
+                @click="selectedSubFocus = sub as GatheringSubFocus"
+              >
+                <img
+                  v-if="jobIcons[sub.toLowerCase()]"
+                  :src="jobIcons[sub.toLowerCase()]"
+                  :alt="sub"
+                  class="size-4 object-contain"
+                  loading="lazy"
+                />
+                {{ sub }}
+              </button>
+            </div>
+          </div>
+
+          <!-- Tier -->
+          <div class="space-y-2">
+            <h4
+              class="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground"
+            >
+              Tier
+              <span
+                v-if="tierLevelReq > 0"
+                class="text-[11px] font-semibold normal-case tracking-normal text-muted-foreground/70"
+              >
+                (Requires Player LVL {{ tierLevelReq }})
+              </span>
+            </h4>
+            <div class="inline-flex rounded-lg border border-border bg-muted/45 p-1">
+              <button
+                v-for="t in 5"
+                :key="t"
+                class="focus-ring rounded-md px-3 py-1.5 text-xs font-semibold transition"
+                :class="
+                  selectedTier === t
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                "
+                @click="selectedTier = t"
+              >
+                {{ TIER_LABELS[t - 1] }}
+              </button>
+            </div>
+          </div>
+
+          <!-- Stat Weights -->
+          <div class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Stat Weights
+            </h4>
+            <div
+              v-for="[key, weight] in weightedStats"
+              :key="key"
+              class="grid grid-cols-[80px_minmax(0,1fr)_44px] items-center gap-2"
+            >
+              <span class="text-xs text-muted-foreground">{{ statLabels[key] }}</span>
+              <div class="h-2 rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full bg-primary"
+                  :style="{ width: `${weight * 100}%` }"
+                />
+              </div>
+              <span class="text-right text-xs font-semibold text-foreground"
+                >{{ Math.round(weight * 100) }}%</span
+              >
+            </div>
+          </div>
+
+          <!-- Tier Table -->
+          <div class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Tier Overview
+            </h4>
+            <div class="overflow-hidden rounded-lg border border-border">
+              <table class="w-full text-xs">
+                <thead>
+                  <tr class="bg-muted/45">
+                    <th class="px-3 py-1.5 text-left font-semibold text-muted-foreground">Tier</th>
+                    <th class="px-3 py-1.5 text-right font-semibold text-muted-foreground">
+                      Base Rating
+                    </th>
+                    <th class="px-3 py-1.5 text-right font-semibold text-muted-foreground">
+                      XP Reward
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="tier in config.tiers"
+                    :key="tier.tier"
+                    class="border-t border-border/50"
+                    :class="tier.tier === selectedTier ? 'bg-primary/10' : ''"
+                  >
+                    <td class="px-3 py-1.5 font-semibold">{{ TIER_LABELS[tier.tier - 1] }}</td>
+                    <td class="px-3 py-1.5 text-right font-mono">
+                      {{ tier.baseRating.toLocaleString() }}
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono">
+                      {{ tier.xpReward.toLocaleString() }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Grade Table -->
+          <div class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Grade Thresholds
+            </h4>
+            <div class="overflow-hidden rounded-lg border border-border">
+              <table class="w-full text-xs">
+                <thead>
+                  <tr class="bg-muted/45">
+                    <th class="px-3 py-1.5 text-left font-semibold text-muted-foreground">Grade</th>
+                    <th class="px-3 py-1.5 text-right font-semibold text-muted-foreground">
+                      Min Score
+                    </th>
+                    <th class="px-3 py-1.5 text-right font-semibold text-muted-foreground">
+                      Reward Mult.
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    v-for="grade in config.grades"
+                    :key="grade.grade"
+                    class="border-t border-border/50"
+                    :class="currentGrade?.grade === grade.grade ? 'bg-primary/10' : ''"
+                  >
+                    <td class="px-3 py-1.5">
+                      <span
+                        class="inline-block w-6 rounded-md py-0.5 text-center text-xs font-bold"
+                        :class="[GRADE_COLORS[grade.grade].text, GRADE_COLORS[grade.grade].bg]"
+                      >
+                        {{ grade.grade }}
+                      </span>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono">
+                      {{
+                        Math.floor(grade.minRatio * currentTierConfig.baseRating).toLocaleString()
+                      }}
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono">{{ grade.multiplier }}x</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Requirements -->
+          <div class="rounded-lg border border-border bg-muted/30 p-3">
+            <p class="text-[11px] text-muted-foreground">
+              Requires
+              <span class="font-semibold text-foreground">{{
+                toTitleCase(config.requiresItem)
+              }}</span>
+              to enter (1 per creature). Duration:
+              <span class="font-semibold text-foreground">{{ config.duration / 60 }} minutes</span>.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- MIDDLE: Dungeon Details -->
+      <section
+        class="surface-card flex flex-col overflow-hidden"
+        :class="!isDesktop && mobileSection !== 'details' ? 'hidden' : ''"
+      >
+        <div class="border-b border-border/70 px-4 py-3">
+          <h2 class="text-base font-bold">Dungeon Details</h2>
+        </div>
+
+        <div
+          class="max-h-[62vh] animate-fade-in space-y-4 overflow-y-auto p-4 lg:max-h-none lg:min-h-0 lg:flex-1"
+        >
+          <!-- Current Config Summary -->
+          <div class="grid grid-cols-2 gap-2 text-sm">
+            <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
+              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">Focus</p>
+              <p class="font-semibold">
+                {{ toTitleCase(selectedFocus) }}
+                <span v-if="selectedFocus === 'gathering'" class="text-xs text-muted-foreground">
+                  ({{ selectedSubFocus }})
+                </span>
+              </p>
+            </div>
+            <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
+              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">Tier</p>
+              <p class="font-semibold">
+                {{ TIER_LABELS[selectedTier - 1] }}
+                <span class="text-xs text-muted-foreground">
+                  ({{ currentTierConfig.baseRating.toLocaleString() }} rating)
+                </span>
+              </p>
+            </div>
+            <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
+              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">XP / Creature</p>
+              <p class="font-mono font-semibold">
+                {{ predictedXP ? predictedXP.toLocaleString() : '—' }}
+              </p>
+            </div>
+            <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
+              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">Entry Cost</p>
+              <p class="flex items-center gap-1.5 font-semibold">
+                <img
+                  v-if="getItemImage({ id: config.requiresItem })"
+                  :src="getItemImage({ id: config.requiresItem })"
+                  :alt="toTitleCase(config.requiresItem)"
+                  class="size-4 object-contain"
+                  loading="lazy"
+                />
+                {{ partySlots.filter((s) => s !== null).length || 0 }}x
+                {{ toTitleCase(config.requiresItem) }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Rewards -->
+          <div class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Rewards
+              <span v-if="currentGrade" class="normal-case tracking-normal text-foreground">
+                ({{ currentGrade.multiplier }}x)
+              </span>
+            </h4>
+            <div class="flex flex-wrap gap-2">
+              <span
+                v-for="reward in predictedRewards.length
+                  ? predictedRewards
+                  : ((selectedFocus === 'combat'
+                      ? config.combatRewards[String(selectedTier)]
+                      : config.gatheringRewards[selectedSubFocus]?.[String(selectedTier)]) ?? [])"
+                :key="reward.itemId"
+                class="inline-flex items-center gap-1 rounded-lg border border-border bg-muted/45 px-3 py-1 font-mono text-xs"
+              >
+                <img
+                  v-if="getItemImage({ id: reward.itemId })"
+                  :src="getItemImage({ id: reward.itemId })"
+                  :alt="toTitleCase(reward.itemId)"
+                  class="size-4 object-contain"
+                  loading="lazy"
+                />
+                {{ reward.amount }}x
+                {{ toTitleCase(reward.itemId) }}
+              </span>
+            </div>
+          </div>
+
+          <!-- Party Slots -->
+          <div class="space-y-2">
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Party
+            </h4>
+            <div class="flex flex-wrap gap-2">
+              <div
+                v-for="(slot, index) in partySlots"
+                :key="index"
+                class="flex flex-col items-center gap-1"
+              >
+                <div
+                  class="relative size-20 overflow-hidden rounded-lg border transition"
+                  :class="[
+                    slot
+                      ? 'border-border bg-card/50'
+                      : activeSlotIndex === index
+                        ? 'border-dashed border-primary bg-primary/10'
+                        : 'cursor-pointer border-dashed border-border/50 bg-muted/20 hover:border-accent/45',
+                  ]"
+                  @click="!slot ? setActiveSlot(index) : undefined"
+                >
+                  <template v-if="slot">
+                    <img
+                      :src="getCreatureImage(slot)"
+                      :alt="`${slot.name} artwork`"
+                      class="size-full object-cover"
+                      loading="lazy"
+                    />
+                    <span
+                      class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
+                    >
+                      {{ getCreatureSlotScore(slot) }}
+                    </span>
+                    <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
+                      <p class="truncate text-center text-[10px] font-semibold text-white">
+                        {{ slot.name }}
+                      </p>
+                    </div>
+                    <button
+                      class="focus-ring absolute right-0.5 top-0.5 rounded-full bg-black/60 p-0.5 text-white/70 hover:text-white"
+                      @click.stop="removeCreatureFromSlot(index)"
+                    >
+                      <X class="size-3" />
+                    </button>
+                  </template>
+                  <template v-else>
+                    <div class="flex size-full flex-col items-center justify-center gap-1">
+                      <Plus class="size-4 text-muted-foreground/50" />
+                      <span v-if="activeSlotIndex === index" class="text-[9px] text-primary"
+                        >Select</span
+                      >
+                    </div>
+                  </template>
+                </div>
+                <span
+                  v-if="slot"
+                  class="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-semibold text-foreground"
+                >
+                  LVL {{ effectiveLevels[slot.id] || 1 }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Party Summary -->
+          <div
+            v-if="partyScore > 0"
+            class="space-y-2 rounded-lg border border-border bg-muted/30 p-3"
+          >
+            <h4 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+              Party Summary
+            </h4>
+            <div class="grid grid-cols-3 gap-2 text-center text-xs">
+              <div class="rounded-md bg-card px-2 py-2">
+                <p class="text-muted-foreground">Party Score</p>
+                <p class="font-mono text-sm font-semibold text-primary">
+                  {{ partyScore.toLocaleString() }}
+                </p>
+              </div>
+              <div class="rounded-md bg-card px-2 py-2">
+                <p class="text-muted-foreground">Base Rating</p>
+                <p class="font-mono text-sm font-semibold">
+                  {{ currentTierConfig.baseRating.toLocaleString() }}
+                </p>
+              </div>
+              <div class="rounded-md bg-card px-2 py-2">
+                <p class="text-muted-foreground">Score Ratio</p>
+                <p
+                  class="font-mono text-sm font-semibold"
+                  :class="
+                    scoreRatio && scoreRatio >= 1
+                      ? 'text-emerald-700 dark:text-emerald-400'
+                      : 'text-amber-700 dark:text-amber-400'
+                  "
+                >
+                  {{ scoreRatio ? scoreRatio.toFixed(2) : '—' }}
+                </p>
+              </div>
+            </div>
+
+            <!-- Grade Badge -->
+            <div v-if="currentGrade" class="flex flex-col items-center gap-1 py-2">
+              <span
+                class="rounded-lg border px-4 py-2 text-2xl font-black"
+                :class="[gradeClasses?.text, gradeClasses?.bg, gradeClasses?.border]"
+              >
+                {{ currentGrade.grade }}
+              </span>
+              <span class="text-xs font-semibold text-muted-foreground">
+                {{ currentGrade.multiplier }}x rewards
+              </span>
+            </div>
+
+            <!-- Score Progress Bar -->
+            <div class="space-y-1">
+              <div class="relative h-3 overflow-hidden rounded-full bg-muted/60">
+                <div
+                  class="absolute inset-y-0 left-0 rounded-full transition-all duration-500"
+                  :class="gradeClasses?.bg ?? 'bg-primary'"
+                  :style="{
+                    width: `${Math.min(100, (partyScore / (currentTierConfig.baseRating * 2)) * 100)}%`,
+                  }"
+                />
+                <!-- Grade threshold markers -->
+                <div
+                  v-for="grade in config.grades.filter((g) => g.minRatio > 0)"
+                  :key="grade.grade"
+                  class="absolute inset-y-0 w-px bg-foreground/30"
+                  :style="{ left: `${(grade.minRatio / 2) * 100}%` }"
+                />
+              </div>
+              <div class="relative h-4">
+                <span
+                  v-for="grade in config.grades.filter((g) => g.minRatio > 0)"
+                  :key="grade.grade"
+                  class="absolute -translate-x-1/2 text-[9px] font-bold"
+                  :class="GRADE_COLORS[grade.grade].text"
+                  :style="{ left: `${(grade.minRatio / 2) * 100}%` }"
+                >
+                  {{ grade.grade }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- RIGHT: Creature Selector -->
+      <section
+        class="surface-card flex flex-col overflow-hidden"
+        :class="!isDesktop && mobileSection !== 'creature' ? 'hidden' : ''"
+      >
+        <!-- Header with Focus stats -->
+        <div class="flex items-center gap-3 border-b border-border/70 px-4 py-3">
+          <h2 class="text-base font-bold">Select Creature</h2>
+          <div v-if="weightedStats.length" class="flex items-center gap-1.5">
+            <Swords class="size-3.5 text-accent" />
+            <span
+              v-for="[key] in weightedStats"
+              :key="key"
+              class="bg-accent/12 rounded-md border border-accent/35 px-2 py-0.5 text-xs font-semibold text-accent"
+            >
+              {{ statAbbreviations[key] }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Filters -->
+        <div class="space-y-3 border-b border-border/70 px-4 py-3">
+          <input
+            v-model="creatureSearch"
+            type="text"
+            placeholder="Search creature"
+            class="focus-ring w-full rounded-lg border border-input bg-background/70 px-3 py-2 text-sm"
+          />
+
+          <div class="flex flex-wrap gap-2">
+            <button
+              class="pill focus-ring gap-1.5"
+              :class="ownedOnly ? 'pill-active' : ''"
+              @click="ownedOnly = !ownedOnly"
+            >
+              <img :src="summonedIcon" alt="" class="size-4" loading="lazy" />
+              Summoned Only
+            </button>
+            <button
+              class="pill focus-ring gap-1.5"
+              :class="showExcludedCreatures ? 'pill-active' : ''"
+              @click="showExcludedCreatures = !showExcludedCreatures"
+            >
+              Show Excluded
+            </button>
+
+            <div
+              class="ml-auto rounded-full border border-border bg-muted/40 px-3 py-1 text-xs font-semibold text-muted-foreground"
+              aria-live="polite"
+            >
+              {{ displayRecommended.length }} creatures
+            </div>
+          </div>
+
+          <!-- More filters toggle -->
+          <div>
+            <button
+              class="focus-ring inline-flex items-center gap-1.5 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+              :aria-expanded="showMoreCreatureFilters || hasSecondaryCreatureFilters"
+              @click="showMoreCreatureFilters = !showMoreCreatureFilters"
+            >
+              <ChevronDown
+                class="size-3.5 transition-transform"
+                :class="showMoreCreatureFilters || hasSecondaryCreatureFilters ? '' : '-rotate-90'"
+              />
+              More filters
+            </button>
+
+            <div
+              class="mt-3 space-y-3"
+              :class="showMoreCreatureFilters || hasSecondaryCreatureFilters ? 'block' : 'hidden'"
+            >
+              <!-- Type filter -->
+              <div class="flex flex-wrap items-center gap-2">
+                <span
+                  class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground"
+                  >Type</span
+                >
+                <button
+                  v-for="type in creatureTypes"
+                  :key="type"
+                  class="pill focus-ring"
+                  :class="selectedCreatureType === type ? 'pill-active' : ''"
+                  @click="toggleCreatureType(type)"
+                >
+                  <span
+                    class="mr-1.5 inline-block size-2 rounded-full"
+                    :class="selectedCreatureType === type ? 'ring-1 ring-white/60' : ''"
+                    :style="{ backgroundColor: typeColor(type) }"
+                  />
+                  {{ type }}
+                </button>
+              </div>
+
+              <!-- Tier filter -->
+              <div class="flex flex-wrap items-center gap-2">
+                <span
+                  class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground"
+                  >Tier</span
+                >
+                <button
+                  v-for="tier in creatureTierOptions"
+                  :key="tier"
+                  class="pill focus-ring font-mono"
+                  :class="
+                    !allCreatureTiersSelected && selectedCreatureTiers.includes(tier)
+                      ? 'pill-active'
+                      : ''
+                  "
+                  @click="toggleCreatureTier(tier)"
+                >
+                  T{{ tier + 1 }}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <ActiveFilters
+            :filters="activeCreatureFilters"
+            @remove="removeCreatureFilter"
+            @clear-all="clearCreatureFilters"
+          />
+
+          <div class="flex items-start gap-2 rounded-lg bg-muted/30 px-3 py-2">
+            <Info class="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+            <p class="text-[11px] text-muted-foreground">
+              Level changes here are per-dungeon only and do not update your collection.
+            </p>
+          </div>
+        </div>
+
+        <!-- Creature List -->
+        <div class="max-h-[58vh] space-y-2 overflow-y-auto p-3 lg:max-h-none lg:min-h-0 lg:flex-1">
+          <button
+            v-for="{ creature, score, level, suggestedLevel } in displayRecommended"
+            :key="creature.id"
+            class="focus-ring block w-full rounded-xl border px-3 py-3 text-left transition"
+            :class="
+              hasEmptySlot
+                ? 'border-border bg-card/50 hover:border-accent/45 hover:bg-muted/25'
+                : 'cursor-not-allowed border-border/50 bg-card/30 opacity-60'
+            "
+            @click="chooseCreature(creature)"
+          >
+            <div class="flex items-start gap-3">
+              <div class="relative shrink-0">
+                <img
+                  :src="getCreatureImage(creature)"
+                  :alt="`${creature.name} artwork`"
+                  class="size-10 rounded-md border border-border object-cover"
+                  loading="lazy"
+                />
+                <img
+                  v-if="sanctuaryCreatureIds.includes(creature.id)"
+                  :src="sanctuaryIcon"
+                  alt="Sanctuary"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+                <img
+                  v-else-if="helperCreatureIds.includes(creature.id)"
+                  :src="helpersIcon"
+                  alt="Helper"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+                <img
+                  v-else-if="machineCreatureIds.includes(creature.id)"
+                  :src="machinesIcon"
+                  alt="Machine"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+              </div>
+
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-1">
+                  <p
+                    class="truncate font-semibold"
+                    :class="
+                      isAwakened(creature.id)
+                        ? 'text-pink-600 dark:text-pink-400'
+                        : 'text-foreground'
+                    "
+                  >
+                    {{ creature.name }}
+                  </p>
+                  <span
+                    v-if="isOwned(creature.id)"
+                    class="text-xs"
+                    :class="
+                      isAwakened(creature.id)
+                        ? 'text-pink-600 dark:text-pink-400'
+                        : 'text-amber-700 dark:text-amber-400'
+                    "
+                    >★</span
+                  >
+                </div>
+                <div class="mt-1 flex flex-wrap gap-1 text-xs">
+                  <span
+                    v-for="type in creature.types"
+                    :key="type"
+                    class="rounded-full bg-muted px-2 py-0.5 font-semibold"
+                    :style="{ color: typeColor(type) }"
+                  >
+                    {{ type }}
+                  </span>
+                  <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
+                </div>
+              </div>
+
+              <div class="text-right" @click.stop>
+                <p
+                  class="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+                >
+                  Lvl
+                  <span
+                    v-if="suggestedLevel != null"
+                    class="ml-1 normal-case tracking-normal"
+                    :class="
+                      level >= suggestedLevel
+                        ? 'text-emerald-700 dark:text-emerald-400'
+                        : 'text-amber-700 dark:text-amber-400'
+                    "
+                  >
+                    (Suggested: {{ suggestedLevel }})
+                  </span>
+                </p>
+                <div
+                  class="inline-flex items-center overflow-hidden rounded-md border border-input bg-background/85"
+                >
+                  <button
+                    class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="level <= 1"
+                    aria-label="Decrease creature level"
+                    @click.stop="stepCreatureLevel(creature.id, level, -1)"
+                  >
+                    <Minus class="size-3" />
+                  </button>
+                  <input
+                    type="text"
+                    inputmode="numeric"
+                    pattern="[0-9]*"
+                    class="focus-ring h-7 w-11 border-x border-input bg-transparent text-center font-mono text-xs"
+                    :value="level"
+                    aria-label="Creature level"
+                    @blur="normalizeLevelOnBlur(creature.id, level, $event)"
+                  />
+                  <button
+                    class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="level >= 120"
+                    aria-label="Increase creature level"
+                    @click.stop="stepCreatureLevel(creature.id, level, 1)"
+                  >
+                    <Plus class="size-3" />
+                  </button>
+                </div>
+                <p class="mt-1 font-mono text-sm font-semibold text-primary">{{ score }}</p>
+              </div>
+            </div>
+
+            <div v-if="weightedStats.length" class="mt-3 space-y-1.5">
+              <div
+                v-for="[key, weight] in weightedStats"
+                :key="key"
+                class="grid grid-cols-[28px_minmax(0,1fr)] items-center gap-2"
+              >
+                <span class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">{{
+                  statAbbreviations[key]
+                }}</span>
+                <div class="h-1.5 rounded-full bg-muted">
+                  <div
+                    class="h-full rounded-full bg-primary"
+                    :style="{ width: `${statBar(creature, key)}%`, opacity: 0.45 + weight * 0.55 }"
+                  />
+                </div>
+              </div>
+            </div>
+          </button>
+
+          <div
+            v-if="displayRecommended.length === 0"
+            class="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-7 text-center text-sm text-muted-foreground"
+          >
+            No creatures match your filters.
+          </div>
+        </div>
+      </section>
+    </div>
+  </section>
+</template>


### PR DESCRIPTION
## Description

Add a Dungeons page with data, rewards tables, and a party planner for the v5.1 dungeon system. Dungeons use a fixed 15-minute duration, grade-based scoring (S/A/B/C/F), and two focus modes (Combat and Gathering with 6 sub-focuses), differentiating them from the existing expedition system.

Closes ardelato/k2-wiki#83

## Summary

- Add `dungeons.json` config data sourced from game extraction with tier configs, grade thresholds, stat weights, and rewards for all combat and gathering sub-focuses
- Add dungeon type definitions (`DungeonConfig`, `DungeonTier`, `DungeonGrade`, `DungeonFocus`, `GatheringSubFocus`)
- Add dungeon scoring formulas (`calculateDungeonCreatureScore`, `calculateDungeonPartyScore`, `getRecommendedDungeonCreatures`) using weighted stats without biome/trait bonuses
- Add grading and reward formulas (`getDungeonGrade`, `getDungeonScaledRewards`) with S/A/B/C/F grade thresholds and reward multiplier scaling
- Add `useDungeons` composable with tier/focus/sub-focus selection, party management, grade prediction, and collection-level-aware creature levels
- Add `DungeonsView.vue` with 3-column responsive layout: config panel (tier/focus selectors, stat weights, reference tables), detail panel (party slots, grade badge, score progress bar, rewards), and creature selector (filters, level inputs, suggested levels)
- Add `/dungeons` route and sidebar nav link with Swords icon, ordered before Expeditions
- Add 61 tests covering scoring formulas, grading/reward logic, and `dungeons.json` data integrity