### PR TITLE
Add skill levels and player level to Configs

### DIFF
--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -7,6 +7,7 @@ import {
   defaultGardenFlowers,
 } from '@/data/defaults'
 import type { GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
+import { getPlayerLevel } from '@/utils/formulas'
 import { calculateJobTiersFromSanctuary } from '@/utils/parseSave'
 
 const sanctuaryCreatureIds = useLocalStorage<string[]>('config-sanctuary-creatures', [])
@@ -40,8 +41,10 @@ const fabricationAllocations = useLocalStorage<Record<string, number>>(
   {},
 )
 const awakenGoldLevel = useLocalStorage<number>('config-awaken-gold-level', 0)
+const skillLevels = useLocalStorage<Record<string, number>>('config-skill-levels', {})
 
 export function useGameConfig() {
+  const playerLevel = computed(() => getPlayerLevel(skillLevels.value))
   const excludedCreatureIds = computed(() => {
     const set = new Set<string>()
     for (const id of sanctuaryCreatureIds.value) set.add(id)
@@ -162,6 +165,14 @@ export function useGameConfig() {
     awakenGoldLevel.value = Math.max(0, Math.min(5, level))
   }
 
+  function setSkillLevels(levels: Record<string, number>) {
+    skillLevels.value = levels
+  }
+
+  function resetSkillLevels() {
+    skillLevels.value = {}
+  }
+
   function resetGameConfig() {
     sanctuaryCreatureIds.value = []
     helperCreatureIds.value = []
@@ -175,6 +186,7 @@ export function useGameConfig() {
     resetMachines()
     resetFabrication()
     awakenGoldLevel.value = 0
+    resetSkillLevels()
   }
 
   return {
@@ -218,5 +230,9 @@ export function useGameConfig() {
     expeditionToolXpBonus,
     awakenGoldLevel,
     setAwakenGoldLevel,
+    skillLevels,
+    playerLevel,
+    setSkillLevels,
+    resetSkillLevels,
   }
 }

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -14,9 +14,13 @@ import {
   getDungeonGrade,
   getDungeonScaledRewards,
   getLoopXpBonus,
+  getPlayerLevel,
+  getPlayerLevelXpBonus,
   getRecommendedCreatures,
   getRecommendedDungeonCreatures,
+  getSkillLevel,
   levelFromXp,
+  SKILLING_IDS,
   traitAbbreviations,
   xpForLevel,
 } from '@/utils/formulas'
@@ -994,5 +998,74 @@ describe('dungeons.json data integrity', () => {
 
   test('requires armor-set', () => {
     expect(dungeonConfig.requiresItem).toBe('armor-set')
+  })
+})
+
+// ── Skilling / Player Level ───────────────────────────────────────────
+
+describe('getSkillLevel', () => {
+  test('returns 1 for 0 XP', () => {
+    expect(getSkillLevel(0)).toBe(1)
+  })
+
+  test('returns 1 for negative XP', () => {
+    expect(getSkillLevel(-100)).toBe(1)
+  })
+
+  test('returns 2 at first threshold (83 XP)', () => {
+    expect(getSkillLevel(83)).toBe(2)
+    expect(getSkillLevel(82)).toBe(1)
+  })
+
+  test('returns known levels from XP table comments', () => {
+    expect(getSkillLevel(388)).toBe(5)
+    expect(getSkillLevel(1154)).toBe(10)
+    expect(getSkillLevel(4470)).toBe(20)
+    expect(getSkillLevel(101333)).toBe(50)
+    expect(getSkillLevel(737627)).toBe(70)
+    expect(getSkillLevel(13034431)).toBe(99)
+  })
+
+  test('caps at 99', () => {
+    expect(getSkillLevel(999_999_999)).toBe(99)
+  })
+})
+
+describe('getPlayerLevel', () => {
+  test('returns 1 when all skills are missing (default to 1)', () => {
+    expect(getPlayerLevel({})).toBe(1)
+  })
+
+  test('returns floor of average', () => {
+    const levels: Record<string, number> = {}
+    for (const id of SKILLING_IDS) levels[id] = 10
+    expect(getPlayerLevel(levels)).toBe(10)
+  })
+
+  test('floors the average', () => {
+    const levels: Record<string, number> = {}
+    for (const id of SKILLING_IDS) levels[id] = 10
+    levels['Chopping'] = 11
+    expect(getPlayerLevel(levels)).toBe(10)
+  })
+
+  test('missing skills default to 1', () => {
+    expect(getPlayerLevel({ Chopping: 99 })).toBe(11)
+  })
+
+  test('caps at 99', () => {
+    const levels: Record<string, number> = {}
+    for (const id of SKILLING_IDS) levels[id] = 99
+    expect(getPlayerLevel(levels)).toBe(99)
+  })
+})
+
+describe('getPlayerLevelXpBonus', () => {
+  test('level 1 gives 0.50', () => {
+    expect(getPlayerLevelXpBonus(1)).toBeCloseTo(0.5)
+  })
+
+  test('level 99 gives 25.00', () => {
+    expect(getPlayerLevelXpBonus(99)).toBeCloseTo(25.0)
   })
 })

--- a/src/utils/__tests__/parseSave.test.ts
+++ b/src/utils/__tests__/parseSave.test.ts
@@ -148,3 +148,48 @@ describe('parseSave — fabricationAllocations', () => {
     expect(config.fabricationAllocations).toEqual({})
   })
 })
+
+describe('parseSave — skillLevels', () => {
+  test('parses skill XP into levels', () => {
+    const save = baseSave()
+    save.skills = [
+      { id: 'Chopping', xp: 388 }, // level 5
+      { id: 'Mining', xp: 1154 }, // level 10
+    ]
+
+    const config = extractSaveConfig(save)
+    expect(config.skillLevels).toEqual({ Chopping: 5, Mining: 10 })
+  })
+
+  test('includes level 1 skills (0 XP)', () => {
+    const save = baseSave()
+    save.skills = [{ id: 'Chopping', xp: 0 }]
+
+    const config = extractSaveConfig(save)
+    expect(config.skillLevels).toEqual({ Chopping: 1 })
+  })
+
+  test('returns empty object when skills is missing', () => {
+    const save = baseSave()
+    delete save.skills
+
+    const config = extractSaveConfig(save)
+    expect(config.skillLevels).toEqual({})
+  })
+
+  test('returns empty object when skills is not an array', () => {
+    const save = baseSave()
+    save.skills = 'invalid'
+
+    const config = extractSaveConfig(save)
+    expect(config.skillLevels).toEqual({})
+  })
+
+  test('skips entries with missing id or xp', () => {
+    const save = baseSave()
+    save.skills = [{ id: 'Chopping', xp: 388 }, { xp: 500 }, { id: 'Mining' }, {}]
+
+    const config = extractSaveConfig(save)
+    expect(config.skillLevels).toEqual({ Chopping: 5 })
+  })
+})

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -428,3 +428,55 @@ export function getRecommendedDungeonCreatures(
     })
     .toSorted((a, b) => b.score - a.score)
 }
+
+// ── Skilling / Player Level ───────────────────────────────────────────
+
+// XP thresholds from game source (modules/skilling/helpers.ts)
+// Index 0 = XP needed for level 2, index 1 = level 3, etc.
+const skillingXpTable = [
+  83, 174, 276, 388, 512, 650, 801, 969, 1154, 1358, 1584, 1833, 2107, 2411, 2746, 3115, 3523, 3973,
+  4470, 5018, 5624, 6291, 7028, 7842, 8740, 9730, 10824, 12031, 13363, 14833, 16456, 18247, 20224,
+  22406, 24815, 27473, 30408, 33648, 37224, 41171, 45529, 50339, 55649, 61512, 67983, 75127, 83014,
+  91721, 101333, 111945, 123660, 136594, 150872, 166636, 184040, 203254, 224466, 247886, 273742,
+  302288, 333804, 368599, 407015, 449428, 496254, 547953, 605032, 668051, 737627, 814445, 899257,
+  992895, 1096278, 1210421, 1336443, 1475581, 1629200, 1798808, 1986068, 2192818, 2421087, 2673114,
+  2951373, 3258594, 3597792, 3972294, 4385776, 4842295, 5346332, 5902831, 6517253, 7195629, 7944614,
+  8771558, 9684577, 10692629, 11805606, 13034431,
+]
+
+/** Convert cumulative XP to skill level (1–99). */
+export function getSkillLevel(xp: number): number {
+  if (xp < 0) return 1
+  let level = 1
+  while (level <= 99 && xp >= skillingXpTable[level - 1]) {
+    level++
+  }
+  return Math.min(level, 99)
+}
+
+/** All 9 skill IDs that contribute to player level (6 gathering + 3 workstation). */
+export const SKILLING_IDS = [
+  'Chopping',
+  'Mining',
+  'Digging',
+  'Exploring',
+  'Fishing',
+  'Farming',
+  'Furnace',
+  'Stove',
+  'Workbench',
+] as const
+
+/**
+ * Player level = floor(average of all 9 skill levels), capped at 99.
+ * Accepts a map of skill ID → level (1–99). Missing skills default to 1.
+ */
+export function getPlayerLevel(skillLevels: Record<string, number>): number {
+  const totalLevels = SKILLING_IDS.reduce((sum, id) => sum + (skillLevels[id] || 1), 0)
+  return Math.min(Math.floor(totalLevels / SKILLING_IDS.length), 99)
+}
+
+/** XP bonus percentage granted by player level: playerLevel × 0.25 + 0.25 */
+export function getPlayerLevelXpBonus(playerLevel: number): number {
+  return playerLevel * 0.25 + 0.25
+}

--- a/src/utils/parseSave.ts
+++ b/src/utils/parseSave.ts
@@ -2,7 +2,7 @@ import creaturesData from '@/data/creatures.json'
 import { defaultAwakenGatherUpgrades, defaultAwakenSpeedTiers } from '@/data/defaults'
 import type { GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
 
-import { levelFromXp } from './formulas'
+import { levelFromXp, getSkillLevel } from './formulas'
 
 interface SaveInventoryItem {
   id: string
@@ -53,6 +53,7 @@ export interface SaveConfig {
   machineRecipes: Record<string, string | null>
   fabricationAllocations: Record<string, number>
   awakenGoldLevel: number
+  skillLevels: Record<string, number>
   currentExpedition: ExpeditionData
 }
 
@@ -99,6 +100,7 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
   const expeditionCompletions = parseExpeditionCompletions(save)
   const { machineLevels, machineRecipes } = parseMachineDetails(save)
   const fabricationAllocations = parseFabricationAllocations(save)
+  const skillLevels = parseSkillLevels(save)
 
   const currentExpedition = buildExpeditionData(save, creatures)
 
@@ -120,6 +122,7 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
     machineRecipes,
     fabricationAllocations,
     awakenGoldLevel,
+    skillLevels,
     currentExpedition,
   }
 }
@@ -381,6 +384,18 @@ function parseFabricationAllocations(save: Record<string, unknown>): Record<stri
   for (const [itemId, amount] of Object.entries(fabrication.allocations)) {
     if (typeof amount === 'number' && amount > 0) {
       result[itemId] = amount
+    }
+  }
+  return result
+}
+
+function parseSkillLevels(save: Record<string, unknown>): Record<string, number> {
+  const skills = save.skills
+  if (!Array.isArray(skills)) return {}
+  const result: Record<string, number> = {}
+  for (const skill of skills as Array<{ id?: string; xp?: number }>) {
+    if (typeof skill.id === 'string' && typeof skill.xp === 'number') {
+      result[skill.id] = getSkillLevel(skill.xp)
     }
   }
   return result

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -27,7 +27,7 @@ import {
   TIER_UNLOCK_REQUIREMENTS,
 } from '@/utils/expeditionUnlocks'
 import { toTitleCase } from '@/utils/format'
-import { levelFromXp } from '@/utils/formulas'
+import { levelFromXp, getPlayerLevel, getPlayerLevelXpBonus, SKILLING_IDS } from '@/utils/formulas'
 import {
   sourceIcons,
   sanctuaryIcon,
@@ -35,6 +35,7 @@ import {
   machinesIcon,
   upgradesIcon,
   toolIcons,
+  jobIcons,
   expeditionTierIcons,
 } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
@@ -78,6 +79,10 @@ const {
   resetFabrication,
   awakenGoldLevel,
   setAwakenGoldLevel,
+  skillLevels,
+  playerLevel,
+  setSkillLevels,
+  resetSkillLevels,
 } = useGameConfig()
 
 
@@ -398,6 +403,49 @@ const machineLevelsHasDiff = computed(() => {
 })
 
 
+const skillLevelsHasDiff = computed(() => {
+  if (!saveConfig.value) return false
+  return JSON.stringify(skillLevels.value) !== JSON.stringify(saveConfig.value.skillLevels)
+})
+
+
+function displaySkillLevel(skillId: string): number {
+  if (saveConfig.value?.skillLevels) {
+    return saveConfig.value.skillLevels[skillId] || 1
+  }
+  return skillLevels.value[skillId] || 1
+}
+
+
+const displayPlayerLevel = computed(() => {
+  if (saveConfig.value?.skillLevels) {
+    return getPlayerLevel(saveConfig.value.skillLevels)
+  }
+  return playerLevel.value
+})
+
+
+const WORKSTATION_IDS = new Set(['Furnace', 'Stove', 'Workbench'])
+
+
+const skillGroups = [
+  {
+    label: 'Gathering',
+    skills: SKILLING_IDS.filter((id) => !WORKSTATION_IDS.has(id)).map((id) => ({
+      id,
+      icon: jobIcons[id.toLowerCase()],
+    })),
+  },
+  {
+    label: 'Workstation',
+    skills: SKILLING_IDS.filter((id) => WORKSTATION_IDS.has(id)).map((id) => ({
+      id,
+      icon: sourceIcons[`crafting_${id.toLowerCase()}`],
+    })),
+  },
+]
+
+
 const fabricationHasDiff = computed(() => {
   if (!saveConfig.value) return false
   return (
@@ -591,6 +639,7 @@ watch(saveConfig, () => {
     if (!jobTiersHasDiff.value) sectionsCollapsed.value.jobTiers = true
     if (!expeditionCompletionsHasDiff.value) sectionsCollapsed.value.expeditions = true
     if (!toolLevelsHasDiff.value) sectionsCollapsed.value.tools = true
+    if (!skillLevelsHasDiff.value) sectionsCollapsed.value.skills = true
     if (!machineLevelsHasDiff.value) sectionsCollapsed.value.machineDetails = true
     if (!fabricationHasDiff.value) sectionsCollapsed.value.fabrication = true
   })
@@ -656,6 +705,14 @@ function applyTools() {
 }
 
 
+function applySkillLevels() {
+  if (!saveConfig.value) return
+  setSkillLevels({ ...saveConfig.value.skillLevels })
+  appliedSections.value = { ...appliedSections.value, skills: true }
+  sectionsCollapsed.value = { ...sectionsCollapsed.value, skills: true }
+}
+
+
 function applyMachineDetails() {
   if (!saveConfig.value) return
   setMachineLevels({ ...saveConfig.value.machineLevels })
@@ -706,6 +763,7 @@ function applyAll() {
   applyGarden()
   applyAwaken()
   applyTools()
+  applySkillLevels()
   applyMachineDetails()
   applyFabrication()
   applyExpeditionCompletions()
@@ -829,6 +887,7 @@ function resetAll() {
   resetMachines()
   resetFabrication()
   resetExpeditions()
+  resetSkillLevels()
   resetCollection()
 }
 
@@ -2461,6 +2520,122 @@ function jobTierLabel(tier: number): string {
             class="py-2 text-center text-xs text-muted-foreground"
           >
             No tool data available
+          </div>
+        </div>
+      </div>
+
+      <!-- Skill Levels & Player Level -->
+      <div class="rounded-xl border border-border bg-card/50 p-4">
+        <div class="flex items-center justify-between">
+          <button class="flex items-center gap-2" @click="toggleSection('skills')">
+            <component
+              :is="sectionsCollapsed.skills ? ChevronDown : ChevronUp"
+              class="size-4 text-muted-foreground"
+            />
+            <h3 class="text-sm font-bold">Skill Levels</h3>
+          </button>
+          <div class="flex items-center gap-2">
+            <span class="rounded-md bg-muted/50 px-2 py-1 text-xs font-medium">
+              Player Lvl {{ displayPlayerLevel }}
+            </span>
+            <span
+              class="rounded-md bg-emerald-500/15 px-2 py-1 text-xs font-medium text-emerald-400"
+            >
+              +{{ getPlayerLevelXpBonus(displayPlayerLevel).toFixed(2) }}% XP
+            </span>
+            <button
+              class="focus-ring rounded-lg border border-border px-2 py-1.5 text-muted-foreground transition hover:text-foreground"
+              title="Reset Skill Levels"
+              @click="resetSkillLevels"
+            >
+              <RotateCcw class="size-3.5" />
+            </button>
+            <template v-if="saveConfig">
+              <button
+                v-if="!appliedSections.skills && skillLevelsHasDiff"
+                class="focus-ring rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90"
+                @click="applySkillLevels"
+              >
+                Apply
+              </button>
+              <span
+                v-else-if="!appliedSections.skills && !skillLevelsHasDiff"
+                class="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-400"
+              >
+                <Check class="size-3.5" /> Matches Save
+              </span>
+              <span
+                v-else-if="appliedSections.skills"
+                class="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-400"
+              >
+                <Check class="size-3.5" /> Applied
+              </span>
+            </template>
+          </div>
+        </div>
+
+        <div v-if="!sectionsCollapsed.skills" class="mt-3 space-y-3">
+          <div v-for="group in skillGroups" :key="group.label" class="space-y-1">
+            <h4 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {{ group.label }}
+            </h4>
+            <div
+              v-for="skill in group.skills"
+              :key="skill.id"
+              class="flex items-center justify-between rounded-lg px-2 py-1.5 text-sm"
+            >
+              <span class="flex items-center gap-2 font-medium">
+                <img v-if="skill.icon" :src="skill.icon" alt="" class="size-5" loading="lazy" />
+                {{ skill.id }}
+              </span>
+              <div class="flex items-center gap-2">
+                <span class="text-xs tabular-nums text-muted-foreground"> Level </span>
+                <div
+                  class="inline-flex items-center overflow-hidden rounded-md border border-input bg-background/85"
+                >
+                  <button
+                    class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="displaySkillLevel(skill.id) <= 1"
+                    @click="
+                      setSkillLevels({
+                        ...skillLevels,
+                        [skill.id]: Math.max(1, displaySkillLevel(skill.id) - 1),
+                      })
+                    "
+                  >
+                    <Minus class="size-3" />
+                  </button>
+                  <input
+                    type="text"
+                    inputmode="numeric"
+                    pattern="[0-9]*"
+                    class="focus-ring h-7 w-11 border-x border-input bg-transparent text-center font-mono text-xs"
+                    :value="displaySkillLevel(skill.id)"
+                    @blur="
+                      (e) => {
+                        const v = Math.max(
+                          1,
+                          Math.min(99, parseInt((e.target as HTMLInputElement).value) || 1),
+                        )
+                        setSkillLevels({ ...skillLevels, [skill.id]: v })
+                      }
+                    "
+                  />
+                  <button
+                    class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                    :disabled="displaySkillLevel(skill.id) >= 99"
+                    @click="
+                      setSkillLevels({
+                        ...skillLevels,
+                        [skill.id]: Math.min(99, displaySkillLevel(skill.id) + 1),
+                      })
+                    "
+                  >
+                    <Plus class="size-3" />
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

The wiki had no concept of player level or individual skill levels. This adds skill level tracking (6 gathering + 3 workstation skills) to the game config, with player level derived as the floored average of all 9 skill levels — matching the game's formula. Skill levels can be imported from a save file or set manually in the Configs page.

Connects to #86

## Summary

- Add `getSkillLevel`, `getPlayerLevel`, `getPlayerLevelXpBonus`, and `SKILLING_IDS` to `formulas.ts`, porting the skilling XP table from the game source
- Extract skill levels from save files in `parseSave.ts` by converting each skill's cumulative XP to a level
- Add `skillLevels` (localStorage-backed) and derived `playerLevel` computed to `useGameConfig`, with setter and reset functions
- Add collapsible "Skill Levels" section to ConfigsView with per-skill inputs grouped by gathering/workstation, player level badge, XP bonus display, save diff preview, apply, and reset
- Add tests for `getSkillLevel`, `getPlayerLevel`, `getPlayerLevelXpBonus`, and `parseSkillLevels`