### PR TITLE
Add tooltips to all sidebar items

### DIFF
--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -20,6 +20,7 @@ import { computed } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 
 import SteamIcon from '@/components/icons/SteamIcon.vue'
+import AppTooltip from '@/components/shared/AppTooltip.vue'
 import { useTheme } from '@/composables/useTheme'
 import meta from '@/data/meta.json'
 
@@ -45,6 +46,13 @@ function isActive(path: string) {
   if (path === '/') return activePath.value === '/'
   return activePath.value.startsWith(path)
 }
+
+
+const themeLabel = computed(() => {
+  if (preference.value === 'system') return 'Theme: System'
+  if (preference.value === 'light') return 'Theme: Light'
+  return 'Theme: Dark'
+})
 
 
 const navGroups = [
@@ -136,23 +144,28 @@ const navGroups = [
         </h3>
         <div v-else class="mb-1 border-t border-border/40" />
         <div class="space-y-0.5">
-          <RouterLink
+          <AppTooltip
             v-for="item in group.items"
             :key="item.to"
-            :to="item.to"
-            :title="props.collapsed ? item.label : undefined"
-            class="focus-ring flex items-center rounded-lg text-sm font-medium transition"
-            :class="[
-              props.collapsed ? 'justify-center px-2 py-2' : 'gap-2.5 px-2.5 py-2',
-              isActive(item.to)
-                ? 'bg-primary text-primary-foreground shadow-glow'
-                : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground',
-            ]"
-            @click="emit('navigate')"
+            :text="item.label"
+            position="right"
+            :disabled="!props.collapsed"
           >
-            <component :is="item.icon" class="size-4 shrink-0" />
-            <span v-if="!props.collapsed">{{ item.label }}</span>
-          </RouterLink>
+            <RouterLink
+              :to="item.to"
+              class="focus-ring flex items-center rounded-lg text-sm font-medium transition"
+              :class="[
+                props.collapsed ? 'justify-center px-2 py-2' : 'gap-2.5 px-2.5 py-2',
+                isActive(item.to)
+                  ? 'bg-primary text-primary-foreground shadow-glow'
+                  : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground',
+              ]"
+              @click="emit('navigate')"
+            >
+              <component :is="item.icon" class="size-4 shrink-0" />
+              <span v-if="!props.collapsed">{{ item.label }}</span>
+            </RouterLink>
+          </AppTooltip>
         </div>
       </div>
     </nav>
@@ -164,45 +177,56 @@ const navGroups = [
         :class="props.collapsed ? 'flex-col gap-0.5' : 'justify-between'"
       >
         <div class="flex items-center" :class="props.collapsed ? 'flex-col gap-0.5' : 'gap-0.5'">
-          <a
-            href="https://github.com/ardelato/k2-wiki"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="GitHub repository"
-            class="focus-ring rounded-lg p-2 text-muted-foreground transition hover:text-foreground"
-          >
-            <Github class="size-4" />
-          </a>
-          <a
-            href="https://store.steampowered.com/app/2834700/Koltera_2/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Koltera 2 on Steam"
-            class="focus-ring rounded-lg p-2 text-muted-foreground transition hover:text-foreground"
-          >
-            <SteamIcon class="size-4" />
-          </a>
+          <AppTooltip text="GitHub" :position="props.collapsed ? 'right' : 'top'">
+            <a
+              href="https://github.com/ardelato/k2-wiki"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub repository"
+              class="focus-ring rounded-lg p-2 text-muted-foreground transition hover:text-foreground"
+            >
+              <Github class="size-4" />
+            </a>
+          </AppTooltip>
+          <AppTooltip text="Steam" :position="props.collapsed ? 'right' : 'top'">
+            <a
+              href="https://store.steampowered.com/app/2834700/Koltera_2/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Koltera 2 on Steam"
+              class="focus-ring rounded-lg p-2 text-muted-foreground transition hover:text-foreground"
+            >
+              <SteamIcon class="size-4" />
+            </a>
+          </AppTooltip>
         </div>
-        <button
-          aria-label="Toggle theme"
-          class="focus-ring rounded-lg p-2 text-muted-foreground transition hover:text-foreground"
-          @click="cycle"
-        >
-          <SunMoon v-if="preference === 'system'" class="size-4" />
-          <Sun v-else-if="preference === 'light'" class="size-4" />
-          <Moon v-else class="size-4" />
-        </button>
+        <AppTooltip :text="themeLabel" :position="props.collapsed ? 'right' : 'top'">
+          <button
+            aria-label="Toggle theme"
+            class="focus-ring rounded-lg p-2 text-muted-foreground transition hover:text-foreground"
+            @click="cycle"
+          >
+            <SunMoon v-if="preference === 'system'" class="size-4" />
+            <Sun v-else-if="preference === 'light'" class="size-4" />
+            <Moon v-else class="size-4" />
+          </button>
+        </AppTooltip>
       </div>
 
       <!-- Collapse toggle -->
-      <button
-        aria-label="Toggle sidebar"
-        class="focus-ring mt-1 flex w-full items-center justify-center rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/80 hover:text-foreground"
-        @click="emit('toggle-collapse')"
+      <AppTooltip
+        :text="props.collapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+        :position="props.collapsed ? 'right' : 'top'"
       >
-        <ChevronsLeft v-if="!props.collapsed" class="size-4" />
-        <ChevronsRight v-else class="size-4" />
-      </button>
+        <button
+          aria-label="Toggle sidebar"
+          class="focus-ring mt-1 flex w-full items-center justify-center rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/80 hover:text-foreground"
+          @click="emit('toggle-collapse')"
+        >
+          <ChevronsLeft v-if="!props.collapsed" class="size-4" />
+          <ChevronsRight v-else class="size-4" />
+        </button>
+      </AppTooltip>
     </div>
   </div>
 </template>

--- a/src/components/shared/AppTooltip.vue
+++ b/src/components/shared/AppTooltip.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { nextTick, ref, type CSSProperties } from 'vue'
+
+const props = defineProps<{
+  text: string
+  position?: 'top' | 'right' | 'bottom' | 'left'
+  disabled?: boolean
+}>()
+
+
+const visible = ref(false)
+const style = ref<CSSProperties>({})
+const triggerRef = ref<HTMLElement>()
+const tooltipRef = ref<HTMLElement>()
+
+
+const EDGE_PADDING = 6
+
+
+async function show() {
+  if (props.disabled) return
+  const el = triggerRef.value?.firstElementChild as HTMLElement | null
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  const pos = props.position || 'top'
+  const gap = 8
+
+
+  const s: CSSProperties = { position: 'fixed' }
+
+
+  if (pos === 'top') {
+    s.left = `${rect.left + rect.width / 2}px`
+    s.top = `${rect.top - gap}px`
+    s.transform = 'translateX(-50%) translateY(-100%)'
+  } else if (pos === 'right') {
+    s.left = `${rect.right + gap}px`
+    s.top = `${rect.top + rect.height / 2}px`
+    s.transform = 'translateY(-50%)'
+  } else if (pos === 'bottom') {
+    s.left = `${rect.left + rect.width / 2}px`
+    s.top = `${rect.bottom + gap}px`
+    s.transform = 'translateX(-50%)'
+  } else {
+    s.left = `${rect.left - gap}px`
+    s.top = `${rect.top + rect.height / 2}px`
+    s.transform = 'translateX(-100%) translateY(-50%)'
+  }
+
+
+  style.value = s
+  visible.value = true
+
+
+  await nextTick()
+  if (!tooltipRef.value) return
+  const tipRect = tooltipRef.value.getBoundingClientRect()
+  if (tipRect.left < EDGE_PADDING) {
+    style.value = {
+      ...style.value,
+      left: `${parseFloat(s.left as string) + (EDGE_PADDING - tipRect.left)}px`,
+    }
+  } else if (tipRect.right > window.innerWidth - EDGE_PADDING) {
+    style.value = {
+      ...style.value,
+      left: `${parseFloat(s.left as string) - (tipRect.right - window.innerWidth + EDGE_PADDING)}px`,
+    }
+  }
+}
+
+
+function hide() {
+  visible.value = false
+}
+</script>
+
+<template>
+  <div
+    ref="triggerRef"
+    class="contents"
+    @mouseenter="show"
+    @mouseleave="hide"
+    @focusin="show"
+    @focusout="hide"
+  >
+    <slot />
+  </div>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-100"
+      leave-to-class="opacity-0"
+    >
+      <span
+        v-if="visible"
+        ref="tooltipRef"
+        :style="style"
+        class="pointer-events-none z-50 whitespace-nowrap rounded-md border border-border bg-card px-2.5 py-1.5 text-xs font-medium text-card-foreground shadow-lg"
+        role="tooltip"
+      >
+        {{ text }}
+      </span>
+    </Transition>
+  </Teleport>
+</template>


### PR DESCRIPTION
## Description

Adds a reusable AppTooltip component and applies it to every sidebar item so users can identify icon-only buttons on hover. Previously, only nav items had native `title` tooltips when collapsed, and the bottom action buttons (GitHub, Steam, theme toggle, collapse toggle) had no hover text at all.

## Summary
- Add `AppTooltip` shared component using Teleport with fixed positioning, viewport edge clamping, and fade transitions
- Wrap all sidebar nav items with tooltips that only appear when the sidebar is collapsed
- Add tooltips to all four bottom action buttons (GitHub, Steam, theme toggle, collapse toggle) with position adapting to collapsed/expanded state