### PR TITLE
Add sanctuary page with benefit-centric UX

### DIFF
--- a/e2e/sanctuary.spec.ts
+++ b/e2e/sanctuary.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('./sanctuary')
+  await page.waitForLoadState('networkidle')
+})
+
+test.describe('sanctuary page', () => {
+  test('renders page title and description', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Sanctuary', level: 1 })).toBeVisible()
+    await expect(
+      page.getByText('Place awakened creatures to boost gathering skill tiers.'),
+    ).toBeVisible()
+  })
+
+  test('renders party slots section with 8 slots', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Party 0\/8/ })).toBeVisible()
+  })
+
+  test('renders skill benefits for all 6 jobs', async ({ page }) => {
+    await expect(page.getByText('Skill Benefits')).toBeVisible()
+    for (const job of ['Chopping', 'Mining', 'Digging', 'Exploring', 'Fishing', 'Farming']) {
+      await expect(page.getByText(job).first()).toBeVisible()
+    }
+  })
+
+  test('renders creature browser with search and filters', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Select Creature' })).toBeVisible()
+    await expect(page.getByPlaceholder('Search creature')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Summoned Only' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Show Excluded' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'More filters' })).toBeVisible()
+  })
+
+  test('creature count is displayed', async ({ page }) => {
+    await expect(page.getByText(/\d+ creatures/)).toBeVisible()
+  })
+
+  test('clicking a target tier button selects it', async ({ page }) => {
+    const yieldButton = page.getByRole('button', { name: '+1 Yield' }).first()
+    await yieldButton.click()
+    await expect(yieldButton).toHaveClass(/bg-primary/)
+  })
+
+  test('clicking a selected target tier button deselects it', async ({ page }) => {
+    const yieldButton = page.getByRole('button', { name: '+1 Yield' }).first()
+    await yieldButton.click()
+    await expect(yieldButton).toHaveClass(/bg-primary/)
+
+    await yieldButton.click()
+    await expect(yieldButton).not.toHaveClass(/bg-primary/)
+  })
+
+  test('more filters expands type and tier options', async ({ page }) => {
+    await page.getByRole('button', { name: 'More filters' }).click()
+    await expect(page.getByText('Type')).toBeVisible()
+    for (const type of ['Fire', 'Water', 'Wind', 'Earth']) {
+      await expect(page.getByRole('button', { name: type })).toBeVisible()
+    }
+  })
+
+  test('search filters creature list', async ({ page }) => {
+    // Disable "Summoned Only" to ensure creatures are shown
+    await page.getByRole('button', { name: 'Summoned Only' }).click()
+    const countBefore = await page.getByText(/\d+ creatures/).textContent()
+    await page.getByPlaceholder('Search creature').fill('zzzznonexistent')
+    await expect(page.getByText('0 creatures')).toBeVisible()
+    await expect(page.getByText('No creatures match your filters.')).toBeVisible()
+
+    await page.getByPlaceholder('Search creature').clear()
+    await expect(page.getByText(countBefore!)).toBeVisible()
+  })
+
+  test('skill benefit cards show "No bonuses" initially', async ({ page }) => {
+    const noBonuses = page.getByText('No bonuses')
+    await expect(noBonuses.first()).toBeVisible()
+  })
+
+  test('creature rows display tier badges when creatures visible', async ({ page }) => {
+    // Disable "Summoned Only" to show all creatures (no collection data in e2e)
+    await page.getByRole('button', { name: 'Summoned Only' }).click()
+    // Tier badges are small spans with font-mono class inside creature rows
+    const tierBadge = page.locator('span.font-mono').filter({ hasText: /T\d/ }).first()
+    await expect(tierBadge).toBeVisible()
+  })
+
+  test('clear all button is hidden when party is empty', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Clear All' })).not.toBeVisible()
+  })
+})

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -6,6 +6,7 @@ import {
   Cog,
   Compass,
   Swords,
+  Fence,
   FileCog,
   GitBranch,
   Github,
@@ -63,6 +64,7 @@ const navGroups = [
       { label: 'Items', to: '/items', icon: Package },
       { label: 'Dungeons', to: '/dungeons', icon: Swords },
       { label: 'Expeditions', to: '/expeditions', icon: Compass },
+      { label: 'Sanctuary', to: '/sanctuary', icon: Fence },
     ],
   },
   {

--- a/src/components/planner/PlannerSettings.vue
+++ b/src/components/planner/PlannerSettings.vue
@@ -167,25 +167,9 @@ const jobs = ['Chopping', 'Mining', 'Digging', 'Exploring', 'Fishing', 'Farming'
 const jobTiersOpen = ref(false)
 
 
-const JOB_TIER_BENEFITS = [
-  { xpBonus: 0, durationReduction: 0, yieldBonus: 0 },
-  { xpBonus: 20, durationReduction: 0, yieldBonus: 0 },
-  { xpBonus: 20, durationReduction: 10, yieldBonus: 0 },
-  { xpBonus: 40, durationReduction: 10, yieldBonus: 0 },
-  { xpBonus: 40, durationReduction: 20, yieldBonus: 0 },
-  { xpBonus: 40, durationReduction: 20, yieldBonus: 1 },
-]
+import { JOB_TIER_BENEFITS, jobTierLabel as _jobTierLabel } from '@/utils/sanctuaryConstants'
 
-
-function jobTierLabel(tier: number): string {
-  const b = JOB_TIER_BENEFITS[tier] ?? JOB_TIER_BENEFITS[0]
-  if (tier === 0) return 'No bonuses'
-  const parts: string[] = []
-  if (b.xpBonus > 0) parts.push(`+${b.xpBonus}% XP`)
-  if (b.durationReduction > 0) parts.push(`-${b.durationReduction}% Dur`)
-  if (b.yieldBonus > 0) parts.push(`+${b.yieldBonus} Yield`)
-  return parts.join(', ')
-}
+const jobTierLabel = (tier: number) => _jobTierLabel(tier, true)
 
 
 const hasJobChanges = computed(() => Object.values(props.jobTiers).some((t) => t > 0))

--- a/src/composables/__tests__/useSanctuary.test.ts
+++ b/src/composables/__tests__/useSanctuary.test.ts
@@ -1,0 +1,303 @@
+import { useCreatures } from '@/composables/useCreatures'
+import { useGameConfig } from '@/composables/useGameConfig'
+import { useSanctuary } from '@/composables/useSanctuary'
+import { MAX_SANCTUARY_SLOTS, SANCTUARY_JOBS } from '@/utils/sanctuaryConstants'
+
+describe('useSanctuary', () => {
+  beforeEach(() => {
+    const { resetGameConfig } = useGameConfig()
+    resetGameConfig()
+    localStorage.removeItem('sanctuary-target-tiers')
+  })
+
+  describe('party slots', () => {
+    test('starts with all empty slots', () => {
+      const { partySlots } = useSanctuary()
+      expect(partySlots.value).toHaveLength(MAX_SANCTUARY_SLOTS)
+      expect(partySlots.value.every((s) => s === null)).toBe(true)
+    })
+
+    test('hasEmptySlot is true when party is not full', () => {
+      const { hasEmptySlot } = useSanctuary()
+      expect(hasEmptySlot.value).toBe(true)
+    })
+
+    test('placing a creature fills a slot', () => {
+      const { creatures } = useCreatures()
+      const { partySlots, hasEmptySlot, sanctuaryCreatureIds } = useSanctuary()
+      const creature = creatures.value[0]
+
+      const { setSanctuaryCreatures } = useGameConfig()
+      setSanctuaryCreatures([creature.id])
+
+      expect(sanctuaryCreatureIds.value).toHaveLength(1)
+      expect(partySlots.value[0]).not.toBeNull()
+      expect(partySlots.value[0]?.id).toBe(creature.id)
+      expect(hasEmptySlot.value).toBe(true)
+    })
+
+    test('hasEmptySlot is false when all slots filled', () => {
+      const { creatures } = useCreatures()
+      const { hasEmptySlot } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      const ids = creatures.value.slice(0, MAX_SANCTUARY_SLOTS).map((c) => c.id)
+      setSanctuaryCreatures(ids)
+
+      expect(hasEmptySlot.value).toBe(false)
+    })
+  })
+
+  describe('clearSanctuary', () => {
+    test('removes all creatures from party', () => {
+      const { creatures } = useCreatures()
+      const { sanctuaryCreatureIds, clearSanctuary } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      setSanctuaryCreatures([creatures.value[0].id, creatures.value[1].id])
+      expect(sanctuaryCreatureIds.value).toHaveLength(2)
+
+      clearSanctuary()
+      expect(sanctuaryCreatureIds.value).toHaveLength(0)
+    })
+  })
+
+  describe('removeCreatureFromSlot', () => {
+    test('removes the creature at the given index', () => {
+      const { creatures } = useCreatures()
+      const { sanctuaryCreatureIds, removeCreatureFromSlot } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      const [c1, c2, c3] = creatures.value
+      setSanctuaryCreatures([c1.id, c2.id, c3.id])
+
+      removeCreatureFromSlot(1) // remove middle creature
+      expect(sanctuaryCreatureIds.value).toEqual([c1.id, c3.id])
+    })
+
+    test('does nothing when removing from an empty slot', () => {
+      const { sanctuaryCreatureIds, removeCreatureFromSlot } = useSanctuary()
+      removeCreatureFromSlot(0)
+      expect(sanctuaryCreatureIds.value).toHaveLength(0)
+    })
+  })
+
+  describe('jobScores', () => {
+    test('all scores are 0 with empty party', () => {
+      const { jobScores } = useSanctuary()
+      for (const job of SANCTUARY_JOBS) {
+        expect(jobScores.value[job]).toBe(0)
+      }
+    })
+
+    test('scores sum creature contributions', () => {
+      const { creatures } = useCreatures()
+      const { jobScores } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      const creature = creatures.value[0]
+      setSanctuaryCreatures([creature.id])
+
+      for (const job of SANCTUARY_JOBS) {
+        const key = job.toLowerCase() as keyof typeof creature.jobs
+        expect(jobScores.value[job]).toBe(creature.jobs[key] ?? 0)
+      }
+    })
+
+    test('scores accumulate across multiple creatures', () => {
+      const { creatures } = useCreatures()
+      const { jobScores } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      const [c1, c2] = creatures.value
+      setSanctuaryCreatures([c1.id, c2.id])
+
+      for (const job of SANCTUARY_JOBS) {
+        const key = job.toLowerCase() as keyof typeof c1.jobs
+        const expected = (c1.jobs[key] ?? 0) + (c2.jobs[key] ?? 0)
+        expect(jobScores.value[job]).toBe(expected)
+      }
+    })
+  })
+
+  describe('jobProgress', () => {
+    test('returns progress for all 6 jobs', () => {
+      const { jobProgress } = useSanctuary()
+      expect(jobProgress.value).toHaveLength(6)
+      const jobs = jobProgress.value.map((jp) => jp.job)
+      for (const job of SANCTUARY_JOBS) {
+        expect(jobs).toContain(job)
+      }
+    })
+
+    test('empty party has score 0 and positive pointsToNext', () => {
+      const { jobProgress } = useSanctuary()
+      for (const jp of jobProgress.value) {
+        expect(jp.score).toBe(0)
+        expect(jp.pointsToNext).toBeGreaterThan(0)
+        expect(jp.isMaxed).toBe(false)
+      }
+    })
+  })
+
+  describe('setTargetTier', () => {
+    test('sets a target for a specific job', () => {
+      const { targetTiers, setTargetTier } = useSanctuary()
+      setTargetTier('Chopping', 3)
+      expect(targetTiers.value['Chopping']).toBe(3)
+    })
+
+    test('clamps target to valid range', () => {
+      const { targetTiers, setTargetTier } = useSanctuary()
+      setTargetTier('Mining', -1)
+      expect(targetTiers.value['Mining']).toBe(0)
+
+      setTargetTier('Mining', 99)
+      expect(targetTiers.value['Mining']).toBe(5)
+    })
+
+    test('setting target to 0 clears it', () => {
+      const { targetTiers, setTargetTier } = useSanctuary()
+      setTargetTier('Fishing', 3)
+      expect(targetTiers.value['Fishing']).toBe(3)
+
+      setTargetTier('Fishing', 0)
+      expect(targetTiers.value['Fishing']).toBe(0)
+    })
+  })
+
+  describe('setAllTargets', () => {
+    test('sets the same target for all jobs', () => {
+      const { targetTiers, setAllTargets } = useSanctuary()
+      setAllTargets(3)
+      for (const job of SANCTUARY_JOBS) {
+        expect(targetTiers.value[job]).toBe(3)
+      }
+    })
+
+    test('clears all targets when set to 0', () => {
+      const { targetTiers, setAllTargets } = useSanctuary()
+      setAllTargets(5)
+      setAllTargets(0)
+      for (const job of SANCTUARY_JOBS) {
+        expect(targetTiers.value[job]).toBe(0)
+      }
+    })
+  })
+
+  describe('setActiveSlot', () => {
+    test('sets the active slot index', () => {
+      const { activeSlotIndex, setActiveSlot } = useSanctuary()
+      setActiveSlot(3)
+      expect(activeSlotIndex.value).toBe(3)
+    })
+
+    test('toggles off when clicking the same slot', () => {
+      const { activeSlotIndex, setActiveSlot } = useSanctuary()
+      setActiveSlot(2)
+      expect(activeSlotIndex.value).toBe(2)
+
+      setActiveSlot(2)
+      expect(activeSlotIndex.value).toBeNull()
+    })
+
+    test('switches to a different slot', () => {
+      const { activeSlotIndex, setActiveSlot } = useSanctuary()
+      setActiveSlot(1)
+      setActiveSlot(4)
+      expect(activeSlotIndex.value).toBe(4)
+    })
+  })
+
+  describe('getCreatureStatus', () => {
+    test('returns null for unassigned creatures', () => {
+      const { getCreatureStatus } = useSanctuary()
+      expect(getCreatureStatus('unknown-id')).toBeNull()
+    })
+
+    test('returns "helper" for helper creatures', () => {
+      const { setHelperCreatures } = useGameConfig()
+      setHelperCreatures(['h1'])
+      const { getCreatureStatus } = useSanctuary()
+      expect(getCreatureStatus('h1')).toBe('helper')
+    })
+
+    test('returns "machine" for machine creatures', () => {
+      const { setMachineCreatures } = useGameConfig()
+      setMachineCreatures(['m1'])
+      const { getCreatureStatus } = useSanctuary()
+      expect(getCreatureStatus('m1')).toBe('machine')
+    })
+  })
+
+  describe('recommendedCreatures', () => {
+    test('excludes creatures already in sanctuary party', () => {
+      const { creatures } = useCreatures()
+      const { recommendedCreatures } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      const creature = creatures.value[0]
+      setSanctuaryCreatures([creature.id])
+
+      const ids = recommendedCreatures.value.map(({ creature: c }) => c.id)
+      expect(ids).not.toContain(creature.id)
+    })
+
+    test('hides excluded creatures by default', () => {
+      const { creatures } = useCreatures()
+      const { recommendedCreatures } = useSanctuary()
+      const { setHelperCreatures } = useGameConfig()
+
+      const helper = creatures.value[0]
+      setHelperCreatures([helper.id])
+
+      const ids = recommendedCreatures.value.map(({ creature: c }) => c.id)
+      expect(ids).not.toContain(helper.id)
+    })
+
+    test('shows excluded creatures when toggle is on', () => {
+      const { creatures } = useCreatures()
+      const { recommendedCreatures, showExcludedCreatures } = useSanctuary()
+      const { setHelperCreatures } = useGameConfig()
+
+      const helper = creatures.value[0]
+      setHelperCreatures([helper.id])
+      showExcludedCreatures.value = true
+
+      const ids = recommendedCreatures.value.map(({ creature: c }) => c.id)
+      expect(ids).toContain(helper.id)
+    })
+
+    test('without targets, scores equal total job points', () => {
+      const { recommendedCreatures } = useSanctuary()
+      const first = recommendedCreatures.value[0]
+      const totalJobScore = Object.values(first.creature.jobs).reduce((s, v) => s + v, 0)
+      expect(first.score).toBe(totalJobScore)
+    })
+
+    test('sorted by score descending when no targets set', () => {
+      const { recommendedCreatures } = useSanctuary()
+      const scores = recommendedCreatures.value.map(({ score }) => score)
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i]).toBeLessThanOrEqual(scores[i - 1])
+      }
+    })
+  })
+
+  describe('maxAchievableTiers', () => {
+    test('returns a tier for each job', () => {
+      const { maxAchievableTiers } = useSanctuary()
+      for (const job of SANCTUARY_JOBS) {
+        expect(maxAchievableTiers.value[job]).toBeDefined()
+        expect(maxAchievableTiers.value[job]).toBeGreaterThanOrEqual(0)
+      }
+    })
+
+    test('tiers are capped at MAX_TIER', () => {
+      const { maxAchievableTiers } = useSanctuary()
+      for (const job of SANCTUARY_JOBS) {
+        expect(maxAchievableTiers.value[job]).toBeLessThanOrEqual(5)
+      }
+    })
+  })
+})

--- a/src/composables/useSanctuary.ts
+++ b/src/composables/useSanctuary.ts
@@ -1,0 +1,345 @@
+import { useLocalStorage } from '@vueuse/core'
+import { computed, ref } from 'vue'
+
+import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatures } from '@/composables/useCreatures'
+import { useGameConfig } from '@/composables/useGameConfig'
+import type { Creature } from '@/types'
+import {
+  MAX_SANCTUARY_SLOTS,
+  SANCTUARY_JOBS,
+  SCORE_DIVISOR,
+  TIER_THRESHOLDS,
+  TIER_THRESHOLDS_RAW,
+  MAX_TIER,
+} from '@/utils/sanctuaryConstants'
+
+export interface JobProgress {
+  job: string
+  score: number
+  tier: number
+  nextThreshold: number
+  pointsToNext: number
+  isMaxed: boolean
+}
+
+export function useSanctuary() {
+  const { creatures } = useCreatures()
+  const { isOwned, isAwakened } = useCreatureCollection()
+  const {
+    sanctuaryCreatureIds,
+    helperCreatureIds,
+    machineCreatureIds,
+    excludedCreatureIds,
+    jobTiers,
+    setSanctuaryCreatures,
+  } = useGameConfig()
+
+  // Local state
+  const targetTiers = useLocalStorage<Record<string, number>>('sanctuary-target-tiers', {})
+  const activeSlotIndex = ref<number | null>(null)
+  const showExcludedCreatures = ref(false)
+  const ownedOnly = ref(true)
+
+  // Party slots (8 fixed slots)
+  const partySlots = computed<(Creature | null)[]>(() => {
+    const creatureMap = new Map(creatures.value.map((c) => [c.id, c]))
+    const slots: (Creature | null)[] = Array(MAX_SANCTUARY_SLOTS).fill(null)
+    for (let i = 0; i < sanctuaryCreatureIds.value.length && i < MAX_SANCTUARY_SLOTS; i++) {
+      slots[i] = creatureMap.get(sanctuaryCreatureIds.value[i]) ?? null
+    }
+    return slots
+  })
+
+  const partyCreatureIds = computed(() => new Set(sanctuaryCreatureIds.value))
+
+  const isFull = computed(() => sanctuaryCreatureIds.value.length >= MAX_SANCTUARY_SLOTS)
+  const hasEmptySlot = computed(() => sanctuaryCreatureIds.value.length < MAX_SANCTUARY_SLOTS)
+
+  // Raw job scores from sanctuary creatures
+  const jobScores = computed(() => {
+    const scores: Record<string, number> = {}
+    for (const job of SANCTUARY_JOBS) {
+      scores[job] = 0
+    }
+    for (const slot of partySlots.value) {
+      if (!slot) continue
+      for (const job of SANCTUARY_JOBS) {
+        const key = job.toLowerCase() as keyof typeof slot.jobs
+        scores[job] += slot.jobs[key] ?? 0
+      }
+    }
+    return scores
+  })
+
+  // Per-job progress details
+  const jobProgress = computed<JobProgress[]>(() => {
+    return SANCTUARY_JOBS.map((job) => {
+      const score = jobScores.value[job]
+      const tier = jobTiers.value[job] ?? 0
+      const isMaxed = tier >= MAX_TIER
+      const nextThresholdIndex = TIER_THRESHOLDS.findIndex((t) => score < t * SCORE_DIVISOR)
+      const nextThreshold =
+        nextThresholdIndex === -1
+          ? TIER_THRESHOLDS_RAW[TIER_THRESHOLDS_RAW.length - 1]
+          : TIER_THRESHOLDS_RAW[nextThresholdIndex]
+      const pointsToNext = isMaxed ? 0 : Math.ceil(nextThreshold) - score
+
+      return {
+        job,
+        score,
+        tier,
+        nextThreshold,
+        pointsToNext,
+        isMaxed,
+      }
+    })
+  })
+
+  // Whether any targets are set
+  const hasTargets = computed(() => Object.values(targetTiers.value).some((t) => t > 0))
+
+  // Greedy simulation: iteratively pick creatures that contribute most toward remaining deficits.
+  // Returns the ordered picks and final simulated scores.
+  function greedySimulation(
+    available: Creature[],
+    emptySlots: number,
+    currentScores: Record<string, number>,
+    unmetJobs: readonly string[],
+  ): { picks: Creature[]; simScores: Record<string, number> } {
+    const simScores = { ...currentScores }
+    const picks: Creature[] = []
+    const picked = new Set<string>()
+
+    for (let slot = 0; slot < emptySlots && picked.size < available.length; slot++) {
+      let bestCreature: Creature | null = null
+      let bestValue = -1
+
+      for (const c of available) {
+        if (picked.has(c.id)) continue
+        let value = 0
+        for (const job of unmetJobs) {
+          const key = job.toLowerCase() as keyof typeof c.jobs
+          const contribution = c.jobs[key] ?? 0
+          const target = targetTiers.value[job] ?? 0
+          const remaining = TIER_THRESHOLDS_RAW[target - 1] - simScores[job]
+          if (remaining > 0) {
+            value += Math.min(contribution, remaining)
+          }
+        }
+        if (value > bestValue) {
+          bestValue = value
+          bestCreature = c
+        }
+      }
+
+      if (!bestCreature || bestValue <= 0) break
+      picked.add(bestCreature.id)
+      picks.push(bestCreature)
+      for (const job of SANCTUARY_JOBS) {
+        const key = job.toLowerCase() as keyof typeof bestCreature.jobs
+        simScores[job] += bestCreature.jobs[key] ?? 0
+      }
+    }
+
+    return { picks, simScores }
+  }
+
+  // Per-job max achievable tier given the current party and available creatures.
+  // For each job, picks the top N creatures (by that job's contribution) to find the upper bound.
+  const maxAchievableTiers = computed<Record<string, number>>(() => {
+    const emptySlots = MAX_SANCTUARY_SLOTS - sanctuaryCreatureIds.value.length
+    const available = creatures.value.filter((c) => {
+      if (partyCreatureIds.value.has(c.id)) return false
+      if (ownedOnly.value && !isOwned(c.id)) return false
+      return true
+    })
+
+    const result: Record<string, number> = {}
+    for (const job of SANCTUARY_JOBS) {
+      const key = job.toLowerCase() as keyof (typeof available)[0]['jobs']
+      // Sort available creatures by this job's contribution descending, take top N
+      const topContributions = available
+        .map((c) => c.jobs[key] ?? 0)
+        .toSorted((a, b) => b - a)
+        .slice(0, emptySlots)
+
+      const maxScore = jobScores.value[job] + topContributions.reduce((s, v) => s + v, 0)
+      const pct = maxScore / SCORE_DIVISOR
+      let tier = 0
+      for (let i = TIER_THRESHOLDS.length - 1; i >= 0; i--) {
+        if (pct >= TIER_THRESHOLDS[i]) {
+          tier = i + 1
+          break
+        }
+      }
+      result[job] = Math.min(tier, MAX_TIER)
+    }
+    return result
+  })
+
+  // Recommendation scoring
+  function getRecommendationValue(creature: Creature): number {
+    if (hasTargets.value) {
+      let totalValue = 0
+      for (const job of SANCTUARY_JOBS) {
+        const target = targetTiers.value[job] ?? 0
+        const currentTier = jobTiers.value[job] ?? 0
+        if (target <= currentTier) continue
+        const deficit = TIER_THRESHOLDS_RAW[target - 1] - jobScores.value[job]
+        if (deficit <= 0) continue
+        const key = job.toLowerCase() as keyof typeof creature.jobs
+        const contribution = creature.jobs[key] ?? 0
+        totalValue += Math.min(contribution, deficit)
+      }
+      return totalValue
+    }
+    // No targets: rank by total job score
+    return Object.values(creature.jobs).reduce((sum, v) => sum + v, 0)
+  }
+
+  // Filtered and sorted creature list for the browser.
+  // When targets are set, uses greedy simulation to order creatures by how well
+  // they complement each other toward meeting all targets collectively.
+  const recommendedCreatures = computed(() => {
+    const browsable = creatures.value.filter((c) => {
+      if (partyCreatureIds.value.has(c.id)) return false
+      if (!showExcludedCreatures.value && excludedCreatureIds.value.has(c.id)) return false
+      return true
+    })
+
+    // No targets: rank by total job score
+    if (!hasTargets.value) {
+      return browsable
+        .map((c) => ({ creature: c, score: getRecommendationValue(c) }))
+        .toSorted((a, b) => b.score - a.score)
+    }
+
+    // Find unmet target jobs
+    const unmetJobs = SANCTUARY_JOBS.filter((job) => {
+      const target = targetTiers.value[job] ?? 0
+      const currentTier = jobTiers.value[job] ?? 0
+      return target > currentTier
+    })
+
+    // All targets met: rank by total job score
+    if (unmetJobs.length === 0) {
+      return browsable
+        .map((c) => ({ creature: c, score: getRecommendationValue(c) }))
+        .toSorted((a, b) => b.score - a.score)
+    }
+
+    // Run greedy simulation to determine optimal pick order.
+    // When showing all creatures, include unowned in the simulation so suggestions
+    // reflect the best party composition from the full browsable pool.
+    const emptySlots = MAX_SANCTUARY_SLOTS - sanctuaryCreatureIds.value.length
+    const available = ownedOnly.value ? browsable.filter((c) => isOwned(c.id)) : browsable
+    const { picks } = greedySimulation(available, emptySlots, jobScores.value, unmetJobs)
+
+    // Build pick-order ranking: first pick = highest priority
+    const pickRank = new Map<string, number>()
+    for (let i = 0; i < picks.length; i++) {
+      pickRank.set(picks[i].id, i)
+    }
+
+    return browsable
+      .map((c) => ({ creature: c, score: getRecommendationValue(c) }))
+      .toSorted((a, b) => {
+        const rankA = pickRank.get(a.creature.id)
+        const rankB = pickRank.get(b.creature.id)
+        // Simulation-picked creatures always come first, in pick order
+        if (rankA !== undefined && rankB !== undefined) return rankA - rankB
+        if (rankA !== undefined) return -1
+        if (rankB !== undefined) return 1
+        // Non-picked creatures sorted by individual score
+        return b.score - a.score
+      })
+  })
+
+  // Slot actions
+  function setActiveSlot(index: number) {
+    activeSlotIndex.value = activeSlotIndex.value === index ? null : index
+  }
+
+  function assignCreatureToSlot(creature: Creature) {
+    const slots = partySlots.value
+    if (
+      activeSlotIndex.value !== null &&
+      activeSlotIndex.value < slots.length &&
+      !slots[activeSlotIndex.value]
+    ) {
+      const ids = [...sanctuaryCreatureIds.value]
+      // Insert at the correct position
+      while (ids.length < activeSlotIndex.value) ids.push('')
+      ids.splice(activeSlotIndex.value, 0, creature.id)
+      setSanctuaryCreatures(ids.filter(Boolean))
+      activeSlotIndex.value = null
+      return
+    }
+    // Fill first empty slot
+    if (!isFull.value) {
+      setSanctuaryCreatures([...sanctuaryCreatureIds.value, creature.id])
+      activeSlotIndex.value = null
+    }
+  }
+
+  function removeCreatureFromSlot(index: number) {
+    const creature = partySlots.value[index]
+    if (!creature) return
+    setSanctuaryCreatures(sanctuaryCreatureIds.value.filter((id) => id !== creature.id))
+  }
+
+  function setTargetTier(job: string, tier: number) {
+    targetTiers.value = { ...targetTiers.value, [job]: Math.max(0, Math.min(MAX_TIER, tier)) }
+  }
+
+  function setAllTargets(tier: number) {
+    const clamped = Math.max(0, Math.min(MAX_TIER, tier))
+    const newTargets: Record<string, number> = {}
+    for (const job of SANCTUARY_JOBS) {
+      newTargets[job] = clamped
+    }
+    targetTiers.value = newTargets
+  }
+
+  function clearSanctuary() {
+    setSanctuaryCreatures([])
+  }
+
+  function getCreatureStatus(id: string): 'helper' | 'machine' | null {
+    if (helperCreatureIds.value.includes(id)) return 'helper'
+    if (machineCreatureIds.value.includes(id)) return 'machine'
+    return null
+  }
+
+  return {
+    // State
+    sanctuaryCreatureIds,
+    partySlots,
+    activeSlotIndex,
+    hasEmptySlot,
+    jobScores,
+    jobTiers,
+    jobProgress,
+    targetTiers,
+    maxAchievableTiers,
+
+    // Creature browser
+    recommendedCreatures,
+    showExcludedCreatures,
+    ownedOnly,
+
+    // Actions
+    setActiveSlot,
+    assignCreatureToSlot,
+    removeCreatureFromSlot,
+    setTargetTier,
+    setAllTargets,
+    clearSanctuary,
+
+    // Helpers
+    isOwned,
+    isAwakened,
+    getCreatureStatus,
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -43,6 +43,12 @@ export const router = createRouter({
       meta: { title: 'Expeditions' },
     },
     {
+      path: '/sanctuary',
+      name: 'sanctuary',
+      component: () => import('../views/SanctuaryView.vue'),
+      meta: { title: 'Sanctuary' },
+    },
+    {
       path: '/machines',
       name: 'machines',
       component: () => import('../views/MachinesView.vue'),

--- a/src/utils/__tests__/sanctuaryConstants.test.ts
+++ b/src/utils/__tests__/sanctuaryConstants.test.ts
@@ -1,0 +1,109 @@
+import {
+  MAX_SANCTUARY_SLOTS,
+  SANCTUARY_JOBS,
+  SCORE_DIVISOR,
+  TIER_THRESHOLDS,
+  TIER_THRESHOLDS_RAW,
+  MAX_TIER,
+  JOB_TIER_BENEFITS,
+  JOB_COLORS,
+  jobTierLabel,
+} from '@/utils/sanctuaryConstants'
+
+describe('sanctuaryConstants', () => {
+  test('MAX_SANCTUARY_SLOTS is 8', () => {
+    expect(MAX_SANCTUARY_SLOTS).toBe(8)
+  })
+
+  test('SANCTUARY_JOBS has 6 jobs', () => {
+    expect(SANCTUARY_JOBS).toHaveLength(6)
+    expect(SANCTUARY_JOBS).toContain('Chopping')
+    expect(SANCTUARY_JOBS).toContain('Mining')
+    expect(SANCTUARY_JOBS).toContain('Digging')
+    expect(SANCTUARY_JOBS).toContain('Exploring')
+    expect(SANCTUARY_JOBS).toContain('Fishing')
+    expect(SANCTUARY_JOBS).toContain('Farming')
+  })
+
+  test('TIER_THRESHOLDS_RAW are TIER_THRESHOLDS * SCORE_DIVISOR', () => {
+    for (let i = 0; i < TIER_THRESHOLDS.length; i++) {
+      expect(TIER_THRESHOLDS_RAW[i]).toBe(TIER_THRESHOLDS[i] * SCORE_DIVISOR)
+    }
+  })
+
+  test('TIER_THRESHOLDS are sorted ascending', () => {
+    for (let i = 1; i < TIER_THRESHOLDS.length; i++) {
+      expect(TIER_THRESHOLDS[i]).toBeGreaterThan(TIER_THRESHOLDS[i - 1])
+    }
+  })
+
+  test('MAX_TIER equals TIER_THRESHOLDS length', () => {
+    expect(MAX_TIER).toBe(TIER_THRESHOLDS.length)
+    expect(MAX_TIER).toBe(5)
+  })
+
+  test('JOB_TIER_BENEFITS has entries for tier 0 through MAX_TIER', () => {
+    expect(JOB_TIER_BENEFITS).toHaveLength(MAX_TIER + 1)
+  })
+
+  test('JOB_TIER_BENEFITS tier 0 has no bonuses', () => {
+    const t0 = JOB_TIER_BENEFITS[0]
+    expect(t0.xpBonus).toBe(0)
+    expect(t0.durationReduction).toBe(0)
+    expect(t0.yieldBonus).toBe(0)
+  })
+
+  test('JOB_TIER_BENEFITS bonuses never decrease at higher tiers', () => {
+    for (let i = 1; i < JOB_TIER_BENEFITS.length; i++) {
+      const prev = JOB_TIER_BENEFITS[i - 1]
+      const curr = JOB_TIER_BENEFITS[i]
+      expect(curr.xpBonus).toBeGreaterThanOrEqual(prev.xpBonus)
+      expect(curr.durationReduction).toBeGreaterThanOrEqual(prev.durationReduction)
+      expect(curr.yieldBonus).toBeGreaterThanOrEqual(prev.yieldBonus)
+    }
+  })
+
+  test('JOB_TIER_BENEFITS max tier includes yield bonus', () => {
+    const max = JOB_TIER_BENEFITS[MAX_TIER]
+    expect(max.yieldBonus).toBeGreaterThan(0)
+  })
+
+  test('JOB_COLORS has a color for every job', () => {
+    for (const job of SANCTUARY_JOBS) {
+      expect(JOB_COLORS[job.toLowerCase()]).toBeDefined()
+      expect(JOB_COLORS[job.toLowerCase()]).toMatch(/^#[0-9a-fA-F]{6}$/)
+    }
+  })
+})
+
+describe('jobTierLabel', () => {
+  test('tier 0 returns "No bonuses"', () => {
+    expect(jobTierLabel(0)).toBe('No bonuses')
+  })
+
+  test('tier 1 shows XP bonus only', () => {
+    expect(jobTierLabel(1)).toBe('+20% XP')
+  })
+
+  test('tier 2 shows XP and Duration', () => {
+    expect(jobTierLabel(2)).toBe('+20% XP, -10% Duration')
+  })
+
+  test('short duration flag abbreviates Duration to Dur', () => {
+    expect(jobTierLabel(2, true)).toBe('+20% XP, -10% Dur')
+  })
+
+  test('max tier shows all three bonuses', () => {
+    const label = jobTierLabel(MAX_TIER)
+    expect(label).toContain('XP')
+    expect(label).toContain('Duration')
+    expect(label).toContain('Yield')
+  })
+
+  test('out-of-range tier falls back to tier 0 benefits', () => {
+    // Negative tier uses JOB_TIER_BENEFITS[0] via nullish coalescing
+    expect(jobTierLabel(-1)).toBe('')
+    // Beyond max tier uses JOB_TIER_BENEFITS[0] via nullish coalescing
+    expect(jobTierLabel(99)).toBe('')
+  })
+})

--- a/src/utils/parseSave.ts
+++ b/src/utils/parseSave.ts
@@ -231,8 +231,7 @@ export function parseAwakenUpgrades(upgrades: string[]): {
   return { awakenGatherUpgrades, awakenSpeedTiers, awakenGoldLevel }
 }
 
-const SCORE_DIVISOR = 60
-const TIER_THRESHOLDS = [0.1, 0.3, 0.5, 0.7, 0.9]
+import { SCORE_DIVISOR, TIER_THRESHOLDS } from './sanctuaryConstants'
 
 const creatureJobScoresMap: Record<string, Record<string, number>> = Object.fromEntries(
   (creaturesData as { id: string; jobs: Record<string, number> }[]).map((c) => [c.id, c.jobs]),

--- a/src/utils/sanctuaryConstants.ts
+++ b/src/utils/sanctuaryConstants.ts
@@ -1,0 +1,46 @@
+export const MAX_SANCTUARY_SLOTS = 8
+
+export const SANCTUARY_JOBS = [
+  'Chopping',
+  'Mining',
+  'Digging',
+  'Exploring',
+  'Fishing',
+  'Farming',
+] as const
+
+export type SanctuaryJob = (typeof SANCTUARY_JOBS)[number]
+
+export const SCORE_DIVISOR = 60
+export const TIER_THRESHOLDS = [0.1, 0.3, 0.5, 0.7, 0.9]
+export const TIER_THRESHOLDS_RAW = TIER_THRESHOLDS.map((t) => t * SCORE_DIVISOR)
+export const MAX_TIER = TIER_THRESHOLDS.length
+
+export const JOB_TIER_BENEFITS = [
+  { xpBonus: 0, durationReduction: 0, yieldBonus: 0 },
+  { xpBonus: 20, durationReduction: 0, yieldBonus: 0 },
+  { xpBonus: 20, durationReduction: 10, yieldBonus: 0 },
+  { xpBonus: 40, durationReduction: 10, yieldBonus: 0 },
+  { xpBonus: 40, durationReduction: 20, yieldBonus: 0 },
+  { xpBonus: 40, durationReduction: 20, yieldBonus: 1 },
+]
+
+export function jobTierLabel(tier: number, shortDuration = false): string {
+  const b = JOB_TIER_BENEFITS[tier] ?? JOB_TIER_BENEFITS[0]
+  if (tier === 0) return 'No bonuses'
+  const parts: string[] = []
+  if (b.xpBonus > 0) parts.push(`+${b.xpBonus}% XP`)
+  if (b.durationReduction > 0)
+    parts.push(`-${b.durationReduction}% ${shortDuration ? 'Dur' : 'Duration'}`)
+  if (b.yieldBonus > 0) parts.push(`+${b.yieldBonus} Yield`)
+  return parts.join(', ')
+}
+
+export const JOB_COLORS: Record<string, string> = {
+  chopping: '#59e843',
+  mining: '#c9c9c9',
+  digging: '#e89643',
+  exploring: '#fc1717',
+  fishing: '#43c7e8',
+  farming: '#fce917',
+}

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -40,6 +40,7 @@ import {
 } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 import { extractSaveConfig, type SaveConfig } from '@/utils/parseSave'
+import { jobTierLabel } from '@/utils/sanctuaryConstants'
 
 const allExpeditions = (expeditionsData as Expedition[]).toSorted((a, b) => {
   const diff = a.requiredExpeditionCompletions - b.requiredExpeditionCompletions
@@ -1123,27 +1124,6 @@ function updateAwakenSpeed(ws: string, delta: number) {
     ...awakenSpeedTiers.value,
     [ws]: Math.max(0, Math.min(4, (awakenSpeedTiers.value[ws] ?? 0) + delta)),
   }
-}
-
-
-const JOB_TIER_BENEFITS = [
-  { xpBonus: 0, durationReduction: 0, yieldBonus: 0 },
-  { xpBonus: 20, durationReduction: 0, yieldBonus: 0 },
-  { xpBonus: 20, durationReduction: 10, yieldBonus: 0 },
-  { xpBonus: 40, durationReduction: 10, yieldBonus: 0 },
-  { xpBonus: 40, durationReduction: 20, yieldBonus: 0 },
-  { xpBonus: 40, durationReduction: 20, yieldBonus: 1 },
-]
-
-
-function jobTierLabel(tier: number): string {
-  const b = JOB_TIER_BENEFITS[tier] ?? JOB_TIER_BENEFITS[0]
-  if (tier === 0) return 'No bonuses'
-  const parts: string[] = []
-  if (b.xpBonus > 0) parts.push(`+${b.xpBonus}% XP`)
-  if (b.durationReduction > 0) parts.push(`-${b.durationReduction}% Duration`)
-  if (b.yieldBonus > 0) parts.push(`+${b.yieldBonus} Yield`)
-  return parts.join(', ')
 }
 </script>
 

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -1,0 +1,899 @@
+<script setup lang="ts">
+import { useMediaQuery } from '@vueuse/core'
+import { AlertCircle, ChevronDown, Clock3, Layers, Plus, Trash2, X, Zap } from 'lucide-vue-next'
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import summonedIcon from '@/assets/icons/summoned.webp'
+import ActiveFilters from '@/components/shared/ActiveFilters.vue'
+import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import { useSanctuary } from '@/composables/useSanctuary'
+import type { Creature, ElementType, Jobs } from '@/types'
+import { getCreatureImage } from '@/utils/creatureImages'
+import { helpersIcon, machinesIcon } from '@/utils/icons'
+import { jobIcons } from '@/utils/icons'
+import {
+  MAX_SANCTUARY_SLOTS,
+  SANCTUARY_JOBS,
+  JOB_COLORS,
+  JOB_TIER_BENEFITS,
+  TIER_THRESHOLDS_RAW,
+  jobTierLabel,
+} from '@/utils/sanctuaryConstants'
+
+const route = useRoute()
+const router = useRouter()
+const isDesktop = useMediaQuery('(min-width: 1024px)')
+
+
+const {
+  sanctuaryCreatureIds,
+  partySlots,
+  activeSlotIndex,
+  hasEmptySlot,
+  jobProgress,
+  targetTiers,
+  recommendedCreatures,
+  showExcludedCreatures,
+  ownedOnly,
+  maxAchievableTiers,
+  setActiveSlot,
+  assignCreatureToSlot,
+  removeCreatureFromSlot,
+  setTargetTier,
+  setAllTargets,
+  clearSanctuary,
+  isOwned,
+  isAwakened,
+  getCreatureStatus,
+  jobScores,
+  jobTiers,
+} = useSanctuary()
+
+
+// ── Mobile section handling ──
+type MobileSection = 'sanctuary' | 'creatures'
+
+
+function normalizeSection(value: unknown): MobileSection {
+  if (value === 'creatures') return 'creatures'
+  return 'sanctuary'
+}
+
+
+const mobileSection = computed<MobileSection>({
+  get() {
+    return normalizeSection(route.query.section)
+  },
+  set(value) {
+    router.replace({ query: { ...route.query, section: value } })
+  },
+})
+
+
+// ── Unreachable tier tooltip ──
+const tierTooltip = ref<{ x: number; y: number } | null>(null)
+
+
+function showTierTooltip(event: MouseEvent) {
+  const el = event.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  tierTooltip.value = {
+    x: rect.left + rect.width / 2,
+    y: rect.top,
+  }
+}
+
+
+function hideTierTooltip() {
+  tierTooltip.value = null
+}
+
+
+// ── Creature filters ──
+const creatureSearch = ref('')
+const selectedCreatureType = ref<ElementType | 'all'>('all')
+const selectedCreatureTiers = ref<number[]>([])
+const showMoreCreatureFilters = ref(false)
+const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
+
+
+function typeColor(type: ElementType): string {
+  if (type === 'Fire') return 'hsl(var(--type-fire))'
+  if (type === 'Water') return 'hsl(var(--type-water))'
+  if (type === 'Wind') return 'hsl(var(--type-wind))'
+  return 'hsl(var(--type-earth))'
+}
+
+
+const creatureTierOptions = computed(() => {
+  const tiers = new Set(recommendedCreatures.value.map(({ creature }) => creature.tier))
+  return Array.from(tiers).toSorted((a, b) => a - b)
+})
+
+
+const allCreatureTiersSelected = computed(() => {
+  return (
+    creatureTierOptions.value.length > 0 &&
+    creatureTierOptions.value.every((tier) => selectedCreatureTiers.value.includes(tier))
+  )
+})
+
+
+watch(
+  creatureTierOptions,
+  (tiers) => {
+    const preserved = selectedCreatureTiers.value.filter((tier) => tiers.includes(tier))
+    selectedCreatureTiers.value = preserved.length ? preserved : [...tiers]
+  },
+  { immediate: true },
+)
+
+
+const hasSecondaryCreatureFilters = computed(
+  () => selectedCreatureType.value !== 'all' || !allCreatureTiersSelected.value,
+)
+
+
+const filteredRecommended = computed(() => {
+  return recommendedCreatures.value.filter(({ creature }) => {
+    const query = creatureSearch.value.toLowerCase()
+    const matchesSearch =
+      creature.name.toLowerCase().includes(query) || creature.trait.toLowerCase().includes(query)
+    const matchesType =
+      selectedCreatureType.value === 'all' || creature.types.includes(selectedCreatureType.value)
+    const matchesTier =
+      selectedCreatureTiers.value.length === 0 ||
+      selectedCreatureTiers.value.includes(creature.tier)
+    return matchesSearch && matchesType && matchesTier
+  })
+})
+
+
+const displayRecommended = computed(() => {
+  if (ownedOnly.value)
+    return filteredRecommended.value.filter(({ creature }) => isOwned(creature.id))
+  return filteredRecommended.value
+})
+
+
+// Check which targeted jobs are unreachable with the currently displayed creatures
+const unreachableTargets = computed<string[]>(() => {
+  const targets = targetTiers.value
+  const tiers = jobTiers.value
+  const scores = jobScores.value
+
+  const unmetJobs = SANCTUARY_JOBS.filter((job) => {
+    const target = targets[job] ?? 0
+    const tier = tiers[job] ?? 0
+    return target > tier
+  })
+  if (unmetJobs.length === 0) return []
+
+  const emptySlots = MAX_SANCTUARY_SLOTS - sanctuaryCreatureIds.value.length
+  if (emptySlots <= 0) return unmetJobs
+
+  const available = displayRecommended.value.map(({ creature }) => creature)
+
+  // Greedy simulation: pick creatures that contribute most toward remaining deficits
+  const simScores = { ...scores }
+  const picked = new Set<string>()
+
+  for (let slot = 0; slot < emptySlots && picked.size < available.length; slot++) {
+    let bestCreature: Creature | null = null
+    let bestValue = -1
+
+    for (const c of available) {
+      if (picked.has(c.id)) continue
+      let value = 0
+      for (const job of unmetJobs) {
+        const key = job.toLowerCase() as keyof Jobs
+        const contribution = c.jobs[key] ?? 0
+        const target = targets[job] ?? 0
+        const remaining = TIER_THRESHOLDS_RAW[target - 1] - simScores[job]
+        if (remaining > 0) value += Math.min(contribution, remaining)
+      }
+      if (value > bestValue) {
+        bestValue = value
+        bestCreature = c
+      }
+    }
+
+    if (!bestCreature) break
+    picked.add(bestCreature.id)
+    for (const job of SANCTUARY_JOBS) {
+      const key = job.toLowerCase() as keyof Jobs
+      simScores[job] += bestCreature.jobs[key] ?? 0
+    }
+  }
+
+  return unmetJobs.filter((job) => {
+    const target = targets[job] ?? 0
+    return simScores[job] < TIER_THRESHOLDS_RAW[target - 1]
+  })
+})
+
+
+const activeCreatureFilters = computed<ActiveFilter[]>(() => {
+  const filters: ActiveFilter[] = []
+  if (creatureSearch.value)
+    filters.push({
+      key: 'search',
+      group: 'Search',
+      label:
+        creatureSearch.value.length > 20
+          ? `${creatureSearch.value.slice(0, 20)}…`
+          : creatureSearch.value,
+    })
+  if (selectedCreatureType.value !== 'all')
+    filters.push({
+      key: 'type',
+      group: 'Type',
+      label: selectedCreatureType.value,
+      color: typeColor(selectedCreatureType.value),
+    })
+  if (!allCreatureTiersSelected.value) {
+    for (const tier of selectedCreatureTiers.value) {
+      filters.push({ key: `tier:${tier}`, group: 'Tier', label: `T${tier + 1}` })
+    }
+  }
+  if (!ownedOnly.value)
+    filters.push({ key: 'ownedOnly', group: 'Summoned', label: 'Showing All', image: summonedIcon })
+  if (showExcludedCreatures.value)
+    filters.push({ key: 'showExcluded', group: 'Filter', label: 'Showing Excluded' })
+  return filters
+})
+
+
+function removeCreatureFilter(key: string) {
+  if (key === 'search') creatureSearch.value = ''
+  else if (key === 'type') selectedCreatureType.value = 'all'
+  else if (key === 'ownedOnly') ownedOnly.value = true
+  else if (key === 'showExcluded') showExcludedCreatures.value = false
+  else if (key.startsWith('tier:')) selectedCreatureTiers.value = [...creatureTierOptions.value]
+}
+
+
+function clearCreatureFilters() {
+  creatureSearch.value = ''
+  selectedCreatureType.value = 'all'
+  selectedCreatureTiers.value = [...creatureTierOptions.value]
+  ownedOnly.value = true
+  showExcludedCreatures.value = false
+}
+
+
+function toggleCreatureType(type: ElementType) {
+  selectedCreatureType.value = selectedCreatureType.value === type ? 'all' : type
+}
+
+
+function toggleCreatureTier(tier: number) {
+  if (allCreatureTiersSelected.value) {
+    selectedCreatureTiers.value = [tier]
+    return
+  }
+  if (selectedCreatureTiers.value.includes(tier)) {
+    if (selectedCreatureTiers.value.length === 1) {
+      selectedCreatureTiers.value = [...creatureTierOptions.value]
+      return
+    }
+    selectedCreatureTiers.value = selectedCreatureTiers.value.filter((t) => t !== tier)
+  } else {
+    selectedCreatureTiers.value = [...selectedCreatureTiers.value, tier]
+  }
+}
+
+
+// ── Helpers ──
+const maxScore = TIER_THRESHOLDS_RAW[TIER_THRESHOLDS_RAW.length - 1] // 54
+
+
+type BenefitType = 'xp' | 'duration' | 'yield'
+
+
+function tierBenefitType(tier: number): BenefitType {
+  if (tier < 1 || tier > 5) return 'xp'
+  const curr = JOB_TIER_BENEFITS[tier]
+  const prev = JOB_TIER_BENEFITS[tier - 1]
+  if (curr.xpBonus > prev.xpBonus) return 'xp'
+  if (curr.durationReduction > prev.durationReduction) return 'duration'
+  return 'yield'
+}
+
+
+function tierIncrementalLabel(tier: number): string {
+  if (tier < 1 || tier > 5) return ''
+  const curr = JOB_TIER_BENEFITS[tier]
+  const prev = JOB_TIER_BENEFITS[tier - 1]
+  if (curr.xpBonus > prev.xpBonus) return `+${curr.xpBonus - prev.xpBonus}% XP`
+  if (curr.durationReduction > prev.durationReduction)
+    return `-${curr.durationReduction - prev.durationReduction}% Dur`
+  if (curr.yieldBonus > prev.yieldBonus) return `+${curr.yieldBonus - prev.yieldBonus} Yield`
+  return ''
+}
+
+
+function progressPercent(score: number): number {
+  return Math.min(100, (score / maxScore) * 100)
+}
+
+
+function targetPercent(targetTier: number): number {
+  if (targetTier <= 0 || targetTier > 5) return 0
+  return (TIER_THRESHOLDS_RAW[targetTier - 1] / maxScore) * 100
+}
+
+
+function clearAll() {
+  clearSanctuary()
+  setAllTargets(0)
+  clearCreatureFilters()
+}
+
+
+function chooseCreature(creature: Creature) {
+  if (!hasEmptySlot.value) return
+  assignCreatureToSlot(creature)
+  if (!isDesktop.value) {
+    mobileSection.value = 'sanctuary'
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- Page header -->
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-extrabold">Sanctuary</h1>
+        <p class="mt-1 text-sm text-muted-foreground">
+          Place awakened creatures to boost gathering skill tiers.
+        </p>
+      </div>
+      <button
+        v-if="sanctuaryCreatureIds.length > 0"
+        class="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-400 transition hover:bg-red-500/20"
+        @click="clearAll"
+      >
+        <Trash2 class="size-3.5" />
+        Clear All
+      </button>
+    </div>
+
+    <!-- Mobile tabs -->
+    <div class="surface-card p-2 lg:hidden">
+      <div class="grid grid-cols-2 gap-2">
+        <button
+          class="focus-ring rounded-lg px-3 py-2 text-xs font-semibold"
+          :class="
+            mobileSection === 'sanctuary'
+              ? 'bg-primary text-primary-foreground shadow-glow'
+              : 'bg-muted/45 text-muted-foreground'
+          "
+          @click="mobileSection = 'sanctuary'"
+        >
+          Sanctuary
+        </button>
+        <button
+          class="focus-ring rounded-lg px-3 py-2 text-xs font-semibold"
+          :class="
+            mobileSection === 'creatures'
+              ? 'bg-primary text-primary-foreground shadow-glow'
+              : 'bg-muted/45 text-muted-foreground'
+          "
+          @click="mobileSection = 'creatures'"
+        >
+          Creatures
+        </button>
+      </div>
+    </div>
+
+    <!-- Main layout: Left/Right split -->
+    <div
+      class="grid grid-cols-1 gap-4 lg:h-[calc(100vh-12rem)] lg:grid-cols-[minmax(340px,1fr)_minmax(320px,1fr)] lg:grid-rows-[minmax(0,1fr)]"
+    >
+      <!-- ═══ Left: Party + Tier Benefits ═══ -->
+      <section
+        class="surface-card flex flex-col overflow-hidden"
+        :class="!isDesktop && mobileSection !== 'sanctuary' ? 'hidden' : ''"
+      >
+        <div class="flex-1 overflow-y-auto p-4">
+          <!-- Party Slots -->
+          <div class="mb-5">
+            <div class="mb-2 flex items-center justify-between">
+              <h3 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+                Party
+                <span class="ml-1 normal-case tracking-normal text-muted-foreground/70">
+                  {{ sanctuaryCreatureIds.length }}/{{ MAX_SANCTUARY_SLOTS }}
+                </span>
+              </h3>
+              <button
+                class="focus-ring inline-flex items-center gap-1 rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1 text-[10px] font-semibold text-red-400 transition hover:bg-red-500/20"
+                :class="sanctuaryCreatureIds.length === 0 ? 'invisible' : ''"
+                @click="clearSanctuary"
+              >
+                <X class="size-3" />
+                Clear Party
+              </button>
+            </div>
+            <div class="flex flex-wrap gap-1.5">
+              <div
+                v-for="(slot, index) in partySlots"
+                :key="index"
+                class="flex flex-col items-center"
+              >
+                <div
+                  class="relative size-14 overflow-hidden rounded-lg border transition"
+                  :class="[
+                    slot
+                      ? 'border-border bg-card/50'
+                      : activeSlotIndex === index
+                        ? 'border-dashed border-primary bg-primary/10'
+                        : 'cursor-pointer border-dashed border-border/50 bg-muted/20 hover:border-accent/45',
+                  ]"
+                  @click="!slot ? setActiveSlot(index) : undefined"
+                >
+                  <template v-if="slot">
+                    <img
+                      :src="getCreatureImage(slot)"
+                      :alt="slot.name"
+                      class="size-full object-cover"
+                      loading="lazy"
+                    />
+                    <div class="absolute inset-x-0 bottom-0 bg-black/75 px-0.5 py-0.5">
+                      <p class="truncate text-center text-[8px] font-semibold text-white">
+                        {{ slot.name }}
+                      </p>
+                    </div>
+                    <button
+                      class="focus-ring absolute right-0 top-0 rounded-bl bg-black/60 p-0.5 text-white/70 hover:text-white"
+                      @click.stop="removeCreatureFromSlot(index)"
+                    >
+                      <X class="size-2.5" />
+                    </button>
+                  </template>
+                  <template v-else>
+                    <div class="flex size-full flex-col items-center justify-center">
+                      <Plus class="size-3 text-muted-foreground/50" />
+                      <span v-if="activeSlotIndex === index" class="text-[8px] text-primary">
+                        Select
+                      </span>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Tier Benefit Cards -->
+          <div>
+            <div class="mb-2 flex items-start justify-between gap-2">
+              <h3 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
+                Skill Benefits
+              </h3>
+              <div
+                v-if="unreachableTargets.length > 0"
+                class="flex items-center gap-1 text-[10px] font-semibold text-amber-600 dark:text-amber-400"
+              >
+                <AlertCircle class="size-3 shrink-0" />
+                <template v-for="(job, i) in unreachableTargets" :key="job">
+                  <span v-if="i > 0">,</span>
+                  <img
+                    :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
+                    :alt="job"
+                    class="size-3"
+                  />
+                  <span>{{ job }}</span>
+                </template>
+                <span>unreachable</span>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <div
+                v-for="jp in jobProgress"
+                :key="jp.job"
+                class="rounded-lg border border-border/50 bg-muted/10 px-3 py-2.5"
+              >
+                <!-- Header: icon + name + active benefit pills -->
+                <div class="mb-1.5 flex items-center gap-1.5">
+                  <img
+                    :src="jobIcons[jp.job.toLowerCase() as keyof typeof jobIcons]"
+                    :alt="jp.job"
+                    class="size-4"
+                    loading="lazy"
+                  />
+                  <span class="text-sm font-semibold">{{ jp.job }}</span>
+                  <div v-if="jp.tier > 0" class="ml-auto flex gap-1">
+                    <span
+                      v-if="JOB_TIER_BENEFITS[jp.tier].xpBonus > 0"
+                      class="inline-flex items-center gap-0.5 rounded-full border border-emerald-500/25 bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+                    >
+                      <Zap class="size-2.5" />
+                      +{{ JOB_TIER_BENEFITS[jp.tier].xpBonus }}% XP
+                    </span>
+                    <span
+                      v-if="JOB_TIER_BENEFITS[jp.tier].durationReduction > 0"
+                      class="inline-flex items-center gap-0.5 rounded-full border border-amber-500/25 bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400"
+                    >
+                      <Clock3 class="size-2.5" />
+                      -{{ JOB_TIER_BENEFITS[jp.tier].durationReduction }}%
+                    </span>
+                    <span
+                      v-if="JOB_TIER_BENEFITS[jp.tier].yieldBonus > 0"
+                      class="inline-flex items-center gap-0.5 rounded-full border border-violet-500/25 bg-violet-100 px-1.5 py-0.5 text-[10px] font-semibold text-violet-700 dark:bg-violet-500/15 dark:text-violet-400"
+                    >
+                      <Layers class="size-2.5" />
+                      +{{ JOB_TIER_BENEFITS[jp.tier].yieldBonus }}
+                    </span>
+                  </div>
+                  <span v-else class="ml-auto text-[10px] text-muted-foreground/50">
+                    No bonuses
+                  </span>
+                </div>
+
+                <!-- Progress bar with tier markers -->
+                <div class="space-y-0.5">
+                  <div
+                    class="relative h-3 overflow-hidden rounded-full border border-border/40 bg-muted/30 dark:border-transparent"
+                  >
+                    <div
+                      class="absolute inset-y-0 left-0 rounded-full transition-all duration-500"
+                      :style="{
+                        width: `${progressPercent(jp.score)}%`,
+                        backgroundColor: JOB_COLORS[jp.job.toLowerCase()],
+                      }"
+                    />
+                    <!-- Tier threshold markers -->
+                    <div
+                      v-for="t in [1, 2, 3, 4, 5]"
+                      :key="t"
+                      class="absolute inset-y-0 w-px bg-foreground/30"
+                      :style="{ left: `${targetPercent(t)}%` }"
+                    />
+                    <!-- Target marker -->
+                    <div
+                      v-if="(targetTiers[jp.job] ?? 0) > jp.tier"
+                      class="absolute inset-y-0 w-0.5 bg-primary shadow-sm shadow-primary/50"
+                      :style="{ left: `${targetPercent(targetTiers[jp.job])}%` }"
+                    />
+                  </div>
+                  <!-- Tier benefit labels below bar -->
+                  <div class="relative h-3.5">
+                    <span
+                      v-for="t in [1, 2, 3, 4, 5]"
+                      :key="t"
+                      class="absolute -translate-x-1/2 text-[8px] font-semibold"
+                      :class="
+                        jp.tier >= t
+                          ? 'text-emerald-600 dark:text-emerald-400'
+                          : 'text-muted-foreground/50'
+                      "
+                      :style="{ left: `${targetPercent(t)}%` }"
+                    >
+                      <Zap v-if="tierBenefitType(t) === 'xp'" class="mx-auto size-2.5" />
+                      <Clock3
+                        v-else-if="tierBenefitType(t) === 'duration'"
+                        class="mx-auto size-2.5"
+                      />
+                      <Layers v-else class="mx-auto size-2.5" />
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Score -->
+                <div class="text-[11px]">
+                  <span class="text-muted-foreground">
+                    <template v-if="jp.isMaxed">
+                      <span class="font-semibold text-emerald-600 dark:text-emerald-400"
+                        >All bonuses unlocked!</span
+                      >
+                    </template>
+                    <template v-else>
+                      {{ jp.score }}/{{ jp.nextThreshold }} ·
+                      <span class="font-semibold text-foreground/70"
+                        >{{ jp.pointsToNext }} pts</span
+                      >
+                      to next
+                    </template>
+                  </span>
+                </div>
+
+                <!-- Target selector -->
+                <div class="mt-1.5 flex gap-[3px]">
+                  <div
+                    v-for="t in [1, 2, 3, 4, 5]"
+                    :key="t"
+                    class="flex-1"
+                    @mouseenter="
+                      t > (maxAchievableTiers[jp.job] ?? 0) && jp.tier < t
+                        ? showTierTooltip($event)
+                        : undefined
+                    "
+                    @mouseleave="hideTierTooltip"
+                  >
+                    <button
+                      class="focus-ring inline-flex w-full items-center justify-center gap-0.5 rounded px-0.5 py-1 text-[10px] font-semibold transition"
+                      :class="
+                        (targetTiers[jp.job] ?? 0) === t
+                          ? 'bg-primary text-primary-foreground'
+                          : jp.tier >= t
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400'
+                            : 'bg-muted/50 text-muted-foreground hover:text-foreground'
+                      "
+                      :title="`Tier ${t}: ${jobTierLabel(t)}`"
+                      @click="setTargetTier(jp.job, (targetTiers[jp.job] ?? 0) === t ? 0 : t)"
+                    >
+                      <template v-if="jp.tier >= t">✓</template>
+                      <template v-else>
+                        <Zap v-if="tierBenefitType(t) === 'xp'" class="size-2.5" />
+                        <Clock3 v-else-if="tierBenefitType(t) === 'duration'" class="size-2.5" />
+                        <Layers v-else class="size-2.5" />
+                        <span class="hidden sm:inline">{{ tierIncrementalLabel(t) }}</span>
+                      </template>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══ Right: Creature Browser ═══ -->
+      <section
+        class="surface-card flex flex-col overflow-hidden"
+        :class="!isDesktop && mobileSection !== 'creatures' ? 'hidden' : ''"
+      >
+        <!-- Header -->
+        <div class="border-b border-border/70 px-4 py-3">
+          <h2 class="text-base font-bold">Select Creature</h2>
+        </div>
+
+        <!-- Filters -->
+        <div class="space-y-2 border-b border-border/70 px-4 py-3">
+          <input
+            v-model="creatureSearch"
+            type="text"
+            placeholder="Search creature"
+            class="focus-ring w-full rounded-lg border border-input bg-background/70 px-3 py-2 text-sm"
+          />
+
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              class="pill focus-ring gap-1.5"
+              :class="ownedOnly ? 'pill-active' : ''"
+              @click="ownedOnly = !ownedOnly"
+            >
+              <img :src="summonedIcon" alt="" class="size-4" loading="lazy" />
+              Summoned Only
+            </button>
+            <button
+              class="pill focus-ring gap-1.5"
+              :class="showExcludedCreatures ? 'pill-active' : ''"
+              @click="showExcludedCreatures = !showExcludedCreatures"
+            >
+              Show Excluded
+            </button>
+            <div
+              class="ml-auto flex items-center rounded-full border border-border bg-muted/40 px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+              aria-live="polite"
+            >
+              {{ displayRecommended.length }} creatures
+            </div>
+          </div>
+
+          <button
+            class="focus-ring inline-flex items-center gap-1.5 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+            :aria-expanded="showMoreCreatureFilters || hasSecondaryCreatureFilters"
+            @click="showMoreCreatureFilters = !showMoreCreatureFilters"
+          >
+            <ChevronDown
+              class="size-3.5 transition-transform"
+              :class="showMoreCreatureFilters || hasSecondaryCreatureFilters ? '' : '-rotate-90'"
+            />
+            More filters
+          </button>
+
+          <template v-if="showMoreCreatureFilters || hasSecondaryCreatureFilters">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground"
+                >Type</span
+              >
+              <button
+                v-for="type in creatureTypes"
+                :key="type"
+                class="pill focus-ring"
+                :class="selectedCreatureType === type ? 'pill-active' : ''"
+                @click="toggleCreatureType(type)"
+              >
+                <span
+                  class="mr-1.5 inline-block size-2 rounded-full"
+                  :class="selectedCreatureType === type ? 'ring-1 ring-white/60' : ''"
+                  :style="{ backgroundColor: typeColor(type) }"
+                />
+                {{ type }}
+              </button>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground"
+                >Tier</span
+              >
+              <button
+                v-for="tier in creatureTierOptions"
+                :key="tier"
+                class="pill focus-ring font-mono"
+                :class="
+                  !allCreatureTiersSelected && selectedCreatureTiers.includes(tier)
+                    ? 'pill-active'
+                    : ''
+                "
+                @click="toggleCreatureTier(tier)"
+              >
+                T{{ tier + 1 }}
+              </button>
+            </div>
+          </template>
+
+          <ActiveFilters
+            v-if="activeCreatureFilters.length"
+            :filters="activeCreatureFilters"
+            @remove="removeCreatureFilter"
+            @clear-all="clearCreatureFilters"
+          />
+        </div>
+
+        <!-- Creature list -->
+        <div class="flex-1 overflow-y-auto p-2">
+          <div
+            v-if="displayRecommended.length === 0"
+            class="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-7 text-center text-sm text-muted-foreground"
+          >
+            No creatures match your filters.
+          </div>
+          <div class="space-y-1">
+            <button
+              v-for="{ creature, score } in displayRecommended"
+              :key="creature.id"
+              class="focus-ring flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition"
+              :class="
+                hasEmptySlot
+                  ? 'border-border/50 bg-card/50 hover:border-accent/45 hover:bg-muted/25'
+                  : 'cursor-not-allowed border-border/30 bg-card/30 opacity-50'
+              "
+              @click="chooseCreature(creature)"
+            >
+              <!-- Image + assignment badge -->
+              <div class="relative size-12 shrink-0">
+                <img
+                  :src="getCreatureImage(creature)"
+                  :alt="creature.name"
+                  class="size-12 rounded-md border border-border object-cover"
+                  loading="lazy"
+                />
+                <!-- Tier badge -->
+                <span
+                  class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-[9px] font-bold text-muted-foreground shadow-sm"
+                >
+                  T{{ creature.tier + 1 }}
+                </span>
+                <img
+                  v-if="getCreatureStatus(creature.id) === 'helper'"
+                  :src="helpersIcon"
+                  alt="Helper"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+                <img
+                  v-else-if="getCreatureStatus(creature.id) === 'machine'"
+                  :src="machinesIcon"
+                  alt="Machine"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+              </div>
+
+              <!-- Name + status + Job scores -->
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-0.5">
+                  <span
+                    class="truncate text-sm font-semibold"
+                    :class="
+                      isAwakened(creature.id)
+                        ? 'text-pink-600 dark:text-pink-400'
+                        : 'text-foreground/80'
+                    "
+                    >{{ creature.name }}</span
+                  >
+                  <span
+                    v-if="isOwned(creature.id)"
+                    class="shrink-0 text-xs"
+                    :class="
+                      isAwakened(creature.id)
+                        ? 'text-pink-500 dark:text-pink-400'
+                        : 'text-amber-500 dark:text-amber-400'
+                    "
+                    >★</span
+                  >
+                  <span
+                    v-if="score > 0"
+                    class="ml-auto shrink-0 font-mono text-sm font-semibold text-primary"
+                    >{{ score }}</span
+                  >
+                </div>
+                <div class="mt-1 flex gap-1">
+                  <div
+                    v-for="job in SANCTUARY_JOBS"
+                    :key="job"
+                    class="flex flex-1 items-center gap-[2px]"
+                    :title="`${job}: ${creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0}`"
+                  >
+                    <img
+                      :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
+                      :alt="job"
+                      class="size-3.5 shrink-0 opacity-60"
+                      loading="lazy"
+                    />
+                    <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-muted/30">
+                      <div
+                        class="h-full rounded-full"
+                        :style="{
+                          width: `${((creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) / 10) * 100}%`,
+                          backgroundColor:
+                            (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
+                              ? JOB_COLORS[job.toLowerCase()]
+                              : 'transparent',
+                        }"
+                      />
+                    </div>
+                    <span
+                      class="w-3 shrink-0 text-right font-mono text-[10px] font-semibold"
+                      :class="
+                        (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
+                          ? 'text-muted-foreground'
+                          : 'text-muted-foreground/30'
+                      "
+                    >
+                      {{ creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0 }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <!-- Teleported tooltip for unreachable tiers -->
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-150 ease-out"
+      enter-from-class="opacity-0 translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition duration-100 ease-in"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 translate-y-1"
+    >
+      <div
+        v-if="tierTooltip"
+        class="pointer-events-none fixed z-50 -translate-x-1/2 whitespace-nowrap rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium text-card-foreground shadow-lg"
+        :style="{
+          left: `${tierTooltip.x}px`,
+          top: `${tierTooltip.y - 8}px`,
+          transform: 'translate(-50%, -100%)',
+        }"
+      >
+        Unreachable with current creatures
+        <div
+          class="absolute left-1/2 top-full -translate-x-1/2 border-[5px] border-transparent border-t-border"
+        />
+        <div
+          class="absolute left-1/2 top-full -translate-x-1/2 border-[4px] border-transparent border-t-card"
+          style="margin-top: -1px"
+        />
+      </div>
+    </Transition>
+  </Teleport>
+</template>


### PR DESCRIPTION
## Description

Adds a new Sanctuary page where users can manage their creature party and track gathering skill tier progress. The UX is designed around showing actual benefits (XP bonuses, duration reductions, yield bonuses) rather than opaque tier numbers, making it immediately clear what each tier unlock provides.

## Summary

- Add shared `sanctuaryConstants` module with tier thresholds, benefits data, colors, and `jobTierLabel` helper, replacing duplicated definitions in PlannerSettings and ConfigsView
- Add `useSanctuary` composable with party slot management, job score calculation, target tier tracking, greedy recommendation scoring, creature status detection, and max achievable tier computation
- Add Sanctuary page with benefit-centric skill cards showing colored pills (Zap/Clock3/Layers icons) for XP, duration, and yield bonuses with proper light/dark mode support
- Add progress bar tier markers with benefit-type icons, target markers using primary color, and an inline unreachable targets warning that respects active creature filters
- Add creature browser with awakened/summoned status indicators (pink/amber stars), helper/machine assignment badges (corner badge pattern matching Expeditions/Dungeons), tier dogear badges, and recommendation scoring
- Add Clear All (resets party, targets, and filters) and Clear Party buttons with layout-shift-free visibility toggling
- Register `/sanctuary` route and sidebar nav link
- Add 46 Vitest unit tests covering constants integrity, composable party management, job scores, targets, filtering, and recommendations
- Add 12 Playwright e2e tests covering page rendering, target selection, search filtering, tier badges, and filter expansion