### PR TITLE
Add expedition creatures to excluded set

### DIFF
--- a/src/components/expeditions/CreatureSelector.vue
+++ b/src/components/expeditions/CreatureSelector.vue
@@ -11,7 +11,7 @@ import type { Creature, ElementType, Expedition, ExpeditionStatWeights } from '@
 import { getCreatureImage } from '@/utils/creatureImages'
 import { toTitleCase, typeColor } from '@/utils/format'
 import { statAbbreviations } from '@/utils/formulas'
-import { sanctuaryIcon, helpersIcon, machinesIcon } from '@/utils/icons'
+import { sanctuaryIcon, helpersIcon, machinesIcon, expeditionsIcon } from '@/utils/icons'
 
 const props = defineProps<{
   recommendedCreatures: {
@@ -26,6 +26,7 @@ const props = defineProps<{
   sanctuaryCreatureIds: string[]
   helperCreatureIds: string[]
   machineCreatureIds: string[]
+  expeditionCreatureIds: Set<string>
   expeditionToolXpBonus: number
   showExcludedCreatures: boolean
 }>()
@@ -363,6 +364,13 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
               v-else-if="machineCreatureIds.includes(creature.id)"
               :src="machinesIcon"
               alt="Machine"
+              class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+              loading="lazy"
+            />
+            <img
+              v-else-if="expeditionCreatureIds.has(creature.id)"
+              :src="expeditionsIcon"
+              alt="Expedition"
               class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
               loading="lazy"
             />

--- a/src/composables/__tests__/useGameConfig.test.ts
+++ b/src/composables/__tests__/useGameConfig.test.ts
@@ -2,31 +2,54 @@ import { useGameConfig } from '@/composables/useGameConfig'
 
 describe('useGameConfig', () => {
   beforeEach(() => {
-    const { resetGameConfig } = useGameConfig()
+    const { resetGameConfig, expeditionParties } = useGameConfig()
     resetGameConfig()
+    expeditionParties.value = {}
   })
 
-  test('excludedCreatureIds combines sanctuary, helper, and machine IDs', () => {
-    const { excludedCreatureIds, setSanctuaryCreatures, setHelperCreatures, setMachineCreatures } =
-      useGameConfig()
+  test('excludedCreatureIds combines sanctuary, helper, machine, and expedition IDs', () => {
+    const {
+      excludedCreatureIds,
+      expeditionParties,
+      setSanctuaryCreatures,
+      setHelperCreatures,
+      setMachineCreatures,
+    } = useGameConfig()
     setSanctuaryCreatures(['s1', 's2'])
     setHelperCreatures(['h1'])
     setMachineCreatures(['m1'])
+    expeditionParties.value = { exp1: ['e1'] }
     expect(excludedCreatureIds.value.has('s1')).toBe(true)
     expect(excludedCreatureIds.value.has('s2')).toBe(true)
     expect(excludedCreatureIds.value.has('h1')).toBe(true)
     expect(excludedCreatureIds.value.has('m1')).toBe(true)
-    expect(excludedCreatureIds.value.size).toBe(4)
+    expect(excludedCreatureIds.value.has('e1')).toBe(true)
+    expect(excludedCreatureIds.value.size).toBe(5)
   })
 
   test('excludedCreatureIds deduplicates IDs that appear in multiple sources', () => {
-    const { excludedCreatureIds, setSanctuaryCreatures, setHelperCreatures, setMachineCreatures } =
-      useGameConfig()
+    const {
+      excludedCreatureIds,
+      expeditionParties,
+      setSanctuaryCreatures,
+      setHelperCreatures,
+      setMachineCreatures,
+    } = useGameConfig()
     setSanctuaryCreatures(['shared', 'unique-s'])
     setHelperCreatures(['shared', 'unique-h'])
     setMachineCreatures(['shared'])
+    expeditionParties.value = { exp1: ['shared'] }
     expect(excludedCreatureIds.value.has('shared')).toBe(true)
     expect(excludedCreatureIds.value.size).toBe(3)
+  })
+
+  test('expeditionCreatureIds flattens all expedition party members', () => {
+    const { expeditionCreatureIds, expeditionParties } = useGameConfig()
+    expeditionParties.value = { exp1: ['c1', 'c2'], exp2: ['c3'] }
+    expect(expeditionCreatureIds.value.has('c1')).toBe(true)
+    expect(expeditionCreatureIds.value.has('c2')).toBe(true)
+    expect(expeditionCreatureIds.value.has('c3')).toBe(true)
+    expect(expeditionCreatureIds.value.size).toBe(3)
   })
 
   test('setInventory stores a positive amount', () => {

--- a/src/composables/__tests__/usePartyPlanner.test.ts
+++ b/src/composables/__tests__/usePartyPlanner.test.ts
@@ -43,6 +43,7 @@ vi.mock('@/composables/useGameConfig', () => ({
   useGameConfig: () => ({
     excludedCreatureIds: ref(new Set<string>()),
     expeditionToolXpBonus: ref(1),
+    expeditionParties: ref({}),
   }),
 }))
 

--- a/src/composables/__tests__/useSanctuary.test.ts
+++ b/src/composables/__tests__/useSanctuary.test.ts
@@ -228,6 +228,13 @@ describe('useSanctuary', () => {
       const { getCreatureStatus } = useSanctuary()
       expect(getCreatureStatus('m1')).toBe('machine')
     })
+
+    test('returns "expedition" for expedition creatures', () => {
+      const { expeditionParties } = useGameConfig()
+      expeditionParties.value = { exp1: ['e1'] }
+      const { getCreatureStatus } = useSanctuary()
+      expect(getCreatureStatus('e1')).toBe('expedition')
+    })
   })
 
   describe('recommendedCreatures', () => {

--- a/src/composables/useExpeditions.ts
+++ b/src/composables/useExpeditions.ts
@@ -24,7 +24,7 @@ const expeditions = ref<Expedition[]>(expeditionsData as Expedition[])
 const biomes = ref<Biome[]>(biomesData as Biome[])
 
 export function useExpeditions(creatures: Creature[]) {
-  const { excludedCreatureIds, expeditionToolXpBonus } = useGameConfig()
+  const { excludedCreatureIds, expeditionToolXpBonus, expeditionParties } = useGameConfig()
   const showExcludedCreatures = ref(false)
   const searchQuery = ref('')
   const biomeFilter = ref<string | 'all'>('all')
@@ -33,7 +33,6 @@ export function useExpeditions(creatures: Creature[]) {
   const selectedTier = ref(1)
   const partySlots = ref<(Creature | null)[]>([])
   const activeSlotIndex = ref<number | null>(null)
-  const expeditionParties = useLocalStorage<Record<string, string[]>>('expedition-parties', {})
   const creatureLevels = useLocalStorage<Record<string, number>>('expedition-creature-levels', {})
 
   const filteredExpeditions = computed(() => {

--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -14,6 +14,7 @@ const sanctuaryCreatureIds = useLocalStorage<string[]>('config-sanctuary-creatur
 const helperCreatureIds = useLocalStorage<string[]>('config-helper-creatures', [])
 const machineCreatureIds = useLocalStorage<string[]>('config-machine-creature-ids', [])
 const expeditionToolXpBonus = useLocalStorage<number>('config-tool-xp-bonus', 1)
+const expeditionParties = useLocalStorage<Record<string, string[]>>('expedition-parties', {})
 
 const inventoryAmounts = useLocalStorage<Record<string, number>>('config-inventory', {})
 const gardenFlowers = useLocalStorage<Record<string, GardenFlowerEntry[]>>(
@@ -45,11 +46,20 @@ const skillLevels = useLocalStorage<Record<string, number>>('config-skill-levels
 
 export function useGameConfig() {
   const playerLevel = computed(() => getPlayerLevel(skillLevels.value))
+  const expeditionCreatureIds = computed(() => {
+    const set = new Set<string>()
+    for (const ids of Object.values(expeditionParties.value)) {
+      for (const id of ids) set.add(id)
+    }
+    return set
+  })
+
   const excludedCreatureIds = computed(() => {
     const set = new Set<string>()
     for (const id of sanctuaryCreatureIds.value) set.add(id)
     for (const id of helperCreatureIds.value) set.add(id)
     for (const id of machineCreatureIds.value) set.add(id)
+    for (const id of expeditionCreatureIds.value) set.add(id)
     return set
   })
 
@@ -193,6 +203,8 @@ export function useGameConfig() {
     sanctuaryCreatureIds,
     helperCreatureIds,
     machineCreatureIds,
+    expeditionParties,
+    expeditionCreatureIds,
     excludedCreatureIds,
     jobTiers,
     inventoryAmounts,

--- a/src/composables/usePartyPlanner.ts
+++ b/src/composables/usePartyPlanner.ts
@@ -28,8 +28,7 @@ export function usePartyPlanner(
 ) {
   const { creatures } = useCreatures()
   const { ownedCreatureIds, getLevel, isAwakened } = useCreatureCollection()
-  const { excludedCreatureIds, expeditionToolXpBonus } = useGameConfig()
-  const expeditionParties = useLocalStorage<Record<string, string[]>>('expedition-parties', {})
+  const { excludedCreatureIds, expeditionToolXpBonus, expeditionParties } = useGameConfig()
   const expeditionTiers = useLocalStorage<Record<string, number>>('expedition-tiers', {})
   const expeditionLoopCounts = useLocalStorage<Record<string, number>>('expedition-loop-counts', {})
   const { effectiveExpeditionTierSelections } = useExpeditionTierSelections()

--- a/src/composables/useSanctuary.ts
+++ b/src/composables/useSanctuary.ts
@@ -31,6 +31,7 @@ export function useSanctuary() {
     helperCreatureIds,
     machineCreatureIds,
     excludedCreatureIds,
+    expeditionCreatureIds,
     jobTiers,
     setSanctuaryCreatures,
   } = useGameConfig()
@@ -306,9 +307,10 @@ export function useSanctuary() {
     setSanctuaryCreatures([])
   }
 
-  function getCreatureStatus(id: string): 'helper' | 'machine' | null {
+  function getCreatureStatus(id: string): 'helper' | 'machine' | 'expedition' | null {
     if (helperCreatureIds.value.includes(id)) return 'helper'
     if (machineCreatureIds.value.includes(id)) return 'machine'
+    if (expeditionCreatureIds.value.has(id)) return 'expedition'
     return null
   }
 

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -30,7 +30,7 @@ import sawItemIcon from '@/assets/items/saw.webp'
 import stoneItemIcon from '@/assets/items/stone.webp'
 import twigItemIcon from '@/assets/items/twig.webp'
 
-export { helpersIcon, itemGridIcon, machinesIcon, sanctuaryIcon, upgradesIcon }
+export { expeditionsIcon, helpersIcon, itemGridIcon, machinesIcon, sanctuaryIcon, upgradesIcon }
 
 export const jobIcons: Record<string, string> = {
   chopping: choppingIcon,

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -15,7 +15,7 @@ import type { Creature, ElementType, ExpeditionStatKey, GatheringSubFocus } from
 import { getCreatureImage } from '@/utils/creatureImages'
 import { toTitleCase } from '@/utils/format'
 import { statAbbreviations, statLabels } from '@/utils/formulas'
-import { sanctuaryIcon, helpersIcon, machinesIcon, jobIcons } from '@/utils/icons'
+import { sanctuaryIcon, helpersIcon, machinesIcon, expeditionsIcon, jobIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 
 const route = useRoute()
@@ -24,7 +24,8 @@ const isDesktop = useMediaQuery('(min-width: 1024px)')
 
 
 const { creatures } = useCreatures()
-const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds } = useGameConfig()
+const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds, expeditionCreatureIds } =
+  useGameConfig()
 const { isOwned, isAwakened, collectionLevels } = useCreatureCollection()
 
 
@@ -965,6 +966,13 @@ const tierLevelReq = computed(() => {
                   v-else-if="machineCreatureIds.includes(creature.id)"
                   :src="machinesIcon"
                   alt="Machine"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+                <img
+                  v-else-if="expeditionCreatureIds.has(creature.id)"
+                  :src="expeditionsIcon"
+                  alt="Expedition"
                   class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
                   loading="lazy"
                 />

--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -34,8 +34,13 @@ const isDesktop = useMediaQuery('(min-width: 1024px)')
 
 
 const { creatures } = useCreatures()
-const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds, expeditionToolXpBonus } =
-  useGameConfig()
+const {
+  sanctuaryCreatureIds,
+  helperCreatureIds,
+  machineCreatureIds,
+  expeditionCreatureIds,
+  expeditionToolXpBonus,
+} = useGameConfig()
 const {
   filteredExpeditions,
   selectedExpedition,
@@ -580,6 +585,7 @@ function rowSelected(id: string): boolean {
         :sanctuary-creature-ids="sanctuaryCreatureIds"
         :helper-creature-ids="helperCreatureIds"
         :machine-creature-ids="machineCreatureIds"
+        :expedition-creature-ids="expeditionCreatureIds"
         :expedition-tool-xp-bonus="expeditionToolXpBonus"
         :show-excluded-creatures="showExcludedCreatures"
         @update:show-excluded-creatures="showExcludedCreatures = $event"

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -10,7 +10,7 @@ import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
 import { useSanctuary } from '@/composables/useSanctuary'
 import type { Creature, ElementType, Jobs } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { helpersIcon, machinesIcon } from '@/utils/icons'
+import { helpersIcon, machinesIcon, expeditionsIcon } from '@/utils/icons'
 import { jobIcons } from '@/utils/icons'
 import {
   MAX_SANCTUARY_SLOTS,
@@ -758,6 +758,13 @@ function chooseCreature(creature: Creature) {
                   v-else-if="getCreatureStatus(creature.id) === 'machine'"
                   :src="machinesIcon"
                   alt="Machine"
+                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                  loading="lazy"
+                />
+                <img
+                  v-else-if="getCreatureStatus(creature.id) === 'expedition'"
+                  :src="expeditionsIcon"
+                  alt="Expedition"
                   class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
                   loading="lazy"
                 />


### PR DESCRIPTION
## Description

Creatures assigned to expedition parties are now treated as excluded, alongside sanctuary, helper, and machine creatures. This lifts the `expeditionParties` state from local storage in individual composables into `useGameConfig` so it can be shared consistently, and adds expedition icon overlays on excluded creatures across all views.

## Summary

- Move `expeditionParties` local storage into `useGameConfig` and expose a computed `expeditionCreatureIds` set
- Include `expeditionCreatureIds` in the unified `excludedCreatureIds` set
- Show expedition icon badge on creature selectors in Sanctuary, Dungeons, and Expeditions views
- Extend `getCreatureStatus` in `useSanctuary` to return `'expedition'` for expedition creatures
- Add tests for expedition exclusion, deduplication, flattening, and creature status