### PR TITLE
Add tool speed mode support to craft planner

### DIFF
--- a/src/components/planner/PlannerListRow.vue
+++ b/src/components/planner/PlannerListRow.vue
@@ -3,8 +3,9 @@ import { computed, ref } from 'vue'
 
 import type { PlannerMethod, PlannerNode } from '@/types'
 import { itemTypeColor } from '@/utils/format'
-import { upgradesIcon, sanctuaryIcon, machinesIcon, itemGridIcon, sourceIcons } from '@/utils/icons'
+import { sourceIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
+import { extractModifierChips, type ModifierChip } from '@/utils/modifierChips'
 
 import PlannerRecommendation from './PlannerRecommendation.vue'
 
@@ -17,80 +18,11 @@ const props = defineProps<{
 }>()
 
 
-type ModifierChip = {
-  label: string
-  value: string
-  icon?: string
-  color: string
-  accentColor: string
-  subtitle: string
-  stats: string[]
-}
-
-
-function parseStats(value: string): string[] {
-  const inner = value.match(/\(([^)]+)\)/)
-  const raw = inner ? inner[1] : value
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-}
-
-
 const modifierChips = computed<ModifierChip[]>(() => {
   if (!props.activeMethod) return []
-  const chips: ModifierChip[] = []
-  for (const row of props.activeMethod.detailRows) {
-    if (row.label === 'Awaken Tree') {
-      chips.push({
-        label: row.label,
-        value: row.value,
-        icon: upgradesIcon,
-        color:
-          'border-cyan-600/35 bg-cyan-100 text-cyan-800 dark:border-cyan-400/40 dark:bg-cyan-400/20 dark:text-cyan-100',
-        accentColor: 'bg-cyan-500',
-        subtitle: 'Skill tree bonuses',
-        stats: parseStats(row.value),
-      })
-    } else if (row.label === 'Sanctuary') {
-      const tierMatch = row.value.match(/^T(\d+)/)
-      chips.push({
-        label: row.label,
-        value: row.value,
-        icon: sanctuaryIcon,
-        color:
-          'border-amber-600/35 bg-amber-100 text-amber-800 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100',
-        accentColor: 'bg-amber-500',
-        subtitle: tierMatch ? `Tier ${tierMatch[1]} job bonus` : 'Job tier bonus',
-        stats: parseStats(row.value),
-      })
-    } else if (row.label.startsWith('Machine')) {
-      const machineName = row.label.replace('Machine — ', '')
-      chips.push({
-        label: machineName,
-        value: row.value,
-        icon: sourceIcons[machineName] ?? machinesIcon,
-        color:
-          'border-orange-600/35 bg-orange-100 text-orange-800 dark:border-orange-400/40 dark:bg-orange-400/20 dark:text-orange-100',
-        accentColor: 'bg-orange-500',
-        subtitle: 'Passive machine production',
-        stats: [row.value],
-      })
-    } else if (row.label.startsWith('Fabrication')) {
-      chips.push({
-        label: 'Fab',
-        value: row.value,
-        icon: itemGridIcon,
-        color:
-          'border-violet-600/35 bg-violet-100 text-violet-800 dark:border-violet-400/40 dark:bg-violet-400/20 dark:text-violet-100',
-        accentColor: 'bg-violet-500',
-        subtitle: 'Passive fabrication output',
-        stats: [row.value],
-      })
-    }
-  }
-  return chips
+  return extractModifierChips(props.activeMethod.detailRows, props.activeMethod.title, {
+    compact: true,
+  })
 })
 
 

--- a/src/components/planner/PlannerTreeNode.vue
+++ b/src/components/planner/PlannerTreeNode.vue
@@ -4,8 +4,9 @@ import { computed, ref } from 'vue'
 
 import type { PlannerNode } from '@/types'
 import { itemTypeColor } from '@/utils/format'
-import { upgradesIcon, sanctuaryIcon, machinesIcon, itemGridIcon, sourceIcons } from '@/utils/icons'
+import { sourceIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
+import { extractModifierChips, type ModifierChip } from '@/utils/modifierChips'
 
 defineOptions({
   name: 'PlannerTreeNode',
@@ -46,82 +47,9 @@ const activeMethod = computed(() => {
 })
 
 
-// Modifier chips (Awaken, Sanctuary, Machine, Fabrication)
-type ModifierChip = {
-  label: string
-  value: string
-  icon?: string
-  color: string
-  accentColor: string
-  subtitle: string
-  stats: string[]
-}
-
-
-function parseStats(value: string): string[] {
-  // "T3 (-15% duration, +1 yield)" → extract inner part, or split on commas
-  const inner = value.match(/\(([^)]+)\)/)
-  const raw = inner ? inner[1] : value
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-}
-
-
 const modifierChips = computed<ModifierChip[]>(() => {
   if (!activeMethod.value) return []
-  const chips: ModifierChip[] = []
-  for (const row of activeMethod.value.detailRows) {
-    if (row.label === 'Awaken Tree') {
-      chips.push({
-        label: row.label,
-        value: row.value,
-        icon: upgradesIcon,
-        color:
-          'border-cyan-600/35 bg-cyan-100 text-cyan-800 dark:border-cyan-400/40 dark:bg-cyan-400/20 dark:text-cyan-100',
-        accentColor: 'bg-cyan-500',
-        subtitle: 'Skill tree bonuses',
-        stats: parseStats(row.value),
-      })
-    } else if (row.label === 'Sanctuary') {
-      const tierMatch = row.value.match(/^T(\d+)/)
-      chips.push({
-        label: row.label,
-        value: row.value,
-        icon: sanctuaryIcon,
-        color:
-          'border-amber-600/35 bg-amber-100 text-amber-800 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100',
-        accentColor: 'bg-amber-500',
-        subtitle: tierMatch ? `Tier ${tierMatch[1]} job bonus` : 'Job tier bonus',
-        stats: parseStats(row.value),
-      })
-    } else if (row.label.startsWith('Machine')) {
-      const machineName = row.label.replace('Machine — ', '')
-      chips.push({
-        label: machineName,
-        value: row.value,
-        icon: sourceIcons[machineName] ?? machinesIcon,
-        color:
-          'border-orange-600/35 bg-orange-100 text-orange-800 dark:border-orange-400/40 dark:bg-orange-400/20 dark:text-orange-100',
-        accentColor: 'bg-orange-500',
-        subtitle: 'Passive machine production',
-        stats: [row.value],
-      })
-    } else if (row.label.startsWith('Fabrication')) {
-      chips.push({
-        label: 'Fabrication',
-        value: row.value,
-        icon: itemGridIcon,
-        color:
-          'border-violet-600/35 bg-violet-100 text-violet-800 dark:border-violet-400/40 dark:bg-violet-400/20 dark:text-violet-100',
-        accentColor: 'bg-violet-500',
-        subtitle: 'Passive fabrication output',
-        stats: [row.value],
-      })
-    }
-  }
-  return chips
+  return extractModifierChips(activeMethod.value.detailRows, activeMethod.value.title)
 })
 
 

--- a/src/components/summoning-planner/SummoningObjectiveCard.vue
+++ b/src/components/summoning-planner/SummoningObjectiveCard.vue
@@ -5,17 +5,7 @@ import { computed, ref } from 'vue'
 import type { ItemType } from '@/types'
 import { itemTypeColor } from '@/utils/format'
 import { getItemImage } from '@/utils/itemImages'
-
-interface ModifierChipData {
-  label: string
-  value: string
-  icon?: string
-  color: string
-  accentColor: string
-  subtitle: string
-  stats: string[]
-}
-
+import type { ModifierChip } from '@/utils/modifierChips'
 
 const props = withDefaults(
   defineProps<{
@@ -26,7 +16,7 @@ const props = withDefaults(
     inventoryAmount: number
     sourceLabel: string
     sourceIcon?: string | null
-    modifiers?: ModifierChipData[]
+    modifiers?: ModifierChip[]
     compact?: boolean
   }>(),
   {
@@ -37,11 +27,11 @@ const props = withDefaults(
 
 
 const activeChipIndex = ref<number | null>(null)
-const activeChip = ref<ModifierChipData | null>(null)
+const activeChip = ref<ModifierChip | null>(null)
 const popoverStyle = ref<Record<string, string>>({})
 
 
-function onChipEnter(chip: ModifierChipData, index: number, event: MouseEvent) {
+function onChipEnter(chip: ModifierChip, index: number, event: MouseEvent) {
   activeChipIndex.value = index
   activeChip.value = chip
   const target = event.currentTarget as HTMLElement

--- a/src/composables/__tests__/buildPlannerGraphToolSpeed.test.ts
+++ b/src/composables/__tests__/buildPlannerGraphToolSpeed.test.ts
@@ -1,0 +1,225 @@
+import { buildPlannerGraph, type PlannerModifiers } from '@/composables/useCraftPlanner'
+
+/**
+ * Tests the exact craft time formulas in buildPlannerGraph for tool speed mode.
+ *
+ * knife: Workbench, craftTime = 4, outputAmount = 1, no machine source
+ * With machineLevels={} and fabricationAllocations={}, passive.rate = 0
+ * So localTimeSeconds = craftsNeeded * effectiveCraftTime exactly.
+ *
+ * Formula:
+ *   awakenReduction    = awakenSpeedTiers[ws] * 0.15
+ *   toolSpeedBonus     = toolSpeedBonuses[ws]  (fraction, e.g. 0.10)
+ *   speedReduction     = awakenReduction + toolSpeedBonus
+ *   effectiveCraftTime = max(craftTime * 0.01, craftTime * (1 - speedReduction))
+ *   localTimeSeconds   = craftsNeeded * effectiveCraftTime  (when passive.rate = 0)
+ */
+
+function emptyModifiers(overrides: Partial<PlannerModifiers> = {}): PlannerModifiers {
+  return {
+    gardenFlowers: {},
+    awakenGatherUpgrades: {},
+    awakenSpeedTiers: {},
+    toolSpeedBonuses: {},
+    jobTiers: {},
+    goldPerMinute: 0,
+    machineLevels: {},
+    fabricationAllocations: {},
+    expeditionTier: 1,
+    ...overrides,
+  }
+}
+
+function getCraftMethod(graph: ReturnType<typeof buildPlannerGraph>, workstation: string) {
+  const methods = Object.values(graph.methodsById)
+  const rootId = graph.root?.id
+  return methods.find((m) => m.nodeId === rootId && m.kind === 'craft' && m.title === workstation)!
+}
+
+describe('buildPlannerGraph — tool speed exact formulas', () => {
+  // knife: Workbench, craftTime=4, outputAmount=1, no machine → passive.rate=0
+
+  test('baseline: no speed bonuses, localTimeSeconds = craftTime', () => {
+    const graph = buildPlannerGraph('knife', 1, {}, emptyModifiers())
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // effectiveCraftTime = max(4 * 0.01, 4 * 1.0) = max(0.04, 4) = 4
+    // localTimeSeconds = 1 * 4 = 4
+    expect(method.localTimeSeconds).toBe(4)
+  })
+
+  test('tool speed 10% reduction (level 5 × 2%)', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({ toolSpeedBonuses: { Workbench: 0.1 } }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // effectiveCraftTime = max(0.04, 4 * 0.90) = max(0.04, 3.6) = 3.6
+    expect(method.localTimeSeconds).toBeCloseTo(3.6, 10)
+  })
+
+  test('tool speed 20% reduction (level 10 × 2%)', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({ toolSpeedBonuses: { Workbench: 0.2 } }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // effectiveCraftTime = max(0.04, 4 * 0.80) = max(0.04, 3.2) = 3.2
+    expect(method.localTimeSeconds).toBeCloseTo(3.2, 10)
+  })
+
+  test('awaken speed only: tier 2 = 30% reduction', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({ awakenSpeedTiers: { Workbench: 2 } }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // speedReduction = 2 * 0.15 = 0.30
+    // effectiveCraftTime = max(0.04, 4 * 0.70) = max(0.04, 2.8) = 2.8
+    expect(method.localTimeSeconds).toBeCloseTo(2.8, 10)
+  })
+
+  test('additive stacking: awaken tier 2 (30%) + tool speed 20% = 50%', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({
+        awakenSpeedTiers: { Workbench: 2 },
+        toolSpeedBonuses: { Workbench: 0.2 },
+      }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // speedReduction = 0.30 + 0.20 = 0.50
+    // effectiveCraftTime = max(0.04, 4 * 0.50) = max(0.04, 2) = 2
+    expect(method.localTimeSeconds).toBe(2)
+  })
+
+  test('additive stacking: awaken tier 4 (60%) + tool speed 20% = 80%', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({
+        awakenSpeedTiers: { Workbench: 4 },
+        toolSpeedBonuses: { Workbench: 0.2 },
+      }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // speedReduction = 0.60 + 0.20 = 0.80
+    // effectiveCraftTime = max(0.04, 4 * 0.20) = max(0.04, 0.8) = 0.8
+    expect(method.localTimeSeconds).toBeCloseTo(0.8, 10)
+  })
+
+  test('minimum floor clamps extreme reductions', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({
+        awakenSpeedTiers: { Workbench: 4 },
+        // 60% + 42% = 102% → would go negative without floor
+        toolSpeedBonuses: { Workbench: 0.42 },
+      }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    // speedReduction = 0.60 + 0.42 = 1.02
+    // craftTime * (1 - 1.02) = 4 * (-0.02) = -0.08
+    // Floor = 4 * 0.01 = 0.04
+    // effectiveCraftTime = max(0.04, -0.08) = 0.04
+    expect(method.localTimeSeconds).toBeCloseTo(0.04, 10)
+  })
+
+  test('quantity scales linearly', () => {
+    const modifiers = emptyModifiers({ toolSpeedBonuses: { Workbench: 0.1 } })
+
+    const graph1 = buildPlannerGraph('knife', 1, {}, modifiers)
+    const time1 = getCraftMethod(graph1, 'Workbench').localTimeSeconds!
+
+    const graph5 = buildPlannerGraph('knife', 5, {}, modifiers)
+    const time5 = getCraftMethod(graph5, 'Workbench').localTimeSeconds!
+
+    expect(time1).toBeCloseTo(3.6, 10)
+    expect(time5).toBeCloseTo(18, 10)
+    expect(time5).toBeCloseTo(time1 * 5, 10)
+  })
+
+  test('tool speed bonus for wrong workstation has no effect', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({ toolSpeedBonuses: { Furnace: 0.2, Stove: 0.2 } }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+
+    expect(method.localTimeSeconds).toBe(4)
+  })
+})
+
+describe('buildPlannerGraph — tool speed detail rows', () => {
+  test('Speed Tier row shows correct value with Speed unit', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({ awakenSpeedTiers: { Workbench: 3 } }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+    const row = method.detailRows.find((r) => r.label === 'Speed Tier')
+
+    expect(row).toBeDefined()
+    expect(row!.value).toBe('+45% Speed')
+  })
+
+  test('Tool Speed row shows correct value with Speed unit', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({ toolSpeedBonuses: { Workbench: 0.14 } }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+    const row = method.detailRows.find((r) => r.label === 'Tool Speed')
+
+    expect(row).toBeDefined()
+    expect(row!.value).toBe('+14% Speed')
+  })
+
+  test('both rows present when both bonuses active', () => {
+    const graph = buildPlannerGraph(
+      'knife',
+      1,
+      {},
+      emptyModifiers({
+        awakenSpeedTiers: { Workbench: 1 },
+        toolSpeedBonuses: { Workbench: 0.06 },
+      }),
+    )
+    const method = getCraftMethod(graph, 'Workbench')
+    const rows = method.detailRows
+
+    expect(rows.find((r) => r.label === 'Speed Tier')!.value).toBe('+15% Speed')
+    expect(rows.find((r) => r.label === 'Tool Speed')!.value).toBe('+6% Speed')
+  })
+
+  test('no speed rows when no bonuses', () => {
+    const graph = buildPlannerGraph('knife', 1, {}, emptyModifiers())
+    const method = getCraftMethod(graph, 'Workbench')
+
+    expect(method.detailRows.find((r) => r.label === 'Speed Tier')).toBeUndefined()
+    expect(method.detailRows.find((r) => r.label === 'Tool Speed')).toBeUndefined()
+  })
+})

--- a/src/composables/__tests__/useCraftPlannerToolSpeed.test.ts
+++ b/src/composables/__tests__/useCraftPlannerToolSpeed.test.ts
@@ -1,0 +1,210 @@
+import { ref } from 'vue'
+
+import { useCraftPlanner } from '@/composables/useCraftPlanner'
+import { useGameConfig } from '@/composables/useGameConfig'
+import { useTools } from '@/composables/useTools'
+
+/**
+ * coal: Furnace workstation, craftTime = 16 centiseconds, outputAmount = 1
+ * Tool: hammer (id) → Furnace (skillId), speedBonusPerLevel = 2% per level
+ */
+
+function getCraftMethod(planner: ReturnType<typeof useCraftPlanner>) {
+  const methods = planner.rootNode.value!.methods
+  return methods.find((m) => m.kind === 'craft' && m.title === 'Furnace')!
+}
+
+describe('useCraftPlanner — tool speed mode', () => {
+  beforeEach(() => {
+    const { resetGameConfig } = useGameConfig()
+    resetGameConfig()
+  })
+
+  test('baseline craft time without tool speed mode', () => {
+    const planner = useCraftPlanner(ref('coal'), ref(1))
+    const baseTime = getCraftMethod(planner).localTimeSeconds!
+    expect(baseTime).toBeGreaterThan(0)
+  })
+
+  test('craft time is unchanged when tool has level but speed mode is off', () => {
+    const { setToolLevels } = useGameConfig()
+    const plannerBefore = useCraftPlanner(ref('coal'), ref(1))
+    const timeBefore = getCraftMethod(plannerBefore).localTimeSeconds!
+
+    setToolLevels({ hammer: 10 })
+
+    const plannerAfter = useCraftPlanner(ref('coal'), ref(1))
+    const timeAfter = getCraftMethod(plannerAfter).localTimeSeconds!
+
+    expect(timeAfter).toBe(timeBefore)
+  })
+
+  test('craft time decreases when tool speed mode is enabled', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+
+    const plannerBase = useCraftPlanner(ref('coal'), ref(1))
+    const baseTime = getCraftMethod(plannerBase).localTimeSeconds!
+
+    setToolLevels({ hammer: 5 })
+    setToolSpeedModes({ Furnace: true })
+
+    const plannerSpeed = useCraftPlanner(ref('coal'), ref(1))
+    const speedTime = getCraftMethod(plannerSpeed).localTimeSeconds!
+
+    expect(speedTime).toBeLessThan(baseTime)
+  })
+
+  test('higher tool level gives greater speed reduction', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+    setToolSpeedModes({ Furnace: true })
+
+    setToolLevels({ hammer: 3 })
+    const plannerLow = useCraftPlanner(ref('coal'), ref(1))
+    const timeLow = getCraftMethod(plannerLow).localTimeSeconds!
+
+    setToolLevels({ hammer: 8 })
+    const plannerHigh = useCraftPlanner(ref('coal'), ref(1))
+    const timeHigh = getCraftMethod(plannerHigh).localTimeSeconds!
+
+    expect(timeHigh).toBeLessThan(timeLow)
+  })
+
+  test('tool speed stacks with awaken speed tiers for greater reduction', () => {
+    const { setToolLevels, setToolSpeedModes, setAwakenSpeedTier } = useGameConfig()
+
+    // Awaken only
+    setAwakenSpeedTier('Furnace', 2) // 30%
+    const plannerAwaken = useCraftPlanner(ref('coal'), ref(1))
+    const awakenTime = getCraftMethod(plannerAwaken).localTimeSeconds!
+
+    // Awaken + tool speed
+    setToolLevels({ hammer: 10 })
+    setToolSpeedModes({ Furnace: true }) // +20%
+    const plannerCombined = useCraftPlanner(ref('coal'), ref(1))
+    const combinedTime = getCraftMethod(plannerCombined).localTimeSeconds!
+
+    expect(combinedTime).toBeLessThan(awakenTime)
+  })
+
+  test('tool speed mode has no effect for level 0 tool', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+
+    const plannerBase = useCraftPlanner(ref('coal'), ref(1))
+    const baseTime = getCraftMethod(plannerBase).localTimeSeconds!
+
+    setToolLevels({ hammer: 0 })
+    setToolSpeedModes({ Furnace: true })
+
+    const plannerZero = useCraftPlanner(ref('coal'), ref(1))
+    const zeroTime = getCraftMethod(plannerZero).localTimeSeconds!
+
+    expect(zeroTime).toBe(baseTime)
+  })
+
+  test('tool speed mode for one workstation does not affect another', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+
+    const plannerBase = useCraftPlanner(ref('coal'), ref(1))
+    const baseTime = getCraftMethod(plannerBase).localTimeSeconds!
+
+    setToolLevels({ saw: 10 }) // Workbench tool, not Furnace
+    setToolSpeedModes({ Workbench: true })
+
+    const plannerOther = useCraftPlanner(ref('coal'), ref(1))
+    const otherTime = getCraftMethod(plannerOther).localTimeSeconds!
+
+    expect(otherTime).toBe(baseTime)
+  })
+
+  test('multiple crafts scale time linearly with tool speed', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+    setToolLevels({ hammer: 10 })
+    setToolSpeedModes({ Furnace: true })
+
+    const planner1 = useCraftPlanner(ref('coal'), ref(1))
+    const time1 = getCraftMethod(planner1).localTimeSeconds!
+
+    const planner10 = useCraftPlanner(ref('coal'), ref(10))
+    const time10 = getCraftMethod(planner10).localTimeSeconds!
+
+    expect(time10).toBeCloseTo(time1 * 10, 4)
+  })
+})
+
+describe('useCraftPlanner — tool speed detail rows', () => {
+  beforeEach(() => {
+    const { resetGameConfig } = useGameConfig()
+    resetGameConfig()
+  })
+
+  test('Tool Speed row shows +10% Speed at level 5', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+    setToolLevels({ hammer: 5 })
+    setToolSpeedModes({ Furnace: true })
+
+    const planner = useCraftPlanner(ref('coal'), ref(1))
+    const row = getCraftMethod(planner).detailRows.find((r) => r.label === 'Tool Speed')
+    expect(row).toBeDefined()
+    expect(row!.value).toBe('+10% Speed')
+  })
+
+  test('Tool Speed row shows +20% Speed at level 10', () => {
+    const { setToolLevels, setToolSpeedModes } = useGameConfig()
+    setToolLevels({ hammer: 10 })
+    setToolSpeedModes({ Furnace: true })
+
+    const planner = useCraftPlanner(ref('coal'), ref(1))
+    const row = getCraftMethod(planner).detailRows.find((r) => r.label === 'Tool Speed')
+    expect(row).toBeDefined()
+    expect(row!.value).toBe('+20% Speed')
+  })
+
+  test('Tool Speed row is absent when speed mode is off', () => {
+    const { setToolLevels } = useGameConfig()
+    setToolLevels({ hammer: 5 })
+
+    const planner = useCraftPlanner(ref('coal'), ref(1))
+    const row = getCraftMethod(planner).detailRows.find((r) => r.label === 'Tool Speed')
+    expect(row).toBeUndefined()
+  })
+
+  test('Speed Tier row includes Speed unit', () => {
+    const { setAwakenSpeedTier } = useGameConfig()
+    setAwakenSpeedTier('Furnace', 2)
+
+    const planner = useCraftPlanner(ref('coal'), ref(1))
+    const row = getCraftMethod(planner).detailRows.find((r) => r.label === 'Speed Tier')
+    expect(row).toBeDefined()
+    expect(row!.value).toBe('+30% Speed')
+  })
+
+  test('both Speed Tier and Tool Speed rows appear when both active', () => {
+    const { setToolLevels, setToolSpeedModes, setAwakenSpeedTier } = useGameConfig()
+    setToolLevels({ hammer: 5 })
+    setToolSpeedModes({ Furnace: true })
+    setAwakenSpeedTier('Furnace', 1)
+
+    const planner = useCraftPlanner(ref('coal'), ref(1))
+    const rows = getCraftMethod(planner).detailRows
+
+    expect(rows.find((r) => r.label === 'Speed Tier')).toBeDefined()
+    expect(rows.find((r) => r.label === 'Speed Tier')!.value).toBe('+15% Speed')
+    expect(rows.find((r) => r.label === 'Tool Speed')).toBeDefined()
+    expect(rows.find((r) => r.label === 'Tool Speed')!.value).toBe('+10% Speed')
+  })
+})
+
+describe('useTools — speed bonus', () => {
+  test('speedBonusPerLevel is 2', () => {
+    const { speedBonusPerLevel } = useTools()
+    expect(speedBonusPerLevel).toBe(2)
+  })
+
+  test('getSpeedBonus returns correct bonus per level', () => {
+    const { getSpeedBonus } = useTools()
+    expect(getSpeedBonus(0)).toBe(0)
+    expect(getSpeedBonus(1)).toBe(2)
+    expect(getSpeedBonus(5)).toBe(10)
+    expect(getSpeedBonus(10)).toBe(20)
+  })
+})

--- a/src/composables/useCraftPlanner.ts
+++ b/src/composables/useCraftPlanner.ts
@@ -3,6 +3,7 @@ import { computed, ref, type Ref } from 'vue'
 
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useGameConfig } from '@/composables/useGameConfig'
+import { useTools } from '@/composables/useTools'
 import {
   itemById,
   jobActivityIndex,
@@ -35,6 +36,7 @@ export interface PlannerModifiers {
   gardenFlowers: Record<string, GardenFlowerEntry[]>
   awakenGatherUpgrades: Record<string, AwakenGatherUpgrade>
   awakenSpeedTiers: Record<string, number> // per workstation, 0–4
+  toolSpeedBonuses: Record<string, number> // workstation → speed bonus fraction (e.g. 0.10 = +10%)
   jobTiers: Record<string, number>
   goldPerMinute: number
   machineLevels: Record<string, number>
@@ -160,7 +162,7 @@ function passiveDetailRows(passive: PassiveRateResult): { label: string; value: 
   }))
 }
 
-function buildPlannerGraph(
+export function buildPlannerGraph(
   targetItemId: string,
   targetQuantity: number,
   inventory: Record<string, number>,
@@ -283,7 +285,9 @@ function buildPlannerGraph(
         }
       })
 
-      const speedReduction = (modifiers.awakenSpeedTiers[recipe.workstation] ?? 0) * 0.15
+      const awakenReduction = (modifiers.awakenSpeedTiers[recipe.workstation] ?? 0) * 0.15
+      const toolSpeedBonus = modifiers.toolSpeedBonuses[recipe.workstation] ?? 0
+      const speedReduction = awakenReduction + toolSpeedBonus
       const effectiveCraftTime = Math.max(
         recipe.craftTime * 0.01,
         recipe.craftTime * (1 - speedReduction),
@@ -328,7 +332,15 @@ function buildPlannerGraph(
             ? [
                 {
                   label: 'Speed Tier',
-                  value: `+${modifiers.awakenSpeedTiers[recipe.workstation] * 15}%`,
+                  value: `+${modifiers.awakenSpeedTiers[recipe.workstation] * 15}% Speed`,
+                },
+              ]
+            : []),
+          ...((modifiers.toolSpeedBonuses[recipe.workstation] ?? 0) > 0
+            ? [
+                {
+                  label: 'Tool Speed',
+                  value: `+${Math.round(modifiers.toolSpeedBonuses[recipe.workstation] * 100)}% Speed`,
                 },
               ]
             : []),
@@ -1176,8 +1188,11 @@ export function useCraftPlanner(
     machineLevels: baseMachineLevels,
     fabricationAllocations: baseFabricationAllocations,
     awakenGoldLevel,
+    toolSpeedModes: baseToolSpeedModes,
+    toolLevels: baseToolLevels,
   } = useGameConfig()
 
+  const { workstationTools, speedBonusPerLevel } = useTools()
   const { ownedCreatureIds, isAwakened: isCreatureAwakened } = useCreatureCollection()
 
   // Fabrication simulated allocations (from Fabrication page, separate from save baseline)
@@ -1191,6 +1206,8 @@ export function useCraftPlanner(
   const jobTierOverrides = ref<Record<string, number> | null>(null)
   const machineLevelOverrides = ref<Record<string, number> | null>(null)
   const fabricationOverrides = ref<Record<string, number> | null>(null)
+  const toolSpeedModeOverrides = ref<Record<string, boolean> | null>(null)
+  const toolLevelOverrides = ref<Record<string, number> | null>(null)
 
   const inventoryAmounts = computed(() => inventoryOverrides.value ?? baseInventory.value)
   const gardenFlowers = computed(() => gardenOverrides.value ?? baseGarden.value)
@@ -1205,6 +1222,18 @@ export function useCraftPlanner(
         ...fabricationSimulated.value,
       },
   )
+  const toolSpeedModes = computed(() => toolSpeedModeOverrides.value ?? baseToolSpeedModes.value)
+  const toolLevels = computed(() => toolLevelOverrides.value ?? baseToolLevels.value)
+
+  const toolSpeedBonuses = computed(() => {
+    const bonuses: Record<string, number> = {}
+    for (const tool of workstationTools.value) {
+      if (toolSpeedModes.value[tool.skillId]) {
+        bonuses[tool.skillId] = ((toolLevels.value[tool.id] ?? 0) * speedBonusPerLevel) / 100
+      }
+    }
+    return bonuses
+  })
 
   const awakenedCount = computed(() => {
     let count = 0
@@ -1226,6 +1255,7 @@ export function useCraftPlanner(
     gardenFlowers: gardenFlowers.value,
     awakenGatherUpgrades: awakenGatherUpgrades.value,
     awakenSpeedTiers: awakenSpeedTiers.value,
+    toolSpeedBonuses: toolSpeedBonuses.value,
     jobTiers: jobTiers.value,
     goldPerMinute: goldPerMinute.value,
     machineLevels: machineLevels.value,

--- a/src/utils/modifierChips.ts
+++ b/src/utils/modifierChips.ts
@@ -1,0 +1,114 @@
+import {
+  upgradesIcon,
+  sanctuaryIcon,
+  machinesIcon,
+  itemGridIcon,
+  sourceIcons,
+  toolIcons,
+} from '@/utils/icons'
+
+export interface ModifierChip {
+  label: string
+  value: string
+  icon?: string
+  color: string
+  accentColor: string
+  subtitle: string
+  stats: string[]
+}
+
+const workstationToolId: Record<string, string> = {
+  Furnace: 'hammer',
+  Workbench: 'saw',
+  Stove: 'knife',
+}
+
+function parseStats(value: string): string[] {
+  const inner = value.match(/\(([^)]+)\)/)
+  const raw = inner ? inner[1] : value
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+export function extractModifierChips(
+  detailRows: { label: string; value: string }[],
+  methodTitle?: string,
+  options?: { compact?: boolean },
+): ModifierChip[] {
+  const chips: ModifierChip[] = []
+  for (const row of detailRows) {
+    if (row.label === 'Awaken Tree') {
+      chips.push({
+        label: row.label,
+        value: row.value,
+        icon: upgradesIcon,
+        color:
+          'border-cyan-600/35 bg-cyan-100 text-cyan-800 dark:border-cyan-400/40 dark:bg-cyan-400/20 dark:text-cyan-100',
+        accentColor: 'bg-cyan-500',
+        subtitle: 'Skill tree bonuses',
+        stats: parseStats(row.value),
+      })
+    } else if (row.label === 'Sanctuary') {
+      const tierMatch = row.value.match(/^T(\d+)/)
+      chips.push({
+        label: row.label,
+        value: row.value,
+        icon: sanctuaryIcon,
+        color:
+          'border-amber-600/35 bg-amber-100 text-amber-800 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100',
+        accentColor: 'bg-amber-500',
+        subtitle: tierMatch ? `Tier ${tierMatch[1]} job bonus` : 'Job tier bonus',
+        stats: parseStats(row.value),
+      })
+    } else if (row.label.startsWith('Machine')) {
+      const machineName = row.label.replace('Machine — ', '')
+      chips.push({
+        label: machineName,
+        value: row.value,
+        icon: sourceIcons[machineName] ?? machinesIcon,
+        color:
+          'border-orange-600/35 bg-orange-100 text-orange-800 dark:border-orange-400/40 dark:bg-orange-400/20 dark:text-orange-100',
+        accentColor: 'bg-orange-500',
+        subtitle: 'Passive machine production',
+        stats: [row.value],
+      })
+    } else if (row.label.startsWith('Fabrication')) {
+      chips.push({
+        label: options?.compact ? 'Fab' : 'Fabrication',
+        value: row.value,
+        icon: itemGridIcon,
+        color:
+          'border-violet-600/35 bg-violet-100 text-violet-800 dark:border-violet-400/40 dark:bg-violet-400/20 dark:text-violet-100',
+        accentColor: 'bg-violet-500',
+        subtitle: 'Passive fabrication output',
+        stats: [row.value],
+      })
+    } else if (row.label === 'Speed Tier') {
+      chips.push({
+        label: 'Speed Tier',
+        value: row.value,
+        icon: upgradesIcon,
+        color:
+          'border-emerald-600/35 bg-emerald-100 text-emerald-800 dark:border-emerald-400/40 dark:bg-emerald-400/20 dark:text-emerald-100',
+        accentColor: 'bg-emerald-500',
+        subtitle: 'Awaken speed upgrade',
+        stats: [row.value],
+      })
+    } else if (row.label === 'Tool Speed') {
+      const toolId = methodTitle ? workstationToolId[methodTitle] : undefined
+      chips.push({
+        label: 'Tool Speed',
+        value: row.value,
+        icon: toolId ? toolIcons[toolId] : upgradesIcon,
+        color:
+          'border-teal-600/35 bg-teal-100 text-teal-800 dark:border-teal-400/40 dark:bg-teal-400/20 dark:text-teal-100',
+        accentColor: 'bg-teal-500',
+        subtitle: 'Tool speed mode bonus',
+        stats: [row.value],
+      })
+    }
+  }
+  return chips
+}

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -17,6 +17,7 @@ import LevelPlannerCreaturePicker from '@/components/level-planner/LevelPlannerC
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
+import { useTools } from '@/composables/useTools'
 import expeditionsData from '@/data/expeditions.json'
 import type { Expedition, GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
@@ -68,6 +69,7 @@ const {
   setExpeditionCompletions,
   setExpeditionToolXpBonus,
   toolLevels,
+  toolSpeedModes,
   machineLevels,
   fabricationAllocations,
   setToolLevels,
@@ -85,6 +87,9 @@ const {
   setSkillLevels,
   resetSkillLevels,
 } = useGameConfig()
+
+
+const { getToolById, speedBonusPerLevel } = useTools()
 
 
 const MACHINES_MAX = 9
@@ -2491,8 +2496,37 @@ function updateAwakenSpeed(ws: string, delta: number) {
               />
               {{ toolId.replace(/-/g, ' ') }}
             </span>
-            <span class="text-xs tabular-nums text-muted-foreground">
-              Level {{ level }}/10 (+{{ level * 5 }}% XP)
+            <span class="flex items-center gap-2">
+              <span class="text-xs tabular-nums text-muted-foreground"> Level {{ level }}/10 </span>
+              <span
+                v-if="getToolById(toolId)?.category === 'workstation'"
+                class="cursor-pointer rounded px-1.5 py-0.5 text-xs font-semibold transition"
+                :class="
+                  toolSpeedModes[getToolById(toolId)!.skillId]
+                    ? 'bg-emerald-500/15 text-emerald-400'
+                    : 'bg-muted/50 text-muted-foreground hover:text-foreground'
+                "
+                :title="
+                  toolSpeedModes[getToolById(toolId)!.skillId]
+                    ? 'Speed Mode — click to switch to XP mode'
+                    : 'XP Mode — click to switch to Speed mode'
+                "
+                @click="
+                  setToolSpeedModes({
+                    ...toolSpeedModes,
+                    [getToolById(toolId)!.skillId]: !toolSpeedModes[getToolById(toolId)!.skillId],
+                  })
+                "
+              >
+                {{
+                  toolSpeedModes[getToolById(toolId)!.skillId]
+                    ? `+${(level as number) * speedBonusPerLevel}% Spd`
+                    : `+${(level as number) * 5}% XP`
+                }}
+              </span>
+              <span v-else class="text-xs text-muted-foreground">
+                +{{ (level as number) * 5 }}% XP
+              </span>
             </span>
           </div>
           <div

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -38,16 +38,10 @@ import {
   getLootAmount,
   getRecommendedCreatures,
 } from '@/utils/formulas'
-import {
-  expeditionTierIcons,
-  itemGridIcon,
-  machinesIcon,
-  sanctuaryIcon,
-  sourceIcons,
-  upgradesIcon,
-} from '@/utils/icons'
+import { expeditionTierIcons, sourceIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 import { mergeSchedules } from '@/utils/mergeSchedules'
+import { extractModifierChips, type ModifierChip } from '@/utils/modifierChips'
 import { computePriorityWaves } from '@/utils/prioritySteps'
 
 const isDesktop = useMediaQuery('(min-width: 1024px)')
@@ -929,7 +923,7 @@ const goldInventory = computed(() => gameConfig.inventoryAmounts.value['gold'] ?
 const hasCurrencyGroup = computed(() => groupedCosts.value.some((g) => g.group === 'Currency'))
 
 
-const goldModifiers = computed<ModifierChipData[]>(() => {
+const goldModifiers = computed<ModifierChip[]>(() => {
   if (goldPerMinute.value <= 0) return []
   return [
     {
@@ -954,82 +948,6 @@ const goldModifiers = computed<ModifierChipData[]>(() => {
 
 
 // --- Flattened list of all nodes across all trees ---
-interface ModifierChipData {
-  label: string
-  value: string
-  icon?: string
-  color: string
-  accentColor: string
-  subtitle: string
-  stats: string[]
-}
-
-
-function parseModifierStats(value: string): string[] {
-  const inner = value.match(/\(([^)]+)\)/)
-  const raw = inner ? inner[1] : value
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-}
-
-
-function extractModifierChips(detailRows: { label: string; value: string }[]): ModifierChipData[] {
-  const chips: ModifierChipData[] = []
-  for (const row of detailRows) {
-    if (row.label === 'Awaken Tree') {
-      chips.push({
-        label: row.label,
-        value: row.value,
-        icon: upgradesIcon,
-        color:
-          'border-cyan-600/35 bg-cyan-100 text-cyan-800 dark:border-cyan-400/40 dark:bg-cyan-400/20 dark:text-cyan-100',
-        accentColor: 'bg-cyan-500',
-        subtitle: 'Skill tree bonuses',
-        stats: parseModifierStats(row.value),
-      })
-    } else if (row.label === 'Sanctuary') {
-      const tierMatch = row.value.match(/^T(\d+)/)
-      chips.push({
-        label: row.label,
-        value: row.value,
-        icon: sanctuaryIcon,
-        color:
-          'border-amber-600/35 bg-amber-100 text-amber-800 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-100',
-        accentColor: 'bg-amber-500',
-        subtitle: tierMatch ? `Tier ${tierMatch[1]} job bonus` : 'Job tier bonus',
-        stats: parseModifierStats(row.value),
-      })
-    } else if (row.label.startsWith('Machine')) {
-      const machineName = row.label.replace('Machine — ', '')
-      chips.push({
-        label: machineName,
-        value: row.value,
-        icon: sourceIcons[machineName] ?? machinesIcon,
-        color:
-          'border-orange-600/35 bg-orange-100 text-orange-800 dark:border-orange-400/40 dark:bg-orange-400/20 dark:text-orange-100',
-        accentColor: 'bg-orange-500',
-        subtitle: 'Passive machine production',
-        stats: [row.value],
-      })
-    } else if (row.label.startsWith('Fabrication')) {
-      chips.push({
-        label: 'Fabrication',
-        value: row.value,
-        icon: itemGridIcon,
-        color:
-          'border-violet-600/35 bg-violet-100 text-violet-800 dark:border-violet-400/40 dark:bg-violet-400/20 dark:text-violet-100',
-        accentColor: 'bg-violet-500',
-        subtitle: 'Passive fabrication output',
-        stats: [row.value],
-      })
-    }
-  }
-  return chips
-}
-
-
 interface FlatListEntry {
   itemId: string
   itemName: string
@@ -1040,7 +958,7 @@ interface FlatListEntry {
   sourceIcon: string | null
   sourceGroup: SourceGroup
   gatherJob: string | null
-  modifiers: ModifierChipData[]
+  modifiers: ModifierChip[]
   maxDepth: number
 }
 
@@ -1079,7 +997,9 @@ const flatListEntries = computed(() => {
         sourceIcon: source.icon,
         sourceGroup: group,
         gatherJob: gatherInfo?.jobId ?? null,
-        modifiers: activeMethod ? extractModifierChips(activeMethod.detailRows) : [],
+        modifiers: activeMethod
+          ? extractModifierChips(activeMethod.detailRows, activeMethod.title)
+          : [],
         maxDepth: node.depth,
       })
     }


### PR DESCRIPTION
## Description

The craft planner now factors in workstation tool speed bonuses when calculating crafting times. When a tool is in speed mode, the planner reduces effective craft time by the tool's speed bonus (2% per level, up to 20% at level 10), stacking additively with awaken speed tiers. This also adds speed mode toggles to the config page and consolidates duplicated modifier chip logic into a shared utility.

Closes #82

## Summary
- Add `toolSpeedBonuses` field to `PlannerModifiers` and wire `toolSpeedModes`/`toolLevels` from `useGameConfig` into `useCraftPlanner` with override refs
- Update craft time formula to additively stack tool speed bonus with awaken speed reduction, respecting the minimum craft time floor
- Add "Tool Speed" and "Speed Tier" detail rows with `+X% Speed` unit labels
- Add clickable speed/XP mode toggle on workstation tool rows in ConfigsView
- Extract `extractModifierChips` utility from three duplicated copies in PlannerTreeNode, PlannerListRow, and SummoningPlannerView into `src/utils/modifierChips.ts`
- Add Speed Tier (emerald) and Tool Speed (teal, workstation tool icon) modifier chips across all planner views
- Add 28 tests: integration tests via `useCraftPlanner` and exact formula tests via `buildPlannerGraph` covering additive stacking, floor clamping, workstation isolation, and detail row content