### PR TITLE
Integrate workstation queued recipes into planners

### DIFF
--- a/e2e/fixtures/save.json
+++ b/e2e/fixtures/save.json
@@ -38,5 +38,49 @@
     "expedition-type-1": { "1": 25, "2": 10 }
   },
   "activeExpeditions": [],
-  "tools": { "sword": 2 }
+  "tools": { "sword": 2 },
+  "furnace": {
+    "isActive": true,
+    "item": { "id": "coal" },
+    "amount": 100,
+    "completedItems": 20,
+    "speedMode": true,
+    "queue": [
+      {
+        "id": "q1",
+        "itemId": "coal",
+        "amount": 100,
+        "recipe": { "outputAmount": 2 },
+        "singleItemDuration": 3.84
+      },
+      {
+        "id": "q2",
+        "itemId": "copper-bar",
+        "amount": 50,
+        "recipe": { "outputAmount": 1 },
+        "singleItemDuration": 7.68
+      }
+    ]
+  },
+  "stove": {
+    "isActive": false,
+    "queue": [],
+    "speedMode": false
+  },
+  "workbench": {
+    "isActive": true,
+    "item": { "id": "leather" },
+    "amount": 30,
+    "completedItems": 0,
+    "speedMode": false,
+    "queue": [
+      {
+        "id": "q3",
+        "itemId": "leather",
+        "amount": 30,
+        "recipe": { "outputAmount": 1 },
+        "singleItemDuration": 7.68
+      }
+    ]
+  }
 }

--- a/src/components/planner/PlannerGantt.vue
+++ b/src/components/planner/PlannerGantt.vue
@@ -27,10 +27,20 @@ function humanAmount(n: number): string {
 }
 
 
+/** Get queue offset time for a resource (workstation name like "Furnace") */
+function queueOffsetFor(resource: string): number {
+  return props.queueOffsets?.[resource] ?? 0
+}
+
+
 const props = defineProps<{
   schedule: PlannerSchedule
   nodesById: Record<string, PlannerNode>
   selectedNodeId: string | null
+  /** Queue time offsets per workstation (e.g. { Furnace: 50650 }) */
+  queueOffsets?: Record<string, number>
+  /** Queued item amounts per itemId */
+  queuedAmounts?: Record<string, number>
 }>()
 
 
@@ -261,7 +271,7 @@ const activeTaskNode = computed(() => {
 })
 
 
-/** Total required amount across all merged nodes (for consolidated bars). */
+/** Total required amount across all merged nodes (for consolidated bars), minus queued. */
 const activeTaskAmount = computed(() => {
   if (!activeTask.value) return null
   const task = activeTask.value as ScheduledTask & { _mergedNodeIds?: string[] }
@@ -271,7 +281,11 @@ const activeTaskAmount = computed(() => {
     const node = props.nodesById[id]
     if (node) total += node.requiredAmount
   }
-  return total > 0 ? total : (activeTaskNode.value?.requiredAmount ?? null)
+  const raw = total > 0 ? total : (activeTaskNode.value?.requiredAmount ?? null)
+  if (raw == null) return null
+  const itemId = activeTask.value.itemId
+  const queued = props.queuedAmounts?.[itemId] ?? 0
+  return Math.max(0, raw - queued)
 })
 
 
@@ -455,6 +469,22 @@ function barHighlightClasses(task: ScheduledTask): string {
               :style="{ minWidth: laneMinWidth, minHeight: '44px' }"
               @click.self="closePopover"
             >
+              <!-- Queue offset bar -->
+              <div
+                v-if="queueOffsetFor(group.resources[0]) > 0"
+                class="gantt-queue-bar absolute bottom-2 top-2 rounded-lg border border-sky-500/40"
+                :style="{
+                  left: '0%',
+                  width: `${Math.max(0.3, (queueOffsetFor(group.resources[0]) / schedule.totalTime) * 100)}%`,
+                }"
+                :title="`Queue: ${formatDuration(queueOffsetFor(group.resources[0]))}`"
+              >
+                <span
+                  class="absolute inset-0 flex items-center justify-center text-[10px] font-semibold text-sky-600 dark:text-sky-400"
+                >
+                  Queue
+                </span>
+              </div>
               <button
                 v-for="task in tasksByResource[group.resources[0]]"
                 :key="task.nodeId"
@@ -586,6 +616,22 @@ function barHighlightClasses(task: ScheduledTask): string {
               :style="{ minWidth: laneMinWidth, minHeight: '44px' }"
               @click.self="closePopover"
             >
+              <!-- Queue offset bar -->
+              <div
+                v-if="queueOffsetFor(resource) > 0"
+                class="gantt-queue-bar absolute bottom-2 top-2 rounded-lg border border-sky-500/40"
+                :style="{
+                  left: '0%',
+                  width: `${Math.max(0.3, (queueOffsetFor(resource) / schedule.totalTime) * 100)}%`,
+                }"
+                :title="`Queue: ${formatDuration(queueOffsetFor(resource))}`"
+              >
+                <span
+                  class="absolute inset-0 flex items-center justify-center text-[10px] font-semibold text-sky-600 dark:text-sky-400"
+                >
+                  Queue
+                </span>
+              </div>
               <button
                 v-for="task in tasksByResource[resource]"
                 :key="task.nodeId"
@@ -767,6 +813,17 @@ function barHighlightClasses(task: ScheduledTask): string {
 .popover-leave-to {
   opacity: 0;
   transform: translateY(-4px);
+}
+
+/* Queue offset bar — diagonal stripe pattern */
+.gantt-queue-bar {
+  background: repeating-linear-gradient(
+    -45deg,
+    rgb(56 189 248 / 0.08),
+    rgb(56 189 248 / 0.08) 4px,
+    rgb(56 189 248 / 0.18) 4px,
+    rgb(56 189 248 / 0.18) 8px
+  );
 }
 
 /* Dependency highlighting */

--- a/src/components/planner/PlannerListRow.vue
+++ b/src/components/planner/PlannerListRow.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   node: PlannerNode
   activeMethod: PlannerMethod | null
   inventoryAmount: number
+  queuedAmount?: number
   recommendation: { text: string } | null
   subtreeCost: number | null
 }>()
@@ -142,6 +143,55 @@ function onChipLeave() {
   activeChipIndex.value = null
   activeChip.value = null
 }
+
+
+const totalNeeded = computed(() => props.node.requiredAmount + props.inventoryAmount)
+
+
+const ownedPct = computed(() =>
+  Math.min(100, Math.round((props.inventoryAmount / Math.max(1, totalNeeded.value)) * 100)),
+)
+
+
+const queuedPct = computed(() => {
+  if (!props.queuedAmount || props.queuedAmount <= 0) return 0
+  return Math.min(
+    100 - ownedPct.value,
+    Math.round((props.queuedAmount / Math.max(1, totalNeeded.value)) * 100),
+  )
+})
+
+
+const barPopoverSegment = ref<'owned' | 'queued' | null>(null)
+const barPopoverStyle = ref<Record<string, string>>({})
+
+
+function onSegmentEnter(segment: 'owned' | 'queued', event: MouseEvent) {
+  barPopoverSegment.value = segment
+  updateBarPopoverPosition(event)
+}
+
+
+function onSegmentMove(event: MouseEvent) {
+  if (!barPopoverSegment.value) return
+  updateBarPopoverPosition(event)
+}
+
+
+function updateBarPopoverPosition(event: MouseEvent) {
+  const POPOVER_WIDTH = 180
+  const GAP = 12
+  const viewportWidth = document.documentElement.clientWidth
+  let top = event.clientY + GAP
+  let left = event.clientX - POPOVER_WIDTH / 2
+  left = Math.max(GAP, Math.min(left, viewportWidth - POPOVER_WIDTH - GAP))
+  barPopoverStyle.value = { position: 'fixed', top: `${top}px`, left: `${left}px` }
+}
+
+
+function onSegmentLeave() {
+  barPopoverSegment.value = null
+}
 </script>
 
 <template>
@@ -202,6 +252,27 @@ function onChipLeave() {
             activeMethod.title
           }}</span>
         </div>
+        <!-- Progress bar -->
+        <div class="h-1 overflow-hidden rounded-full bg-border/30">
+          <div class="flex h-full">
+            <div
+              class="h-full rounded-l-full bg-amber-400 transition-all duration-300"
+              :class="{ 'rounded-r-full': queuedPct === 0 }"
+              :style="{ width: `${ownedPct}%` }"
+              @mouseenter="onSegmentEnter('owned', $event)"
+              @mousemove="onSegmentMove"
+              @mouseleave="onSegmentLeave"
+            />
+            <div
+              v-if="queuedPct > 0"
+              class="h-full rounded-r-full bg-sky-400 transition-all duration-300"
+              :style="{ width: `${queuedPct}%` }"
+              @mouseenter="onSegmentEnter('queued', $event)"
+              @mousemove="onSegmentMove"
+              @mouseleave="onSegmentLeave"
+            />
+          </div>
+        </div>
       </div>
 
       <!-- Right side: cost -->
@@ -224,6 +295,32 @@ function onChipLeave() {
     <!-- Recommendation hint -->
     <PlannerRecommendation v-if="recommendation" :text="recommendation.text" class="mx-1" />
   </div>
+
+  <!-- Bar segment popover -->
+  <Teleport to="body">
+    <Transition name="popover">
+      <div
+        v-if="barPopoverSegment !== null"
+        class="w-45 pointer-events-none z-50 overflow-hidden rounded-xl border border-border/70 bg-card shadow-xl shadow-black/30"
+        :style="barPopoverStyle"
+      >
+        <div class="flex items-center gap-1.5 px-3 py-2">
+          <template v-if="barPopoverSegment === 'owned'">
+            <span class="font-mono text-xs font-bold text-amber-600 dark:text-amber-400">
+              {{ inventoryAmount.toLocaleString() }}
+            </span>
+            <span class="text-[11px] text-muted-foreground">have</span>
+          </template>
+          <template v-else-if="barPopoverSegment === 'queued'">
+            <span class="font-mono text-xs font-bold text-sky-600 dark:text-sky-400">
+              {{ (queuedAmount ?? 0).toLocaleString() }}
+            </span>
+            <span class="text-[11px] text-muted-foreground">queued</span>
+          </template>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
 
   <!-- Modifier chip popover -->
   <Teleport to="body">

--- a/src/components/planner/PlannerListView.vue
+++ b/src/components/planner/PlannerListView.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   nodesById: Record<string, PlannerNode>
   activeMethodIdByNode: Record<string, string | null>
   inventoryAmounts: Record<string, number>
+  queuedAmounts?: Record<string, number>
   getActiveMethod: (nodeId: string) => PlannerMethod | null
   recommendations: Record<string, { text: string }>
 }>()
@@ -157,6 +158,7 @@ defineExpose({ collapseAll, expandAll })
         :node="node"
         :active-method="getActiveMethod(node.id)"
         :inventory-amount="inventoryAmounts[node.itemId] ?? 0"
+        :queued-amount="queuedAmounts?.[node.itemId] ?? 0"
         :recommendation="recommendations[node.id] ?? null"
         :subtree-cost="subtreeCostForNode(node)"
       />

--- a/src/components/planner/PlannerTreeNode.vue
+++ b/src/components/planner/PlannerTreeNode.vue
@@ -21,6 +21,7 @@ const props = withDefaults(
     selectedMethodId: string | null
     collapsedNodeIds: Set<string>
     inventoryAmounts: Record<string, number>
+    queuedAmounts?: Record<string, number>
     completionTimeByNode: Record<string, number>
     nodeAnnotations?: Record<string, string>
     subtreeCostByNode?: Record<string, number>
@@ -30,6 +31,7 @@ const props = withDefaults(
   {
     nodeAnnotations: () => ({}),
     subtreeCostByNode: () => ({}),
+    queuedAmounts: () => ({}),
     forceCollapsible: false,
     recommendations: () => ({}),
   },
@@ -37,7 +39,9 @@ const props = withDefaults(
 
 
 const stockOnHand = computed(() => props.inventoryAmounts[props.node.itemId] ?? 0)
+const queuedForItem = computed(() => props.queuedAmounts?.[props.node.itemId] ?? 0)
 const totalNeeded = computed(() => props.node.requiredAmount + stockOnHand.value)
+const deficit = computed(() => Math.max(0, props.node.requiredAmount - queuedForItem.value))
 
 
 const activeMethod = computed(() => {
@@ -153,6 +157,38 @@ function onChipEnter(chip: ModifierChip, index: number, event: MouseEvent) {
 function onChipLeave() {
   activeChipIndex.value = null
   activeChip.value = null
+}
+
+
+const barPopoverSegment = ref<'owned' | 'queued' | null>(null)
+const barPopoverStyle = ref<Record<string, string>>({})
+
+
+function onSegmentEnter(segment: 'owned' | 'queued', event: MouseEvent) {
+  barPopoverSegment.value = segment
+  updateBarPopoverPosition(event)
+}
+
+
+function onSegmentMove(event: MouseEvent) {
+  if (!barPopoverSegment.value) return
+  updateBarPopoverPosition(event)
+}
+
+
+function updateBarPopoverPosition(event: MouseEvent) {
+  const POPOVER_WIDTH = 180
+  const GAP = 12
+  const viewportWidth = document.documentElement.clientWidth
+  let top = event.clientY + GAP
+  let left = event.clientX - POPOVER_WIDTH / 2
+  left = Math.max(GAP, Math.min(left, viewportWidth - POPOVER_WIDTH - GAP))
+  barPopoverStyle.value = { position: 'fixed', top: `${top}px`, left: `${left}px` }
+}
+
+
+function onSegmentLeave() {
+  barPopoverSegment.value = null
 }
 
 
@@ -295,12 +331,28 @@ function forwardPinMethod(nodeId: string, methodId: string) {
 
             <!-- Progress bar -->
             <div class="h-1.5 overflow-hidden rounded-full bg-border/30">
-              <div
-                class="h-full rounded-full bg-amber-400 transition-all duration-300"
-                :style="{
-                  width: `${Math.min(100, Math.round((stockOnHand / Math.max(1, totalNeeded)) * 100))}%`,
-                }"
-              />
+              <div class="flex h-full">
+                <div
+                  class="h-full rounded-l-full bg-amber-400 transition-all duration-300"
+                  :class="{ 'rounded-r-full': queuedForItem === 0 }"
+                  :style="{
+                    width: `${Math.min(100, Math.round((stockOnHand / Math.max(1, totalNeeded)) * 100))}%`,
+                  }"
+                  @mouseenter="onSegmentEnter('owned', $event)"
+                  @mousemove="onSegmentMove"
+                  @mouseleave="onSegmentLeave"
+                />
+                <div
+                  v-if="queuedForItem > 0"
+                  class="h-full rounded-r-full bg-sky-400 transition-all duration-300"
+                  :style="{
+                    width: `${Math.min(100 - Math.round((stockOnHand / Math.max(1, totalNeeded)) * 100), Math.round((queuedForItem / Math.max(1, totalNeeded)) * 100))}%`,
+                  }"
+                  @mouseenter="onSegmentEnter('queued', $event)"
+                  @mousemove="onSegmentMove"
+                  @mouseleave="onSegmentLeave"
+                />
+              </div>
             </div>
 
             <!-- Amounts -->
@@ -312,13 +364,13 @@ function forwardPinMethod(nodeId: string, methodId: string) {
                 <span class="text-[10px] font-normal text-muted-foreground/50"> Total</span>
               </span>
               <span
-                v-if="node.requiredAmount > 0"
+                v-if="deficit > 0"
                 class="font-mono text-[11px] font-semibold text-amber-600 dark:text-amber-400"
               >
                 <span class="text-[10px] font-normal text-amber-600/60 dark:text-amber-400/60"
                   >Need
                 </span>
-                {{ node.requiredAmount.toLocaleString() }}
+                {{ deficit.toLocaleString() }}
               </span>
             </div>
           </div>
@@ -342,6 +394,7 @@ function forwardPinMethod(nodeId: string, methodId: string) {
         :selected-method-id="selectedMethodId"
         :collapsed-node-ids="collapsedNodeIds"
         :inventory-amounts="inventoryAmounts"
+        :queued-amounts="queuedAmounts"
         :completion-time-by-node="completionTimeByNode"
         :node-annotations="nodeAnnotations"
         :subtree-cost-by-node="subtreeCostByNode"
@@ -366,6 +419,32 @@ function forwardPinMethod(nodeId: string, methodId: string) {
         {{ activeMethod!.children.length }} items
       </button>
     </div>
+
+    <!-- Bar segment popover -->
+    <Teleport to="body">
+      <Transition name="chip-popover">
+        <div
+          v-if="barPopoverSegment !== null"
+          class="w-45 pointer-events-none z-50 overflow-hidden rounded-xl border border-border/70 bg-card shadow-xl shadow-black/30"
+          :style="barPopoverStyle"
+        >
+          <div class="flex items-center gap-1.5 px-3 py-2">
+            <template v-if="barPopoverSegment === 'owned'">
+              <span class="font-mono text-xs font-bold text-amber-600 dark:text-amber-400">
+                {{ stockOnHand.toLocaleString() }}
+              </span>
+              <span class="text-[11px] text-muted-foreground">have</span>
+            </template>
+            <template v-else-if="barPopoverSegment === 'queued'">
+              <span class="font-mono text-xs font-bold text-sky-600 dark:text-sky-400">
+                {{ queuedForItem.toLocaleString() }}
+              </span>
+              <span class="text-[11px] text-muted-foreground">queued</span>
+            </template>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
 
     <!-- Modifier chip popover -->
     <Teleport to="body">

--- a/src/components/summoning-planner/SummoningMaterialTree.vue
+++ b/src/components/summoning-planner/SummoningMaterialTree.vue
@@ -31,6 +31,7 @@ const {
   schedule,
   summary,
   inventoryAmounts,
+  flatQueuedAmounts,
   getActiveMethod,
   setPinnedMethod,
 } = useCraftPlanner(targetItemId, targetQuantity, { deductRootInventory: true })
@@ -225,6 +226,7 @@ defineExpose({
         :selected-method-id="selectedMethodId"
         :collapsed-node-ids="collapsedNodeIds"
         :inventory-amounts="inventoryAmounts"
+        :queued-amounts="flatQueuedAmounts"
         :completion-time-by-node="schedule?.completionTimeByNode ?? {}"
         @select-node="selectNode"
         @select-method="selectMethod"

--- a/src/components/summoning-planner/SummoningObjectiveCard.vue
+++ b/src/components/summoning-planner/SummoningObjectiveCard.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
     itemType: ItemType
     totalNeeded: number
     inventoryAmount: number
+    queuedAmount?: number
     sourceLabel: string
     sourceIcon?: string | null
     modifiers?: ModifierChipData[]
@@ -64,6 +65,38 @@ function onChipLeave() {
 }
 
 
+const barPopoverSegment = ref<'owned' | 'queued' | null>(null)
+const barPopoverStyle = ref<Record<string, string>>({})
+
+
+function onSegmentEnter(segment: 'owned' | 'queued', event: MouseEvent) {
+  barPopoverSegment.value = segment
+  updateBarPopoverPosition(event)
+}
+
+
+function onSegmentMove(event: MouseEvent) {
+  if (!barPopoverSegment.value) return
+  updateBarPopoverPosition(event)
+}
+
+
+function updateBarPopoverPosition(event: MouseEvent) {
+  const POPOVER_WIDTH = 180
+  const GAP = 12
+  const viewportWidth = document.documentElement.clientWidth
+  let top = event.clientY + GAP
+  let left = event.clientX - POPOVER_WIDTH / 2
+  left = Math.max(GAP, Math.min(left, viewportWidth - POPOVER_WIDTH - GAP))
+  barPopoverStyle.value = { position: 'fixed', top: `${top}px`, left: `${left}px` }
+}
+
+
+function onSegmentLeave() {
+  barPopoverSegment.value = null
+}
+
+
 const fulfilled = computed(() => props.inventoryAmount >= props.totalNeeded)
 
 
@@ -72,7 +105,9 @@ const progressPct = computed(() =>
 )
 
 
-const deficit = computed(() => Math.max(0, props.totalNeeded - props.inventoryAmount))
+const deficit = computed(() =>
+  Math.max(0, props.totalNeeded - props.inventoryAmount - (props.queuedAmount ?? 0)),
+)
 
 
 function fmt(n: number): string {
@@ -154,11 +189,29 @@ function fmt(n: number): string {
 
         <!-- Progress bar -->
         <div class="h-1.5 overflow-hidden rounded-full bg-border/30">
-          <div
-            class="h-full rounded-full transition-all"
-            :class="fulfilled ? 'bg-emerald-500' : 'bg-amber-400'"
-            :style="{ width: `${progressPct}%` }"
-          />
+          <div class="flex h-full">
+            <div
+              class="h-full rounded-l-full transition-all"
+              :class="[
+                fulfilled ? 'bg-emerald-500' : 'bg-amber-400',
+                { 'rounded-r-full': !queuedAmount || queuedAmount === 0 },
+              ]"
+              :style="{ width: `${progressPct}%` }"
+              @mouseenter="onSegmentEnter('owned', $event)"
+              @mousemove="onSegmentMove"
+              @mouseleave="onSegmentLeave"
+            />
+            <div
+              v-if="queuedAmount && queuedAmount > 0"
+              class="h-full rounded-r-full bg-sky-400 transition-all"
+              :style="{
+                width: `${Math.min(100 - progressPct, Math.round((queuedAmount / Math.max(1, totalNeeded)) * 100))}%`,
+              }"
+              @mouseenter="onSegmentEnter('queued', $event)"
+              @mousemove="onSegmentMove"
+              @mouseleave="onSegmentLeave"
+            />
+          </div>
         </div>
 
         <!-- Amounts -->
@@ -183,6 +236,32 @@ function fmt(n: number): string {
         </div>
       </div>
     </div>
+
+    <!-- Bar segment popover -->
+    <Teleport to="body">
+      <Transition name="chip-popover">
+        <div
+          v-if="barPopoverSegment !== null"
+          class="w-45 pointer-events-none z-50 overflow-hidden rounded-xl border border-border/70 bg-card shadow-xl shadow-black/30"
+          :style="barPopoverStyle"
+        >
+          <div class="flex items-center gap-1.5 px-3 py-2">
+            <template v-if="barPopoverSegment === 'owned'">
+              <span class="font-mono text-xs font-bold text-amber-600 dark:text-amber-400">
+                {{ fmt(inventoryAmount) }}
+              </span>
+              <span class="text-[11px] text-muted-foreground">have</span>
+            </template>
+            <template v-else-if="barPopoverSegment === 'queued'">
+              <span class="font-mono text-xs font-bold text-sky-600 dark:text-sky-400">
+                {{ fmt(queuedAmount ?? 0) }}
+              </span>
+              <span class="text-[11px] text-muted-foreground">queued</span>
+            </template>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
 
     <!-- Modifier chip popover -->
     <Teleport to="body">

--- a/src/components/summoning-planner/SummoningTimeline.vue
+++ b/src/components/summoning-planner/SummoningTimeline.vue
@@ -18,6 +18,8 @@ const props = defineProps<{
     string,
     { expeditionName: string; party: { creature: Creature; rating: number }[] }
   >
+  queueOffsets?: Record<string, number>
+  queuedAmounts?: Record<string, number>
 }>()
 
 
@@ -68,6 +70,8 @@ function copyScheduleJson() {
       :schedule="schedule"
       :nodes-by-id="nodesById"
       :selected-node-id="null"
+      :queue-offsets="queueOffsets"
+      :queued-amounts="queuedAmounts"
     />
 
     <!-- Debug: copy schedule JSON -->

--- a/src/composables/useCraftPlanner.ts
+++ b/src/composables/useCraftPlanner.ts
@@ -959,9 +959,11 @@ export function computeSchedule(
   activeMethodIdByNode: Record<string, string | null>,
   methodsById: Record<string, PlannerMethod>,
   modifiers?: PlannerModifiers,
+  /** Pre-existing queue times per workstation — offsets when the planner can start using each station */
+  queueOffsets?: Record<string, number>,
 ): PlannerSchedule {
   const tasks: ScheduledTask[] = []
-  const resourceNextFree: Record<string, number> = {}
+  const resourceNextFree: Record<string, number> = { ...queueOffsets }
   const completionTime = new Map<string, number>()
 
   function schedule(node: PlannerNode): number {
@@ -1169,6 +1171,8 @@ export function useCraftPlanner(
 
   const {
     inventoryAmounts: baseInventory,
+    queuedAmounts: baseQueuedAmounts,
+    queuedTimes: baseQueuedTimes,
     gardenFlowers: baseGarden,
     awakenGatherUpgrades: baseAwakenGather,
     awakenSpeedTiers: baseAwakenSpeed,
@@ -1192,7 +1196,20 @@ export function useCraftPlanner(
   const machineLevelOverrides = ref<Record<string, number> | null>(null)
   const fabricationOverrides = ref<Record<string, number> | null>(null)
 
-  const inventoryAmounts = computed(() => inventoryOverrides.value ?? baseInventory.value)
+  const rawInventoryAmounts = computed(() => inventoryOverrides.value ?? baseInventory.value)
+  const queuedAmounts = computed(() => baseQueuedAmounts.value)
+  const inventoryAmounts = computed(() => {
+    const inv = rawInventoryAmounts.value
+    const queued = queuedAmounts.value
+    if (Object.keys(queued).length === 0) return inv
+    const merged = { ...inv }
+    for (const stationItems of Object.values(queued)) {
+      for (const [id, amount] of Object.entries(stationItems)) {
+        if (amount > 0) merged[id] = (merged[id] ?? 0) + amount
+      }
+    }
+    return merged
+  })
   const gardenFlowers = computed(() => gardenOverrides.value ?? baseGarden.value)
   const awakenGatherUpgrades = computed(() => awakenGatherOverrides.value ?? baseAwakenGather.value)
   const awakenSpeedTiers = computed(() => awakenSpeedOverrides.value ?? baseAwakenSpeed.value)
@@ -1548,6 +1565,7 @@ export function useCraftPlanner(
       activeMethodIdByNode.value,
       graph.value.methodsById,
       modifiers.value,
+      baseQueuedTimes.value,
     )
   })
 
@@ -1587,6 +1605,16 @@ export function useCraftPlanner(
     shoppingListText,
     pinnedMethodIds,
     inventoryAmounts,
+    queuedAmounts,
+    flatQueuedAmounts: computed(() => {
+      const flat: Record<string, number> = {}
+      for (const stationItems of Object.values(queuedAmounts.value)) {
+        for (const [id, amount] of Object.entries(stationItems)) {
+          if (amount > 0) flat[id] = (flat[id] ?? 0) + amount
+        }
+      }
+      return flat
+    }),
     gardenFlowers,
     awakenGatherUpgrades,
     awakenSpeedTiers,

--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -41,6 +41,12 @@ const fabricationAllocations = useLocalStorage<Record<string, number>>(
   'config-fabrication-allocations',
   {},
 )
+const queuedAmounts = useLocalStorage<Record<string, Record<string, number>>>(
+  'config-queued-recipes',
+  {},
+)
+/** Estimated total queue time in seconds per workstation (e.g. { Furnace: 50650 }) */
+const queuedTimes = useLocalStorage<Record<string, number>>('config-queued-times', {})
 const awakenGoldLevel = useLocalStorage<number>('config-awaken-gold-level', 0)
 const skillLevels = useLocalStorage<Record<string, number>>('config-skill-levels', {})
 
@@ -183,6 +189,19 @@ export function useGameConfig() {
     skillLevels.value = {}
   }
 
+  function setQueuedAmounts(amounts: Record<string, Record<string, number>>) {
+    queuedAmounts.value = amounts
+  }
+
+  function setQueuedTimes(times: Record<string, number>) {
+    queuedTimes.value = times
+  }
+
+  function resetQueuedAmounts() {
+    queuedAmounts.value = {}
+    queuedTimes.value = {}
+  }
+
   function resetGameConfig() {
     sanctuaryCreatureIds.value = []
     helperCreatureIds.value = []
@@ -195,6 +214,7 @@ export function useGameConfig() {
     resetToolLevels()
     resetMachines()
     resetFabrication()
+    resetQueuedAmounts()
     awakenGoldLevel.value = 0
     resetSkillLevels()
   }
@@ -246,5 +266,10 @@ export function useGameConfig() {
     playerLevel,
     setSkillLevels,
     resetSkillLevels,
+    queuedAmounts,
+    queuedTimes,
+    setQueuedAmounts,
+    setQueuedTimes,
+    resetQueuedAmounts,
   }
 }

--- a/src/utils/parseSave.ts
+++ b/src/utils/parseSave.ts
@@ -54,6 +54,8 @@ export interface SaveConfig {
   fabricationAllocations: Record<string, number>
   awakenGoldLevel: number
   skillLevels: Record<string, number>
+  queuedAmounts: Record<string, Record<string, number>>
+  queuedTimes: Record<string, number>
   currentExpedition: ExpeditionData
 }
 
@@ -101,6 +103,7 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
   const { machineLevels, machineRecipes } = parseMachineDetails(save)
   const fabricationAllocations = parseFabricationAllocations(save)
   const skillLevels = parseSkillLevels(save)
+  const { queuedAmounts, queuedTimes } = parseWorkstationQueues(save)
 
   const currentExpedition = buildExpeditionData(save, creatures)
 
@@ -123,6 +126,8 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
     fabricationAllocations,
     awakenGoldLevel,
     skillLevels,
+    queuedAmounts,
+    queuedTimes,
     currentExpedition,
   }
 }
@@ -398,4 +403,62 @@ function parseSkillLevels(save: Record<string, unknown>): Record<string, number>
     }
   }
   return result
+}
+
+interface SaveWorkstationQueueEntry {
+  itemId?: string
+  item?: { id?: string }
+  amount?: number
+  recipe?: { outputAmount?: number }
+  singleItemDuration?: number
+}
+
+interface SaveWorkstationState {
+  completedItems?: number
+  queue?: SaveWorkstationQueueEntry[]
+}
+
+function parseWorkstationQueues(save: Record<string, unknown>): {
+  queuedAmounts: Record<string, Record<string, number>>
+  queuedTimes: Record<string, number>
+} {
+  const queuedAmounts: Record<string, Record<string, number>> = {}
+  const queuedTimes: Record<string, number> = {}
+
+  for (const ws of ['furnace', 'stove', 'workbench']) {
+    const wsState = save[ws] as SaveWorkstationState | undefined
+    if (!wsState || typeof wsState !== 'object') continue
+    if (!Array.isArray(wsState.queue) || wsState.queue.length === 0) continue
+
+    const stationName = ws.charAt(0).toUpperCase() + ws.slice(1)
+    const stationItems: Record<string, number> = {}
+    let stationTime = 0
+
+    // The queue contains all items including the currently crafting one (index 0).
+    // completedItems on the workstation state tracks how many of queue[0] are done.
+    const completed = typeof wsState.completedItems === 'number' ? wsState.completedItems : 0
+
+    for (let i = 0; i < wsState.queue.length; i++) {
+      const entry: SaveWorkstationQueueEntry = wsState.queue[i]
+      const itemId = entry.itemId ?? entry.item?.id
+      if (!itemId || typeof entry.amount !== 'number' || entry.amount <= 0) continue
+      const outputAmount = entry.recipe?.outputAmount ?? 1
+      const crafts = i === 0 ? Math.max(0, entry.amount - completed) : entry.amount
+      if (crafts > 0) {
+        stationItems[itemId] = (stationItems[itemId] ?? 0) + crafts * outputAmount
+        // singleItemDuration is already speed-adjusted by the game
+        const duration = typeof entry.singleItemDuration === 'number' ? entry.singleItemDuration : 0
+        stationTime += crafts * duration
+      }
+    }
+
+    if (Object.keys(stationItems).length > 0) {
+      queuedAmounts[stationName] = stationItems
+    }
+    if (stationTime > 0) {
+      queuedTimes[stationName] = stationTime
+    }
+  }
+
+  return { queuedAmounts, queuedTimes }
 }

--- a/src/utils/prioritySteps.ts
+++ b/src/utils/prioritySteps.ts
@@ -27,6 +27,7 @@ export interface PriorityWave {
 export function computePriorityWaves(
   schedule: PlannerSchedule,
   nodesById?: Record<string, PlannerNode>,
+  queuedAmounts?: Record<string, number>,
 ): PriorityWave[] {
   if (schedule.tasks.length === 0) return []
 
@@ -75,7 +76,9 @@ export function computePriorityWaves(
     for (const task of raw.tasks) {
       const dedupeKey = `${task.resource}:${task.itemName}`
       const node = nodesById?.[task.passive?.linkedNodeId ?? task.nodeId]
-      const taskAmount = node?.requiredAmount ?? task.passive?.produced ?? 0
+      const rawAmount = node?.requiredAmount ?? task.passive?.produced ?? 0
+      const queued = node ? (queuedAmounts?.[node.itemId] ?? 0) : 0
+      const taskAmount = Math.max(0, rawAmount - queued)
 
       const existing = cardMap.get(dedupeKey)
       if (existing) {

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -26,7 +26,7 @@ import {
   getMaxUnlockedTier,
   TIER_UNLOCK_REQUIREMENTS,
 } from '@/utils/expeditionUnlocks'
-import { toTitleCase } from '@/utils/format'
+import { formatDuration, toTitleCase } from '@/utils/format'
 import { levelFromXp, getPlayerLevel, getPlayerLevelXpBonus, SKILLING_IDS } from '@/utils/formulas'
 import {
   sourceIcons,
@@ -84,6 +84,11 @@ const {
   playerLevel,
   setSkillLevels,
   resetSkillLevels,
+  queuedAmounts,
+  queuedTimes,
+  setQueuedAmounts,
+  setQueuedTimes,
+  resetQueuedAmounts,
 } = useGameConfig()
 
 
@@ -357,6 +362,12 @@ const inventoryHasDiff = computed(() => {
 })
 
 
+const queuedHasDiff = computed(() => {
+  if (!saveConfig.value) return false
+  return JSON.stringify(queuedAmounts.value) !== JSON.stringify(saveConfig.value.queuedAmounts)
+})
+
+
 const gardenHasDiff = computed(() => {
   if (!saveConfig.value) return false
   return JSON.stringify(gardenFlowers.value) !== JSON.stringify(saveConfig.value.gardenFlowers)
@@ -549,6 +560,53 @@ const inventoryDiff = computed(() => {
 })
 
 
+function flattenQueued(nested: Record<string, Record<string, number>>): Record<string, number> {
+  const flat: Record<string, number> = {}
+  for (const items of Object.values(nested)) {
+    for (const [id, amount] of Object.entries(items)) {
+      if (amount > 0) flat[id] = (flat[id] ?? 0) + amount
+    }
+  }
+  return flat
+}
+
+
+const queuedDiff = computed(() => {
+  if (!saveConfig.value) return []
+  const saveFlat = flattenQueued(saveConfig.value.queuedAmounts)
+  const currentFlat = flattenQueued(queuedAmounts.value)
+  const allKeys = new Set([...Object.keys(saveFlat), ...Object.keys(currentFlat)])
+  return [...allKeys]
+    .map((id) => ({
+      id,
+      name: toTitleCase(id),
+      current: currentFlat[id] ?? 0,
+      save: saveFlat[id] ?? 0,
+    }))
+    .filter((d) => d.current !== d.save)
+    .toSorted((a, b) => a.name.localeCompare(b.name))
+})
+
+
+const queuedStationCount = computed(() =>
+  Object.values(queuedAmounts.value).reduce((sum, items) => sum + Object.keys(items).length, 0),
+)
+
+
+const queuedByStation = computed(() =>
+  Object.entries(queuedAmounts.value)
+    .filter(([, items]) => Object.keys(items).length > 0)
+    .map(([station, items]) => ({
+      station,
+      items: Object.entries(items)
+        .filter(([, amount]) => amount > 0)
+        .map(([id, amount]) => ({ id, name: toTitleCase(id), amount }))
+        .toSorted((a, b) => a.name.localeCompare(b.name)),
+    }))
+    .toSorted((a, b) => a.station.localeCompare(b.station)),
+)
+
+
 interface GardenTierDiff {
   level: number
   current: number
@@ -635,6 +693,7 @@ watch(saveConfig, () => {
     if (!creatureCollectionHasDiff.value) sectionsCollapsed.value.creatures = true
     if (!exclusionsHaveDiff.value) sectionsCollapsed.value.exclusions = true
     if (!inventoryHasDiff.value) sectionsCollapsed.value.inventory = true
+    if (!queuedHasDiff.value) sectionsCollapsed.value.queued = true
     if (!gardenHasDiff.value) sectionsCollapsed.value.garden = true
     if (!awakenHasDiff.value) sectionsCollapsed.value.awaken = true
     if (!jobTiersHasDiff.value) sectionsCollapsed.value.jobTiers = true
@@ -675,6 +734,15 @@ function applyInventory() {
   inventoryAmounts.value = { ...saveConfig.value.inventory }
   appliedSections.value = { ...appliedSections.value, inventory: true }
   sectionsCollapsed.value = { ...sectionsCollapsed.value, inventory: true }
+}
+
+
+function applyQueued() {
+  if (!saveConfig.value) return
+  setQueuedAmounts({ ...saveConfig.value.queuedAmounts })
+  setQueuedTimes({ ...saveConfig.value.queuedTimes })
+  appliedSections.value = { ...appliedSections.value, queued: true }
+  sectionsCollapsed.value = { ...sectionsCollapsed.value, queued: true }
 }
 
 
@@ -761,6 +829,7 @@ function applyAll() {
   applyCreatureCollection()
   applyExclusions()
   applyInventory()
+  applyQueued()
   applyGarden()
   applyAwaken()
   applyTools()
@@ -1853,6 +1922,133 @@ function updateAwakenSpeed(ws: string, delta: number) {
           </p>
           <p v-else class="text-sm text-muted-foreground">
             {{ Object.keys(inventoryAmounts).length }} items tracked. Upload a save file to compare.
+          </p>
+        </div>
+      </div>
+
+      <!-- Workstation Queues -->
+      <div class="rounded-xl border border-border bg-card/50 p-4">
+        <div class="flex items-center justify-between">
+          <button class="flex items-center gap-2" @click="toggleSection('queued')">
+            <component
+              :is="sectionsCollapsed.queued ? ChevronDown : ChevronUp"
+              class="size-4 text-muted-foreground"
+            />
+            <h3 class="text-sm font-bold">Workstation Queues</h3>
+          </button>
+          <div class="flex items-center gap-2">
+            <span class="rounded-md bg-muted/50 px-2 py-1 text-xs font-medium">
+              {{ queuedStationCount }} items
+            </span>
+            <template v-if="saveConfig">
+              <button
+                v-if="!appliedSections.queued && queuedHasDiff"
+                class="focus-ring rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90"
+                @click="applyQueued"
+              >
+                Apply
+              </button>
+              <span
+                v-else-if="!appliedSections.queued && !queuedHasDiff"
+                class="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-400"
+              >
+                <Check class="size-3.5" /> Matches Save
+              </span>
+              <span
+                v-else-if="appliedSections.queued"
+                class="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-400"
+              >
+                <Check class="size-3.5" /> Applied
+              </span>
+            </template>
+            <button
+              v-if="queuedStationCount > 0"
+              class="focus-ring rounded-lg border border-red-500/30 bg-red-500/10 px-2 py-1.5 text-xs font-semibold text-red-400 transition hover:bg-red-500/20"
+              @click="resetQueuedAmounts"
+            >
+              <RotateCcw class="size-3" />
+            </button>
+          </div>
+        </div>
+
+        <div v-if="!sectionsCollapsed.queued" class="mt-3 space-y-3">
+          <!-- Save Diff -->
+          <div v-if="saveConfig && queuedDiff.length > 0">
+            <p class="mb-1 text-xs font-medium text-muted-foreground">Save changes</p>
+            <div class="max-h-40 space-y-0.5 overflow-y-auto pr-1">
+              <div
+                v-for="d in queuedDiff"
+                :key="'diff-' + d.id"
+                class="flex items-center justify-between rounded-lg bg-amber-500/10 px-2 py-1.5 text-sm"
+              >
+                <div class="flex items-center gap-2">
+                  <img
+                    v-if="getItemImage({ id: d.id })"
+                    :src="getItemImage({ id: d.id })"
+                    :alt="d.name"
+                    class="size-5 object-contain"
+                    loading="lazy"
+                  />
+                  <span class="font-medium">{{ d.name }}</span>
+                </div>
+                <span class="tabular-nums text-muted-foreground">
+                  <span class="text-muted-foreground/60">{{ d.current.toLocaleString() }}</span>
+                  <span class="mx-1">&rarr;</span>
+                  <span class="text-foreground">{{ d.save.toLocaleString() }}</span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <p
+            v-else-if="saveConfig && queuedDiff.length === 0 && queuedByStation.length > 0"
+            class="text-sm text-muted-foreground"
+          >
+            Queued items match save file.
+          </p>
+          <p
+            v-else-if="saveConfig && queuedByStation.length === 0"
+            class="text-sm text-muted-foreground"
+          >
+            No queued recipes found in save file.
+          </p>
+
+          <!-- Current queued items grouped by workstation -->
+          <div v-if="queuedByStation.length > 0" class="space-y-2">
+            <div v-for="group in queuedByStation" :key="group.station">
+              <div class="mb-1 flex items-center gap-2">
+                <p class="text-xs font-medium text-muted-foreground">{{ group.station }}</p>
+                <span
+                  v-if="queuedTimes[group.station]"
+                  class="rounded-md bg-muted/50 px-1.5 py-0.5 text-xs tabular-nums text-muted-foreground"
+                >
+                  {{ formatDuration(queuedTimes[group.station]) }}
+                </span>
+              </div>
+              <div class="space-y-0.5">
+                <div
+                  v-for="item in group.items"
+                  :key="item.id"
+                  class="flex items-center justify-between rounded-lg bg-muted/30 px-2 py-1.5 text-sm"
+                >
+                  <div class="flex items-center gap-2">
+                    <img
+                      v-if="getItemImage({ id: item.id })"
+                      :src="getItemImage({ id: item.id })"
+                      :alt="item.name"
+                      class="size-5 object-contain"
+                      loading="lazy"
+                    />
+                    <span class="font-medium">{{ item.name }}</span>
+                  </div>
+                  <span class="tabular-nums text-foreground">
+                    {{ item.amount.toLocaleString() }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p v-else-if="!saveConfig" class="text-sm text-muted-foreground">
+            No queued recipes configured. Upload a save to import workstation queues.
           </p>
         </div>
       </div>

--- a/src/views/ItemPlannerView.vue
+++ b/src/views/ItemPlannerView.vue
@@ -93,6 +93,7 @@ const {
   activeMethodIdByNode,
   schedule,
   inventoryAmounts,
+  flatQueuedAmounts,
   getActiveMethod,
   setPinnedMethod,
   resetPins,
@@ -360,6 +361,16 @@ function switchTab(tab: 'craft' | 'levelup' | 'summoning') {
         </template>
       </PlannerToolbar>
 
+      <div
+        v-if="rootNode"
+        class="flex items-center gap-2 rounded-lg border border-sky-500/25 bg-sky-500/5 px-3 py-2"
+      >
+        <span class="text-xs text-sky-700 dark:text-sky-300">
+          This planner targets <span class="font-bold">additional</span> crafts beyond your current
+          inventory and queued workstation items.
+        </span>
+      </div>
+
       <PlannerEmptyState
         v-if="!rootNode"
         title="Choose an item to begin planning."
@@ -455,6 +466,7 @@ function switchTab(tab: 'craft' | 'levelup' | 'summoning') {
           :nodes-by-id="nodesById"
           :active-method-id-by-node="activeMethodIdByNode"
           :inventory-amounts="inventoryAmounts"
+          :queued-amounts="flatQueuedAmounts"
           :get-active-method="getActiveMethod"
           :recommendations="recommendations"
         />
@@ -465,6 +477,8 @@ function switchTab(tab: 'craft' | 'levelup' | 'summoning') {
             :schedule="schedule"
             :nodes-by-id="nodesById"
             :selected-node-id="selectedNodeId"
+            :queue-offsets="gameConfig.queuedTimes.value"
+            :queued-amounts="flatQueuedAmounts"
             @select-node="selectNode"
           />
         </div>
@@ -479,6 +493,7 @@ function switchTab(tab: 'craft' | 'levelup' | 'summoning') {
             :selected-method-id="null"
             :collapsed-node-ids="collapsedNodeIds"
             :inventory-amounts="inventoryAmounts"
+            :queued-amounts="flatQueuedAmounts"
             :completion-time-by-node="schedule?.completionTimeByNode ?? {}"
             :recommendations="recommendations"
             @select-node="selectNode"

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -57,6 +57,17 @@ const gameConfig = useGameConfig()
 const { goldPerMinute, breakdown: goldBreakdown } = useGoldIncome()
 
 
+const flatQueuedAmounts = computed(() => {
+  const flat: Record<string, number> = {}
+  for (const items of Object.values(gameConfig.queuedAmounts.value)) {
+    for (const [id, amount] of Object.entries(items)) {
+      if (amount > 0) flat[id] = (flat[id] ?? 0) + amount
+    }
+  }
+  return flat
+})
+
+
 const expeditions = expeditionsData as Expedition[]
 const biomeMap = new Map((biomesData as import('@/types').Biome[]).map((b) => [b.id, b]))
 
@@ -254,8 +265,12 @@ function sortTreeEntries(entries: GroupedCostEntry[]): GroupedCostEntry[] {
       case 'name':
         return dir * a.itemName.localeCompare(b.itemName)
       case 'progress': {
-        const invA = gameConfig.inventoryAmounts.value[a.itemId] ?? 0
-        const invB = gameConfig.inventoryAmounts.value[b.itemId] ?? 0
+        const invA =
+          (gameConfig.inventoryAmounts.value[a.itemId] ?? 0) +
+          (flatQueuedAmounts.value[a.itemId] ?? 0)
+        const invB =
+          (gameConfig.inventoryAmounts.value[b.itemId] ?? 0) +
+          (flatQueuedAmounts.value[b.itemId] ?? 0)
         const pctA = a.amount > 0 ? invA / a.amount : 1
         const pctB = b.amount > 0 ? invB / b.amount : 1
         return dir * (pctA - pctB) || a.itemName.localeCompare(b.itemName)
@@ -815,7 +830,7 @@ const mergedNodesById = computed(() => {
 
 
 const priorityWaves = computed(() =>
-  computePriorityWaves(mergedSchedule.value, mergedNodesById.value),
+  computePriorityWaves(mergedSchedule.value, mergedNodesById.value, flatQueuedAmounts.value),
 )
 
 
@@ -869,7 +884,9 @@ const readiness = computed(() => {
 
   let fulfilled = 0
   for (const cost of costs) {
-    const owned = gameConfig.inventoryAmounts.value[cost.itemId] ?? 0
+    const owned =
+      (gameConfig.inventoryAmounts.value[cost.itemId] ?? 0) +
+      (flatQueuedAmounts.value[cost.itemId] ?? 0)
     if (owned >= cost.amount) fulfilled++
   }
   const percent = Math.round((fulfilled / costs.length) * 100)
@@ -1036,6 +1053,7 @@ interface FlatListEntry {
   itemType: import('@/types').ItemType
   totalNeeded: number
   inventoryAmount: number
+  queuedAmount: number
   sourceLabel: string
   sourceIcon: string | null
   sourceGroup: SourceGroup
@@ -1056,6 +1074,8 @@ const flatListEntries = computed(() => {
     treeRef: InstanceType<typeof SummoningMaterialTree>,
   ) {
     const inv = gameConfig.inventoryAmounts.value[node.itemId] ?? 0
+    const queued = flatQueuedAmounts.value[node.itemId] ?? 0
+    const available = inv + queued
     const existing = merged.get(node.itemId)
 
     if (existing) {
@@ -1073,8 +1093,9 @@ const flatListEntries = computed(() => {
         itemId: node.itemId,
         itemName: node.itemName,
         itemType: node.itemType,
-        totalNeeded: node.requiredAmount + inv,
-        inventoryAmount: inv,
+        totalNeeded: node.requiredAmount + available,
+        inventoryAmount: available,
+        queuedAmount: queued,
         sourceLabel: source.label,
         sourceIcon: source.icon,
         sourceGroup: group,
@@ -1113,6 +1134,7 @@ const flatListEntries = computed(() => {
       itemType: 'Currency',
       totalNeeded: totalGold.value,
       inventoryAmount: goldInventory.value,
+      queuedAmount: 0,
       sourceLabel: '',
       sourceIcon: getItemImage({ id: 'gold' }) ?? null,
       sourceGroup: 'Currency',
@@ -1355,6 +1377,7 @@ const flatGroupedCosts = computed(() => {
                     :item-type="entry.itemType"
                     :total-needed="entry.totalNeeded"
                     :inventory-amount="entry.inventoryAmount"
+                    :queued-amount="entry.queuedAmount"
                     :source-label="entry.sourceLabel"
                     :source-icon="entry.sourceIcon"
                     :modifiers="entry.modifiers"
@@ -1374,6 +1397,7 @@ const flatGroupedCosts = computed(() => {
                   :item-type="entry.itemType"
                   :total-needed="entry.totalNeeded"
                   :inventory-amount="entry.inventoryAmount"
+                  :queued-amount="entry.queuedAmount"
                   :source-label="entry.sourceLabel"
                   :source-icon="entry.sourceIcon"
                   :modifiers="entry.modifiers"
@@ -1391,6 +1415,8 @@ const flatGroupedCosts = computed(() => {
         :nodes-by-id="mergedNodesById"
         :waves="priorityWaves"
         :expedition-parties="expeditionPartiesByItemId"
+        :queue-offsets="gameConfig.queuedTimes.value"
+        :queued-amounts="flatQueuedAmounts"
       />
 
       <!-- Tree view -->
@@ -1429,6 +1455,7 @@ const flatGroupedCosts = computed(() => {
                     :selected-method-id="treeRefs[cost.sortedIndex].selectedMethodId"
                     :collapsed-node-ids="treeRefs[cost.sortedIndex].collapsedNodeIds"
                     :inventory-amounts="treeRefs[cost.sortedIndex].inventoryAmounts"
+                    :queued-amounts="flatQueuedAmounts"
                     :completion-time-by-node="
                       treeRefs[cost.sortedIndex].schedule?.completionTimeByNode ?? {}
                     "
@@ -1478,6 +1505,7 @@ const flatGroupedCosts = computed(() => {
                     :selected-method-id="treeRefs[cost.sortedIndex].selectedMethodId"
                     :collapsed-node-ids="treeRefs[cost.sortedIndex].collapsedNodeIds"
                     :inventory-amounts="treeRefs[cost.sortedIndex].inventoryAmounts"
+                    :queued-amounts="flatQueuedAmounts"
                     :completion-time-by-node="
                       treeRefs[cost.sortedIndex].schedule?.completionTimeByNode ?? {}
                     "


### PR DESCRIPTION
## Description

Adds support for workstation queue data (furnace, stove, workbench) from save files, integrating queued item amounts and time offsets into both the Craft Planner and Summoning Cost Planner. Queued items are treated as available inventory for planning purposes, and the UI replaces noisy inline "(X queued)" text with clean segmented progress bars.

## Summary

- Parse workstation queues from save files, extracting per-item amounts and estimated queue times with support for partial completion and output multipliers
- Add Workstation Queues section to the Configs page with diff detection, apply/reset controls, and per-station item display
- Merge queued amounts into effective inventory in `useCraftPlanner` so the planner treats in-progress crafts as available stock
- Offset scheduled task start times by existing workstation queue durations
- Add striped sky-blue queue offset bars to Gantt chart lanes showing time already committed per workstation
- Replace inline queued text and pill badges with blue progress bar segments across PlannerTreeNode, PlannerListRow, and SummoningObjectiveCard, with cursor-following popovers showing "X have" or "X queued"
- Subtract queued amounts from "Need" displays, Gantt popover amounts, and Priority Step card amounts
- Wire queued data through to all planner views including sort-by-progress and readiness calculations in the Summoning Cost Planner