### PR TITLE
Add consistent creature inspection across all pages

### DIFF
--- a/src/components/expeditions/CreatureSelector.vue
+++ b/src/components/expeditions/CreatureSelector.vue
@@ -5,6 +5,7 @@ import { computed, ref, watch } from 'vue'
 import summonedIcon from '@/assets/icons/summoned.webp'
 import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
 import type { Creature, ElementType, Expedition, ExpeditionStatWeights } from '@/types'
@@ -34,6 +35,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'choose-creature': [creature: Creature]
+  'inspect-creature': [creature: Creature]
   'step-level': [creatureId: string, currentLevel: number, delta: number]
   'normalize-level': [creatureId: string, currentLevel: number, event: FocusEvent]
   'update:showExcludedCreatures': [value: boolean]
@@ -334,81 +336,83 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
         :class="
           hasEmptySlot
             ? 'border-border bg-card/50 hover:border-accent/45 hover:bg-muted/25'
-            : 'cursor-not-allowed border-border/50 bg-card/30 opacity-60'
+            : 'border-border/50 bg-card/30 opacity-60'
         "
         @click="emit('choose-creature', creature)"
       >
         <div class="flex items-start gap-3">
-          <div class="relative shrink-0">
-            <img
-              :src="getCreatureImage(creature)"
-              :alt="`${creature.name} artwork`"
-              class="size-10 rounded-md border border-border object-cover"
-              loading="lazy"
-            />
-            <img
-              v-if="sanctuaryCreatureIds.includes(creature.id)"
-              :src="sanctuaryIcon"
-              alt="Sanctuary"
-              class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-              loading="lazy"
-            />
-            <img
-              v-else-if="helperCreatureIds.includes(creature.id)"
-              :src="helpersIcon"
-              alt="Helper"
-              class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-              loading="lazy"
-            />
-            <img
-              v-else-if="machineCreatureIds.includes(creature.id)"
-              :src="machinesIcon"
-              alt="Machine"
-              class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-              loading="lazy"
-            />
-            <img
-              v-else-if="expeditionCreatureIds.has(creature.id)"
-              :src="expeditionsIcon"
-              alt="Expedition"
-              class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-              loading="lazy"
-            />
-          </div>
+          <RightClickHint @contextmenu="emit('inspect-creature', creature)">
+            <div class="relative shrink-0">
+              <img
+                :src="getCreatureImage(creature)"
+                :alt="`${creature.name} artwork`"
+                class="size-10 rounded-md border border-border object-cover"
+                loading="lazy"
+              />
+              <img
+                v-if="sanctuaryCreatureIds.includes(creature.id)"
+                :src="sanctuaryIcon"
+                alt="Sanctuary"
+                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                loading="lazy"
+              />
+              <img
+                v-else-if="helperCreatureIds.includes(creature.id)"
+                :src="helpersIcon"
+                alt="Helper"
+                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                loading="lazy"
+              />
+              <img
+                v-else-if="machineCreatureIds.includes(creature.id)"
+                :src="machinesIcon"
+                alt="Machine"
+                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                loading="lazy"
+              />
+              <img
+                v-else-if="expeditionCreatureIds.has(creature.id)"
+                :src="expeditionsIcon"
+                alt="Expedition"
+                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                loading="lazy"
+              />
+            </div>
 
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-1">
-              <p
-                class="truncate font-semibold"
-                :class="
-                  isAwakened(creature.id) ? 'text-pink-600 dark:text-pink-400' : 'text-foreground'
-                "
-              >
-                {{ creature.name }}
-              </p>
-              <span
-                v-if="isOwned(creature.id)"
-                class="text-xs"
-                :class="
-                  isAwakened(creature.id)
-                    ? 'text-pink-600 dark:text-pink-400'
-                    : 'text-amber-700 dark:text-amber-400'
-                "
-                >★</span
-              >
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-1">
+                <p
+                  class="truncate font-semibold"
+                  :class="
+                    isAwakened(creature.id) ? 'text-pink-600 dark:text-pink-400' : 'text-foreground'
+                  "
+                >
+                  {{ creature.name }}
+                </p>
+                <span
+                  v-if="isOwned(creature.id)"
+                  class="text-xs"
+                  :class="
+                    isAwakened(creature.id)
+                      ? 'text-pink-600 dark:text-pink-400'
+                      : 'text-amber-700 dark:text-amber-400'
+                  "
+                  >★</span
+                >
+              </div>
+              <div class="mt-1 flex flex-wrap gap-1 text-xs">
+                <span
+                  v-for="type in creature.types"
+                  :key="type"
+                  class="rounded-full bg-muted px-2 py-0.5 font-semibold"
+                  :style="{ color: typeColor(type) }"
+                >
+                  {{ type }}
+                </span>
+                <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
+              </div>
             </div>
-            <div class="mt-1 flex flex-wrap gap-1 text-xs">
-              <span
-                v-for="type in creature.types"
-                :key="type"
-                class="rounded-full bg-muted px-2 py-0.5 font-semibold"
-                :style="{ color: typeColor(type) }"
-              >
-                {{ type }}
-              </span>
-              <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
-            </div>
-          </div>
+          </RightClickHint>
 
           <div class="text-right" @click.stop>
             <p

--- a/src/components/expeditions/ExpeditionDetail.vue
+++ b/src/components/expeditions/ExpeditionDetail.vue
@@ -41,6 +41,7 @@ const emit = defineEmits<{
   'update:loopCount': [count: number]
   'set-active-slot': [index: number]
   'remove-creature': [index: number]
+  'inspect-creature': [creature: Creature]
 }>()
 
 
@@ -130,7 +131,8 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
           <div
             v-for="{ creature, percent } in topRecommendedCreatures"
             :key="creature.id"
-            class="inline-flex items-center gap-2 rounded-lg border border-border bg-muted/35 py-1 pl-1 pr-3"
+            class="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/35 py-1 pl-1 pr-3 transition hover:border-accent/45 hover:bg-muted/50"
+            @click="emit('inspect-creature', creature)"
           >
             <div class="size-6 overflow-hidden rounded-full bg-card">
               <img
@@ -313,21 +315,25 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
                 <img
                   :src="getCreatureImage(slot)"
                   :alt="`${slot.name} artwork`"
-                  class="size-full object-cover"
+                  class="size-full cursor-pointer object-cover"
                   loading="lazy"
+                  @click="emit('inspect-creature', slot)"
                 />
                 <span
                   class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
                 >
                   {{ getCreatureSlotRating(slot) }}
                 </span>
-                <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
+                <div
+                  class="absolute inset-x-0 bottom-0 cursor-pointer select-none bg-black/75 px-1.5 py-1"
+                  @click="emit('inspect-creature', slot)"
+                >
                   <p class="truncate text-center text-[10px] font-semibold text-white">
                     {{ slot.name }}
                   </p>
                 </div>
                 <button
-                  class="focus-ring absolute right-0.5 top-0.5 rounded-full bg-black/60 p-0.5 text-white/70 hover:text-white"
+                  class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                   @click.stop="emit('remove-creature', index)"
                 >
                   <X class="size-3" />

--- a/src/components/expeditions/ExpeditionDetail.vue
+++ b/src/components/expeditions/ExpeditionDetail.vue
@@ -304,7 +304,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
               class="relative size-20 overflow-hidden rounded-lg border transition"
               :class="[
                 slot
-                  ? 'border-border bg-card/50'
+                  ? 'border-border bg-card/50 hover:border-primary/50'
                   : activeSlotIndex === index
                     ? 'border-dashed border-primary bg-primary/10'
                     : 'cursor-pointer border-dashed border-border/50 bg-muted/20 hover:border-accent/45',

--- a/src/components/items/ItemDetail.vue
+++ b/src/components/items/ItemDetail.vue
@@ -28,6 +28,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   close: []
   'select-item': [id: string]
+  'select-creature': [id: string]
 }>()
 
 
@@ -632,7 +633,9 @@ const jobColorMap: Record<string, string> = {
           <div
             v-for="creature in summoningCreatures"
             :key="creature.id"
-            class="relative aspect-square overflow-hidden rounded-lg bg-muted/20"
+            role="button"
+            class="relative aspect-square cursor-pointer overflow-hidden rounded-lg bg-muted/20 transition hover:ring-1 hover:ring-accent/40"
+            @click="emit('select-creature', creature.id)"
           >
             <img
               v-if="getCreatureImage({ id: creature.id, image: '' })"

--- a/src/components/level-planner/LevelPlannerCreaturePicker.vue
+++ b/src/components/level-planner/LevelPlannerCreaturePicker.vue
@@ -2,7 +2,10 @@
 import { Search } from 'lucide-vue-next'
 import { computed, ref, nextTick, watch } from 'vue'
 
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
@@ -29,6 +32,12 @@ const emit = defineEmits<{
 
 
 const { creatures } = useCreatures()
+const {
+  selectedCreature: drawerCreature,
+  drawerOpen,
+  openCreature,
+  closeDrawer,
+} = useCreatureDrawer()
 const { ownedCreatureIds, getLevel, isAwakened } = useCreatureCollection()
 
 
@@ -107,13 +116,15 @@ function close() {
       @click="toggle"
     >
       <template v-if="selected">
-        <img
-          :src="getCreatureImage(selected)"
-          :alt="selected.name"
-          class="size-10 rounded-xl border border-border object-cover"
-          :style="{ backgroundColor: `hsl(${typeColorVar(selected.types[0])} / 0.1)` }"
-          loading="lazy"
-        />
+        <RightClickHint @contextmenu="openCreature(selected)">
+          <img
+            :src="getCreatureImage(selected)"
+            :alt="selected.name"
+            class="size-10 rounded-xl border border-border object-cover"
+            :style="{ backgroundColor: `hsl(${typeColorVar(selected.types[0])} / 0.1)` }"
+            loading="lazy"
+          />
+        </RightClickHint>
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-1.5">
             <p
@@ -199,13 +210,15 @@ function close() {
             "
             @click.stop="pick(creature)"
           >
-            <img
-              :src="getCreatureImage(creature)"
-              :alt="creature.name"
-              class="size-10 rounded-xl border border-border object-cover"
-              :style="{ backgroundColor: `hsl(${typeColorVar(creature.types[0])} / 0.1)` }"
-              loading="lazy"
-            />
+            <RightClickHint @contextmenu="openCreature(creature)">
+              <img
+                :src="getCreatureImage(creature)"
+                :alt="creature.name"
+                class="size-10 rounded-xl border border-border object-cover"
+                :style="{ backgroundColor: `hsl(${typeColorVar(creature.types[0])} / 0.1)` }"
+                loading="lazy"
+              />
+            </RightClickHint>
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-1">
                 <p
@@ -241,4 +254,5 @@ function close() {
       </div>
     </Teleport>
   </div>
+  <CreatureDetail :creature="drawerCreature" :open="drawerOpen" @close="closeDrawer" />
 </template>

--- a/src/components/level-planner/LevelPlannerTimelineStep.vue
+++ b/src/components/level-planner/LevelPlannerTimelineStep.vue
@@ -11,6 +11,8 @@ import {
 } from 'lucide-vue-next'
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { formatDuration } from '@/utils/format'
@@ -51,6 +53,9 @@ defineEmits<{
   selectAlternative: [fromLevel: number, toLevel: number, expeditionId: string, tier: number]
   resetOverride: [fromLevel: number]
 }>()
+
+
+const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
 
 
 function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
@@ -113,8 +118,9 @@ function formatDelta(value: number): string {
             v-if="partyMembers?.[0]?.creature"
             :src="getCreatureImage(partyMembers[0].creature)"
             :alt="creatureName"
-            class="size-10 shrink-0 rounded-lg border border-pink-500/30 object-cover sm:size-12"
+            class="size-10 shrink-0 cursor-pointer rounded-lg border border-pink-500/30 object-cover transition hover:ring-1 hover:ring-pink-500/50 sm:size-12"
             loading="lazy"
+            @click.stop="openCreature(partyMembers[0].creature!)"
           />
           <div class="min-w-0 flex-1">
             <div class="flex items-center gap-2">
@@ -216,11 +222,15 @@ function formatDelta(value: number): string {
               >
                 <div
                   class="relative size-16 overflow-hidden rounded-lg border bg-card/50 sm:size-20"
-                  :class="
+                  :class="[
                     highlightCreatureId && member.creatureId === highlightCreatureId
                       ? 'border-primary ring-2 ring-primary/50'
-                      : 'border-border'
-                  "
+                      : 'border-border',
+                    member.creature
+                      ? 'cursor-pointer transition hover:ring-1 hover:ring-accent/40'
+                      : '',
+                  ]"
+                  @click="member.creature ? openCreature(member.creature) : undefined"
                 >
                   <img
                     v-if="member.creature"
@@ -471,4 +481,5 @@ function formatDelta(value: number): string {
       </div>
     </div>
   </div>
+  <CreatureDetail :creature="selectedCreature" :open="drawerOpen" @close="closeDrawer" />
 </template>

--- a/src/components/level-planner/PartyCreatureTile.vue
+++ b/src/components/level-planner/PartyCreatureTile.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 
@@ -17,6 +20,9 @@ const props = defineProps<{
 defineEmits<{
   toggle: []
 }>()
+
+
+const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
 
 
 function tileBorderClass(): string {
@@ -54,13 +60,15 @@ function levelBadgeClass(): string {
       :title="`${creature.name} — LVL ${level}${awakened ? ' ★' : ''}${titleSuffix ?? ''}`"
       @click="$emit('toggle')"
     >
-      <img
-        v-if="getCreatureImage(creature)"
-        :src="getCreatureImage(creature)"
-        :alt="creature.name"
-        class="size-full object-cover"
-        loading="lazy"
-      />
+      <RightClickHint @contextmenu="openCreature(creature)">
+        <img
+          v-if="getCreatureImage(creature)"
+          :src="getCreatureImage(creature)"
+          :alt="creature.name"
+          class="size-full object-cover"
+          loading="lazy"
+        />
+      </RightClickHint>
       <div class="absolute inset-x-0 bottom-0 bg-black/70 px-1 py-0.5">
         <p class="truncate text-center text-[9px] font-semibold" :class="nameClass()">
           {{ creature.name }}
@@ -74,4 +82,5 @@ function levelBadgeClass(): string {
       LVL {{ level }}<span v-if="awakened" class="ml-0.5">★</span>
     </span>
   </div>
+  <CreatureDetail :creature="selectedCreature" :open="drawerOpen" @close="closeDrawer" />
 </template>

--- a/src/components/level-planner/PartyPlannerGantt.vue
+++ b/src/components/level-planner/PartyPlannerGantt.vue
@@ -3,6 +3,9 @@ import { Clock3, Minus, Plus, Repeat, RotateCcw, Users, Zap } from 'lucide-vue-n
 import { computed, ref, nextTick } from 'vue'
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useGanttZoom, niceTimeStep } from '@/composables/useGanttZoom'
 import biomesData from '@/data/biomes.json'
 import type { PartyLevelingPlan, PartyPlanStep, Creature, AwakenEvent } from '@/types'
@@ -27,6 +30,14 @@ const props = withDefaults(
     filterCreatureId: '',
   },
 )
+
+
+const {
+  selectedCreature: ganttInspectedCreature,
+  drawerOpen: ganttDrawerOpen,
+  openCreature: ganttInspectCreature,
+  closeDrawer: ganttCloseDrawer,
+} = useCreatureDrawer()
 
 
 interface GanttBar {
@@ -383,13 +394,17 @@ const activeBarScoreRatio = computed(() => {
               class="size-7 overflow-hidden rounded-full border-2 border-pink-500 bg-card shadow-md shadow-pink-500/20 transition-transform hover:scale-110"
               :class="activeAwakenMarker === marker ? 'ring-2 ring-pink-400/60' : ''"
             >
-              <img
+              <RightClickHint
                 v-if="marker.creature"
-                :src="getCreatureImage(marker.creature)"
-                :alt="marker.creature.name"
-                class="size-full object-cover"
-                loading="lazy"
-              />
+                @contextmenu="ganttInspectCreature(marker.creature)"
+              >
+                <img
+                  :src="getCreatureImage(marker.creature)"
+                  :alt="marker.creature.name"
+                  class="size-full object-cover"
+                  loading="lazy"
+                />
+              </RightClickHint>
             </div>
           </button>
         </div>
@@ -434,14 +449,18 @@ const activeBarScoreRatio = computed(() => {
           >
             <!-- Creature avatars -->
             <div class="flex shrink-0 -space-x-2">
-              <img
+              <RightClickHint
                 v-for="cId in bar.creatureIds.slice(0, 3)"
                 :key="cId"
-                :src="getCreatureImage(creatures.get(cId)!)"
-                :alt="creatures.get(cId)?.name"
-                class="size-8 rounded-full border-2 border-background object-cover"
-                loading="lazy"
-              />
+                @contextmenu="ganttInspectCreature(creatures.get(cId)!)"
+              >
+                <img
+                  :src="getCreatureImage(creatures.get(cId)!)"
+                  :alt="creatures.get(cId)?.name"
+                  class="size-8 rounded-full border-2 border-background object-cover"
+                  loading="lazy"
+                />
+              </RightClickHint>
             </div>
             <img
               :src="expeditionTierIcons[bar.tier]"
@@ -587,8 +606,9 @@ const activeBarScoreRatio = computed(() => {
                   v-if="creatures.get(member.creatureId)"
                   :src="getCreatureImage(creatures.get(member.creatureId)!)"
                   :alt="creatures.get(member.creatureId)?.name"
-                  class="size-7 shrink-0 rounded-full border border-border object-cover"
+                  class="size-7 shrink-0 cursor-pointer rounded-full border border-border object-cover transition hover:ring-1 hover:ring-accent/40"
                   loading="lazy"
+                  @click="ganttInspectCreature(creatures.get(member.creatureId)!)"
                 />
                 <div class="min-w-0 flex-1">
                   <p class="truncate text-xs font-semibold text-foreground">
@@ -627,7 +647,12 @@ const activeBarScoreRatio = computed(() => {
           <div class="px-4 py-3">
             <div class="flex items-center gap-3">
               <div
-                class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-pink-500 bg-card"
+                class="size-10 shrink-0 cursor-pointer overflow-hidden rounded-full border-2 border-pink-500 bg-card transition hover:ring-1 hover:ring-pink-500/50"
+                @click="
+                  activeAwakenMarker.creature
+                    ? ganttInspectCreature(activeAwakenMarker.creature)
+                    : undefined
+                "
               >
                 <img
                   v-if="activeAwakenMarker.creature"
@@ -673,6 +698,11 @@ const activeBarScoreRatio = computed(() => {
       </span>
     </div>
   </div>
+  <CreatureDetail
+    :creature="ganttInspectedCreature"
+    :open="ganttDrawerOpen"
+    @close="ganttCloseDrawer"
+  />
 </template>
 
 <style scoped>

--- a/src/components/shared/RightClickHint.vue
+++ b/src/components/shared/RightClickHint.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{
+  label?: string
+}>()
+
+
+const emit = defineEmits<{
+  contextmenu: [event: MouseEvent]
+}>()
+
+
+const hint = ref({ visible: false, x: 0, y: 0 })
+
+
+function onMouseMove(e: MouseEvent) {
+  hint.value.x = e.clientX
+  hint.value.y = e.clientY
+}
+
+
+function onContextMenu(e: MouseEvent) {
+  e.preventDefault()
+  hint.value.visible = false
+  emit('contextmenu', e)
+}
+</script>
+
+<template>
+  <div
+    class="contents"
+    @mouseenter="hint.visible = true"
+    @mouseleave="hint.visible = false"
+    @mousemove="onMouseMove"
+    @contextmenu="onContextMenu"
+  >
+    <slot />
+  </div>
+
+  <Teleport to="body">
+    <div
+      v-if="hint.visible"
+      class="pointer-events-none fixed z-50 flex items-center gap-1.5 rounded-md border border-border bg-card px-2 py-1 shadow-lg"
+      :style="{ top: `${hint.y + 16}px`, left: `${hint.x + 12}px` }"
+    >
+      <svg
+        class="size-3.5 text-muted-foreground"
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+      >
+        <path d="M12 2v8h6a6 6 0 0 0-6-6Z" fill="currentColor" opacity="0.5" />
+        <rect x="4" y="2" width="16" height="20" rx="8" stroke="currentColor" stroke-width="2" />
+        <line x1="12" y1="2" x2="12" y2="10" stroke="currentColor" stroke-width="2" />
+      </svg>
+      <span class="text-[10px] font-medium text-muted-foreground">{{
+        label ?? 'Right-click'
+      }}</span>
+    </div>
+  </Teleport>
+</template>

--- a/src/components/summoning-planner/SummoningExpeditionPlan.vue
+++ b/src/components/summoning-planner/SummoningExpeditionPlan.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { Compass } from 'lucide-vue-next'
 
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Expedition } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import type { ExpeditionPlan } from '@/utils/expeditionOptimizer'
@@ -12,6 +15,9 @@ defineProps<{
   plans: { expedition: Expedition; plan: ExpeditionPlan }[]
   bestPlan: ExpeditionPlan
 }>()
+
+
+const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
 </script>
 
 <template>
@@ -86,23 +92,27 @@ defineProps<{
 
         <div class="flex items-center gap-1.5">
           <div class="flex min-w-0 flex-1 flex-wrap gap-1.5">
-            <div
+            <RightClickHint
               v-for="member in plan.party"
               :key="member.creature.id"
-              class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
+              @contextmenu="openCreature(member.creature)"
             >
-              <div class="size-5 overflow-hidden rounded-md bg-card">
-                <img
-                  v-if="getCreatureImage(member.creature)"
-                  :src="getCreatureImage(member.creature)"
-                  :alt="member.creature.name"
-                  class="size-full object-cover"
-                />
+              <div
+                class="inline-flex cursor-default items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
+              >
+                <div class="size-5 overflow-hidden rounded-md bg-card">
+                  <img
+                    v-if="getCreatureImage(member.creature)"
+                    :src="getCreatureImage(member.creature)"
+                    :alt="member.creature.name"
+                    class="size-full object-cover"
+                  />
+                </div>
+                <span class="text-[10px] font-semibold text-foreground">{{
+                  member.creature.name
+                }}</span>
               </div>
-              <span class="text-[10px] font-semibold text-foreground">{{
-                member.creature.name
-              }}</span>
-            </div>
+            </RightClickHint>
           </div>
           <div class="shrink-0 text-right text-[10px] text-muted-foreground">
             <span>{{ toTitleCase(expedition.biome) }}</span>
@@ -112,4 +122,5 @@ defineProps<{
       </div>
     </div>
   </div>
+  <CreatureDetail :creature="selectedCreature" :open="drawerOpen" @close="closeDrawer" />
 </template>

--- a/src/components/summoning-planner/SummoningTimeline.vue
+++ b/src/components/summoning-planner/SummoningTimeline.vue
@@ -2,7 +2,10 @@
 import { Clock3, Copy, Check } from 'lucide-vue-next'
 import { computed, ref } from 'vue'
 
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import PlannerGantt from '@/components/planner/PlannerGantt.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Creature, ItemType, PlannerNode, PlannerSchedule } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { formatDuration, itemTypeColor, methodKindLabel } from '@/utils/format'
@@ -19,6 +22,9 @@ const props = defineProps<{
     { expeditionName: string; party: { creature: Creature; rating: number }[] }
   >
 }>()
+
+
+const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
 
 
 /** Kinds that are passive / non-actionable — hide from priority steps */
@@ -213,23 +219,27 @@ function copyScheduleJson() {
                 v-if="card.kind === 'expedition' && expeditionParties[card.itemId]?.party.length"
                 class="mt-2 flex flex-wrap items-center gap-1.5 border-t border-border/30 pt-2"
               >
-                <div
+                <RightClickHint
                   v-for="member in expeditionParties[card.itemId].party"
                   :key="member.creature.id"
-                  class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
+                  @contextmenu="openCreature(member.creature)"
                 >
-                  <div class="size-5 overflow-hidden rounded-md bg-card">
-                    <img
-                      v-if="getCreatureImage(member.creature)"
-                      :src="getCreatureImage(member.creature)"
-                      :alt="member.creature.name"
-                      class="size-full object-cover"
-                    />
+                  <div
+                    class="inline-flex cursor-default items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
+                  >
+                    <div class="size-5 overflow-hidden rounded-md bg-card">
+                      <img
+                        v-if="getCreatureImage(member.creature)"
+                        :src="getCreatureImage(member.creature)"
+                        :alt="member.creature.name"
+                        class="size-full object-cover"
+                      />
+                    </div>
+                    <span class="text-[10px] font-semibold text-foreground">
+                      {{ member.creature.name }}
+                    </span>
                   </div>
-                  <span class="text-[10px] font-semibold text-foreground">
-                    {{ member.creature.name }}
-                  </span>
-                </div>
+                </RightClickHint>
               </div>
             </div>
           </div>
@@ -237,4 +247,5 @@ function copyScheduleJson() {
       </div>
     </div>
   </div>
+  <CreatureDetail :creature="selectedCreature" :open="drawerOpen" @close="closeDrawer" />
 </template>

--- a/src/composables/useCreatureDrawer.ts
+++ b/src/composables/useCreatureDrawer.ts
@@ -1,0 +1,31 @@
+import { ref, watch } from 'vue'
+
+import creaturesData from '@/data/creatures.json'
+import type { Creature } from '@/types'
+
+const creatures = creaturesData as Creature[]
+
+export function useCreatureDrawer() {
+  const selectedCreature = ref<Creature | null>(null)
+  const drawerOpen = ref(false)
+
+  watch(selectedCreature, (val) => {
+    if (val) drawerOpen.value = true
+  })
+
+  function openCreature(creature: Creature) {
+    selectedCreature.value = creature
+  }
+
+  function openCreatureById(id: string) {
+    const creature = creatures.find((c) => c.id === id)
+    if (creature) selectedCreature.value = creature
+  }
+
+  function closeDrawer() {
+    drawerOpen.value = false
+    selectedCreature.value = null
+  }
+
+  return { selectedCreature, drawerOpen, openCreature, openCreatureById, closeDrawer }
+}

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Check, Minus, Pencil, Plus, X } from 'lucide-vue-next'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
 import notSummonedIcon from '@/assets/icons/not_summoned.webp'
@@ -11,8 +11,8 @@ import CreatureGrid from '@/components/beastiary/CreatureGrid.vue'
 import CreaturesTable from '@/components/beastiary/CreaturesTable.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
-import type { Creature } from '@/types'
 import { toTitleCase, typeColor } from '@/utils/format'
 import { jobIcons } from '@/utils/icons'
 
@@ -230,24 +230,7 @@ function removeFilter(key: string) {
 }
 
 
-const selectedCreature = ref<Creature | null>(null)
-const panelOpen = ref(false)
-
-
-watch(selectedCreature, (val) => {
-  if (val) panelOpen.value = true
-})
-
-
-function selectCreature(creature: Creature) {
-  selectedCreature.value = creature
-}
-
-
-function closeDetail() {
-  panelOpen.value = false
-  selectedCreature.value = null
-}
+const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
 </script>
 
 <template>
@@ -427,7 +410,7 @@ function closeDetail() {
         :editing="editing"
         :selected-ids="selectedIds"
         :selected-creature-id="selectedCreature?.id ?? null"
-        @select="selectCreature"
+        @select="openCreature"
         @toggle-selected="toggleSelected"
       />
       <CreaturesTable
@@ -436,13 +419,13 @@ function closeDetail() {
         :editing="editing"
         :selected-ids="selectedIds"
         :selected-creature-id="selectedCreature?.id ?? null"
-        @select="selectCreature"
+        @select="openCreature"
         @toggle-selected="toggleSelected"
       />
     </div>
 
     <!-- Detail Panel -->
-    <CreatureDetail :creature="selectedCreature" :open="panelOpen" @close="closeDetail" />
+    <CreatureDetail :creature="selectedCreature" :open="drawerOpen" @close="closeDrawer" />
   </section>
 </template>
 

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -1421,14 +1421,14 @@ function updateAwakenSpeed(ws: string, delta: number) {
                 >
                   {{ slot.name.charAt(0) }}
                 </div>
-                <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1 py-0.5">
+                <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-0.5">
                   <p class="truncate text-center text-[9px] font-semibold text-white">
                     {{ slot.name }}
                   </p>
                 </div>
                 <button
                   v-if="editingSection === 'exclusions'"
-                  class="focus-ring absolute right-0.5 top-0.5 rounded-full bg-black/60 p-0.5 text-white/70 hover:text-white"
+                  class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                   @click.stop="removeFromSanctuary(index)"
                 >
                   <X class="size-3" />
@@ -1477,7 +1477,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
                     class="size-full object-cover"
                     loading="lazy"
                   />
-                  <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1 py-0.5">
+                  <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-0.5">
                     <p class="truncate text-center text-[8px] font-semibold text-white">
                       {{ c.name }}
                     </p>
@@ -1541,14 +1541,14 @@ function updateAwakenSpeed(ws: string, delta: number) {
                 >
                   {{ slot.name.charAt(0) }}
                 </div>
-                <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1 py-0.5">
+                <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-0.5">
                   <p class="truncate text-center text-[9px] font-semibold text-white">
                     {{ slot.name }}
                   </p>
                 </div>
                 <button
                   v-if="editingSection === 'exclusions'"
-                  class="focus-ring absolute right-0.5 top-0.5 rounded-full bg-black/60 p-0.5 text-white/70 hover:text-white"
+                  class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                   @click.stop="removeFromHelpers(index)"
                 >
                   <X class="size-3" />
@@ -1597,7 +1597,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
                     class="size-full object-cover"
                     loading="lazy"
                   />
-                  <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1 py-0.5">
+                  <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-0.5">
                     <p class="truncate text-center text-[8px] font-semibold text-white">
                       {{ c.name }}
                     </p>
@@ -1666,14 +1666,14 @@ function updateAwakenSpeed(ws: string, delta: number) {
                 >
                   {{ slot.name.charAt(0) }}
                 </div>
-                <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1 py-0.5">
+                <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-0.5">
                   <p class="truncate text-center text-[9px] font-semibold text-white">
                     {{ slot.name }}
                   </p>
                 </div>
                 <button
                   v-if="editingSection === 'exclusions'"
-                  class="focus-ring absolute right-0.5 top-0.5 rounded-full bg-black/60 p-0.5 text-white/70 hover:text-white"
+                  class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                   @click.stop="removeFromMachine(index)"
                 >
                   <X class="size-3" />
@@ -1722,7 +1722,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
                     class="size-full object-cover"
                     loading="lazy"
                   />
-                  <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1 py-0.5">
+                  <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-0.5">
                     <p class="truncate text-center text-[8px] font-semibold text-white">
                       {{ c.name }}
                     </p>

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -672,7 +672,7 @@ const tierLevelReq = computed(() => {
                   class="relative size-20 overflow-hidden rounded-lg border transition"
                   :class="[
                     slot
-                      ? 'border-border bg-card/50'
+                      ? 'border-border bg-card/50 hover:border-primary/50'
                       : activeSlotIndex === index
                         ? 'border-dashed border-primary bg-primary/10'
                         : 'cursor-pointer border-dashed border-border/50 bg-muted/20 hover:border-accent/45',

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -5,9 +5,12 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import summonedIcon from '@/assets/icons/summoned.webp'
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
 import { useDungeons } from '@/composables/useDungeons'
 import { useGameConfig } from '@/composables/useGameConfig'
@@ -27,6 +30,12 @@ const { creatures } = useCreatures()
 const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds, expeditionCreatureIds } =
   useGameConfig()
 const { isOwned, isAwakened, collectionLevels } = useCreatureCollection()
+const {
+  selectedCreature: inspectedCreature,
+  drawerOpen: creatureDrawerOpen,
+  openCreature: inspectCreature,
+  closeDrawer: closeCreatureDrawer,
+} = useCreatureDrawer()
 
 
 const {
@@ -674,21 +683,25 @@ const tierLevelReq = computed(() => {
                     <img
                       :src="getCreatureImage(slot)"
                       :alt="`${slot.name} artwork`"
-                      class="size-full object-cover"
+                      class="size-full cursor-pointer object-cover"
                       loading="lazy"
+                      @click="inspectCreature(slot)"
                     />
                     <span
                       class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
                     >
                       {{ getCreatureSlotScore(slot) }}
                     </span>
-                    <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
+                    <div
+                      class="absolute inset-x-0 bottom-0 cursor-pointer select-none bg-black/75 px-1.5 py-1"
+                      @click="inspectCreature(slot)"
+                    >
                       <p class="truncate text-center text-[10px] font-semibold text-white">
                         {{ slot.name }}
                       </p>
                     </div>
                     <button
-                      class="focus-ring absolute right-0.5 top-0.5 rounded-full bg-black/60 p-0.5 text-white/70 hover:text-white"
+                      class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                       @click.stop="removeCreatureFromSlot(index)"
                     >
                       <X class="size-3" />
@@ -936,83 +949,85 @@ const tierLevelReq = computed(() => {
             :class="
               hasEmptySlot
                 ? 'border-border bg-card/50 hover:border-accent/45 hover:bg-muted/25'
-                : 'cursor-not-allowed border-border/50 bg-card/30 opacity-60'
+                : 'border-border/50 bg-card/30 opacity-60'
             "
             @click="chooseCreature(creature)"
           >
             <div class="flex items-start gap-3">
-              <div class="relative shrink-0">
-                <img
-                  :src="getCreatureImage(creature)"
-                  :alt="`${creature.name} artwork`"
-                  class="size-10 rounded-md border border-border object-cover"
-                  loading="lazy"
-                />
-                <img
-                  v-if="sanctuaryCreatureIds.includes(creature.id)"
-                  :src="sanctuaryIcon"
-                  alt="Sanctuary"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-                <img
-                  v-else-if="helperCreatureIds.includes(creature.id)"
-                  :src="helpersIcon"
-                  alt="Helper"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-                <img
-                  v-else-if="machineCreatureIds.includes(creature.id)"
-                  :src="machinesIcon"
-                  alt="Machine"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-                <img
-                  v-else-if="expeditionCreatureIds.has(creature.id)"
-                  :src="expeditionsIcon"
-                  alt="Expedition"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-              </div>
+              <RightClickHint @contextmenu="inspectCreature(creature)">
+                <div class="relative shrink-0">
+                  <img
+                    :src="getCreatureImage(creature)"
+                    :alt="`${creature.name} artwork`"
+                    class="size-10 rounded-md border border-border object-cover"
+                    loading="lazy"
+                  />
+                  <img
+                    v-if="sanctuaryCreatureIds.includes(creature.id)"
+                    :src="sanctuaryIcon"
+                    alt="Sanctuary"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                  <img
+                    v-else-if="helperCreatureIds.includes(creature.id)"
+                    :src="helpersIcon"
+                    alt="Helper"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                  <img
+                    v-else-if="machineCreatureIds.includes(creature.id)"
+                    :src="machinesIcon"
+                    alt="Machine"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                  <img
+                    v-else-if="expeditionCreatureIds.has(creature.id)"
+                    :src="expeditionsIcon"
+                    alt="Expedition"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                </div>
 
-              <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-1">
-                  <p
-                    class="truncate font-semibold"
-                    :class="
-                      isAwakened(creature.id)
-                        ? 'text-pink-600 dark:text-pink-400'
-                        : 'text-foreground'
-                    "
-                  >
-                    {{ creature.name }}
-                  </p>
-                  <span
-                    v-if="isOwned(creature.id)"
-                    class="text-xs"
-                    :class="
-                      isAwakened(creature.id)
-                        ? 'text-pink-600 dark:text-pink-400'
-                        : 'text-amber-700 dark:text-amber-400'
-                    "
-                    >★</span
-                  >
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-1">
+                    <p
+                      class="truncate font-semibold"
+                      :class="
+                        isAwakened(creature.id)
+                          ? 'text-pink-600 dark:text-pink-400'
+                          : 'text-foreground'
+                      "
+                    >
+                      {{ creature.name }}
+                    </p>
+                    <span
+                      v-if="isOwned(creature.id)"
+                      class="text-xs"
+                      :class="
+                        isAwakened(creature.id)
+                          ? 'text-pink-600 dark:text-pink-400'
+                          : 'text-amber-700 dark:text-amber-400'
+                      "
+                      >★</span
+                    >
+                  </div>
+                  <div class="mt-1 flex flex-wrap gap-1 text-xs">
+                    <span
+                      v-for="type in creature.types"
+                      :key="type"
+                      class="rounded-full bg-muted px-2 py-0.5 font-semibold"
+                      :style="{ color: typeColor(type) }"
+                    >
+                      {{ type }}
+                    </span>
+                    <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
+                  </div>
                 </div>
-                <div class="mt-1 flex flex-wrap gap-1 text-xs">
-                  <span
-                    v-for="type in creature.types"
-                    :key="type"
-                    class="rounded-full bg-muted px-2 py-0.5 font-semibold"
-                    :style="{ color: typeColor(type) }"
-                  >
-                    {{ type }}
-                  </span>
-                  <span class="trait-chip">{{ toTitleCase(creature.trait) }}</span>
-                </div>
-              </div>
+              </RightClickHint>
 
               <div class="text-right" @click.stop>
                 <p
@@ -1092,5 +1107,11 @@ const tierLevelReq = computed(() => {
         </div>
       </section>
     </div>
+
+    <CreatureDetail
+      :creature="inspectedCreature"
+      :open="creatureDrawerOpen"
+      @close="closeCreatureDrawer"
+    />
   </section>
 </template>

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -16,7 +16,7 @@ import { useDungeons } from '@/composables/useDungeons'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, ElementType, ExpeditionStatKey, GatheringSubFocus } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { toTitleCase } from '@/utils/format'
+import { toTitleCase, typeColor } from '@/utils/format'
 import { statAbbreviations, statLabels } from '@/utils/formulas'
 import { sanctuaryIcon, helpersIcon, machinesIcon, expeditionsIcon, jobIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
@@ -97,14 +97,6 @@ const selectedCreatureTiers = ref<number[]>([])
 const ownedOnly = ref(true)
 const showMoreCreatureFilters = ref(false)
 const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
-
-
-function typeColor(type: ElementType): string {
-  if (type === 'Fire') return 'hsl(var(--type-fire))'
-  if (type === 'Water') return 'hsl(var(--type-water))'
-  if (type === 'Wind') return 'hsl(var(--type-wind))'
-  return 'hsl(var(--type-earth))'
-}
 
 
 const weightedStats = computed<[ExpeditionStatKey, number][]>(() => {

--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -15,9 +15,12 @@ import {
 import { computed, nextTick, onMounted, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import CreatureSelector from '@/components/expeditions/CreatureSelector.vue'
 import ExpeditionDetail from '@/components/expeditions/ExpeditionDetail.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
 import { useExpeditions } from '@/composables/useExpeditions'
 import { useGameConfig } from '@/composables/useGameConfig'
@@ -301,6 +304,14 @@ function chooseCreature(creature: Creature) {
 }
 
 
+const {
+  selectedCreature: inspectedCreature,
+  drawerOpen: creatureDrawerOpen,
+  openCreature: inspectCreature,
+  closeDrawer: closeCreatureDrawer,
+} = useCreatureDrawer()
+
+
 function clampLevel(level: number): number {
   if (Number.isNaN(level)) return 1
   return Math.max(1, Math.min(120, Math.round(level)))
@@ -500,23 +511,27 @@ function rowSelected(id: string): boolean {
 
               <div class="flex items-center gap-1.5">
                 <div class="flex min-w-0 flex-1 flex-wrap gap-1.5">
-                  <div
+                  <RightClickHint
                     v-for="creature in getPartyCreatures(expedition.id)"
                     :key="creature.id"
-                    class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
+                    @contextmenu="inspectCreature(creature)"
                   >
-                    <div class="size-5 overflow-hidden rounded-md bg-card">
-                      <img
-                        :src="getCreatureImage(creature)"
-                        :alt="creature.name"
-                        class="size-full object-cover"
-                        loading="lazy"
-                      />
+                    <div
+                      class="inline-flex cursor-default items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
+                    >
+                      <div class="size-5 overflow-hidden rounded-md bg-card">
+                        <img
+                          :src="getCreatureImage(creature)"
+                          :alt="creature.name"
+                          class="size-full object-cover"
+                          loading="lazy"
+                        />
+                      </div>
+                      <span class="text-[10px] font-semibold text-foreground">{{
+                        creature.name
+                      }}</span>
                     </div>
-                    <span class="text-[10px] font-semibold text-foreground">{{
-                      creature.name
-                    }}</span>
-                  </div>
+                  </RightClickHint>
                 </div>
                 <div
                   v-if="expeditionEvaluations[expedition.id]"
@@ -573,6 +588,7 @@ function rowSelected(id: string): boolean {
         @update:loop-count="loopCount = $event"
         @set-active-slot="setActiveSlot"
         @remove-creature="removeCreatureFromSlot"
+        @inspect-creature="inspectCreature"
       />
 
       <!-- Column 3: Creature Selector -->
@@ -590,6 +606,7 @@ function rowSelected(id: string): boolean {
         :show-excluded-creatures="showExcludedCreatures"
         @update:show-excluded-creatures="showExcludedCreatures = $event"
         @choose-creature="chooseCreature"
+        @inspect-creature="inspectCreature"
         @step-level="stepCreatureLevel"
         @normalize-level="normalizeLevelOnBlur"
       />
@@ -684,5 +701,11 @@ function rowSelected(id: string): boolean {
         </div>
       </Transition>
     </Teleport>
+
+    <CreatureDetail
+      :creature="inspectedCreature"
+      :open="creatureDrawerOpen"
+      @close="closeCreatureDrawer"
+    />
   </section>
 </template>

--- a/src/views/ItemsView.vue
+++ b/src/views/ItemsView.vue
@@ -3,10 +3,12 @@ import { useMediaQuery } from '@vueuse/core'
 import { computed, ref, nextTick, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import ItemCard from '@/components/items/ItemCard.vue'
 import ItemDetail from '@/components/items/ItemDetail.vue'
 import ItemsToolbar from '@/components/items/ItemsToolbar.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useItems } from '@/composables/useItems'
 import { summoningIndex } from '@/data/indexes'
 import type { Item } from '@/types'
@@ -24,6 +26,14 @@ const {
   getItemById,
   getRecipeUsages,
 } = useItems()
+
+
+const {
+  selectedCreature: drawerCreature,
+  drawerOpen: creatureDrawerOpen,
+  openCreatureById,
+  closeDrawer: closeCreatureDrawer,
+} = useCreatureDrawer()
 
 
 const viewMode = ref<'grid' | 'table'>('grid')
@@ -525,7 +535,12 @@ onMounted(() => {
             tabindex="-1"
             class="surface-card sticky top-28 max-h-[calc(100vh-8rem)] overflow-y-auto outline-none"
           >
-            <ItemDetail :item="selectedItem" @close="closeDetail" @select-item="selectItemById" />
+            <ItemDetail
+              :item="selectedItem"
+              @close="closeDetail"
+              @select-item="selectItemById"
+              @select-creature="openCreatureById"
+            />
           </div>
         </aside>
       </Transition>
@@ -557,11 +572,22 @@ onMounted(() => {
             <div
               class="mx-auto max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-2xl border border-border bg-card shadow-card"
             >
-              <ItemDetail :item="selectedItem" @close="closeDetail" @select-item="selectItemById" />
+              <ItemDetail
+                :item="selectedItem"
+                @close="closeDetail"
+                @select-item="selectItemById"
+                @select-creature="openCreatureById"
+              />
             </div>
           </Transition>
         </div>
       </Transition>
     </Teleport>
+
+    <CreatureDetail
+      :creature="drawerCreature"
+      :open="creatureDrawerOpen"
+      @close="closeCreatureDrawer"
+    />
   </section>
 </template>

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -13,8 +13,8 @@ import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useSanctuary } from '@/composables/useSanctuary'
 import type { Creature, ElementType, Jobs } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { helpersIcon, machinesIcon, expeditionsIcon } from '@/utils/icons'
-import { jobIcons } from '@/utils/icons'
+import { typeColor } from '@/utils/format'
+import { helpersIcon, machinesIcon, expeditionsIcon, jobIcons } from '@/utils/icons'
 import {
   MAX_SANCTUARY_SLOTS,
   SANCTUARY_JOBS,
@@ -85,14 +85,6 @@ const selectedCreatureType = ref<ElementType | 'all'>('all')
 const selectedCreatureTiers = ref<number[]>([])
 const showMoreCreatureFilters = ref(false)
 const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
-
-
-function typeColor(type: ElementType): string {
-  if (type === 'Fire') return 'hsl(var(--type-fire))'
-  if (type === 'Water') return 'hsl(var(--type-water))'
-  if (type === 'Wind') return 'hsl(var(--type-wind))'
-  return 'hsl(var(--type-earth))'
-}
 
 
 const creatureTierOptions = computed(() => {

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -5,8 +5,11 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import summonedIcon from '@/assets/icons/summoned.webp'
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useSanctuary } from '@/composables/useSanctuary'
 import type { Creature, ElementType, Jobs } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
@@ -48,6 +51,12 @@ const {
   jobScores,
   jobTiers,
 } = useSanctuary()
+const {
+  selectedCreature: inspectedCreature,
+  drawerOpen: creatureDrawerOpen,
+  openCreature: inspectCreature,
+  closeDrawer: closeCreatureDrawer,
+} = useCreatureDrawer()
 
 
 // ── Mobile section handling ──
@@ -418,19 +427,23 @@ function chooseCreature(creature: Creature) {
                     <img
                       :src="getCreatureImage(slot)"
                       :alt="slot.name"
-                      class="size-full object-cover"
+                      class="size-full cursor-pointer object-cover"
                       loading="lazy"
+                      @click="inspectCreature(slot)"
                     />
-                    <div class="absolute inset-x-0 bottom-0 bg-black/75 px-0.5 py-0.5">
+                    <div
+                      class="absolute inset-x-0 bottom-0 cursor-pointer select-none bg-black/75 px-0.5 py-0.5"
+                      @click="inspectCreature(slot)"
+                    >
                       <p class="truncate text-center text-[8px] font-semibold text-white">
                         {{ slot.name }}
                       </p>
                     </div>
                     <button
-                      class="focus-ring absolute right-0 top-0 rounded-bl bg-black/60 p-0.5 text-white/70 hover:text-white"
+                      class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                       @click.stop="removeCreatureFromSlot(index)"
                     >
-                      <X class="size-2.5" />
+                      <X class="size-3" />
                     </button>
                   </template>
                   <template v-else>
@@ -729,117 +742,125 @@ function chooseCreature(creature: Creature) {
               :class="
                 hasEmptySlot
                   ? 'border-border/50 bg-card/50 hover:border-accent/45 hover:bg-muted/25'
-                  : 'cursor-not-allowed border-border/30 bg-card/30 opacity-50'
+                  : 'border-border/30 bg-card/30 opacity-50'
               "
               @click="chooseCreature(creature)"
             >
-              <!-- Image + assignment badge -->
-              <div class="relative size-12 shrink-0">
-                <img
-                  :src="getCreatureImage(creature)"
-                  :alt="creature.name"
-                  class="size-12 rounded-md border border-border object-cover"
-                  loading="lazy"
-                />
-                <!-- Tier badge -->
-                <span
-                  class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-[9px] font-bold text-muted-foreground shadow-sm"
-                >
-                  T{{ creature.tier + 1 }}
-                </span>
-                <img
-                  v-if="getCreatureStatus(creature.id) === 'helper'"
-                  :src="helpersIcon"
-                  alt="Helper"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-                <img
-                  v-else-if="getCreatureStatus(creature.id) === 'machine'"
-                  :src="machinesIcon"
-                  alt="Machine"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-                <img
-                  v-else-if="getCreatureStatus(creature.id) === 'expedition'"
-                  :src="expeditionsIcon"
-                  alt="Expedition"
-                  class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                  loading="lazy"
-                />
-              </div>
-
-              <!-- Name + status + Job scores -->
-              <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-0.5">
+              <RightClickHint @contextmenu="inspectCreature(creature)">
+                <!-- Image + assignment badge -->
+                <div class="relative size-12 shrink-0">
+                  <img
+                    :src="getCreatureImage(creature)"
+                    :alt="creature.name"
+                    class="size-12 rounded-md border border-border object-cover"
+                    loading="lazy"
+                  />
+                  <!-- Tier badge -->
                   <span
-                    class="truncate text-sm font-semibold"
-                    :class="
-                      isAwakened(creature.id)
-                        ? 'text-pink-600 dark:text-pink-400'
-                        : 'text-foreground/80'
-                    "
-                    >{{ creature.name }}</span
+                    class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-[9px] font-bold text-muted-foreground shadow-sm"
                   >
-                  <span
-                    v-if="isOwned(creature.id)"
-                    class="shrink-0 text-xs"
-                    :class="
-                      isAwakened(creature.id)
-                        ? 'text-pink-500 dark:text-pink-400'
-                        : 'text-amber-500 dark:text-amber-400'
-                    "
-                    >★</span
-                  >
-                  <span
-                    v-if="score > 0"
-                    class="ml-auto shrink-0 font-mono text-sm font-semibold text-primary"
-                    >{{ score }}</span
-                  >
+                    T{{ creature.tier + 1 }}
+                  </span>
+                  <img
+                    v-if="getCreatureStatus(creature.id) === 'helper'"
+                    :src="helpersIcon"
+                    alt="Helper"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                  <img
+                    v-else-if="getCreatureStatus(creature.id) === 'machine'"
+                    :src="machinesIcon"
+                    alt="Machine"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                  <img
+                    v-else-if="getCreatureStatus(creature.id) === 'expedition'"
+                    :src="expeditionsIcon"
+                    alt="Expedition"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
                 </div>
-                <div class="mt-1 flex gap-1">
-                  <div
-                    v-for="job in SANCTUARY_JOBS"
-                    :key="job"
-                    class="flex flex-1 items-center gap-[2px]"
-                    :title="`${job}: ${creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0}`"
-                  >
-                    <img
-                      :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
-                      :alt="job"
-                      class="size-3.5 shrink-0 opacity-60"
-                      loading="lazy"
-                    />
-                    <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-muted/30">
-                      <div
-                        class="h-full rounded-full"
-                        :style="{
-                          width: `${((creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) / 10) * 100}%`,
-                          backgroundColor:
-                            (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
-                              ? JOB_COLORS[job.toLowerCase()]
-                              : 'transparent',
-                        }"
-                      />
-                    </div>
+
+                <!-- Name + status + Job scores -->
+                <div class="min-w-0 flex-1">
+                  <div class="flex items-center gap-0.5">
                     <span
-                      class="w-3 shrink-0 text-right font-mono text-[10px] font-semibold"
+                      class="truncate text-sm font-semibold"
                       :class="
-                        (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
-                          ? 'text-muted-foreground'
-                          : 'text-muted-foreground/30'
+                        isAwakened(creature.id)
+                          ? 'text-pink-600 dark:text-pink-400'
+                          : 'text-foreground/80'
                       "
+                      >{{ creature.name }}</span
                     >
-                      {{ creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0 }}
-                    </span>
+                    <span
+                      v-if="isOwned(creature.id)"
+                      class="shrink-0 text-xs"
+                      :class="
+                        isAwakened(creature.id)
+                          ? 'text-pink-500 dark:text-pink-400'
+                          : 'text-amber-500 dark:text-amber-400'
+                      "
+                      >★</span
+                    >
+                    <span
+                      v-if="score > 0"
+                      class="ml-auto shrink-0 font-mono text-sm font-semibold text-primary"
+                      >{{ score }}</span
+                    >
+                  </div>
+                  <div class="mt-1 flex gap-1">
+                    <div
+                      v-for="job in SANCTUARY_JOBS"
+                      :key="job"
+                      class="flex flex-1 items-center gap-[2px]"
+                      :title="`${job}: ${creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0}`"
+                    >
+                      <img
+                        :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
+                        :alt="job"
+                        class="size-3.5 shrink-0 opacity-60"
+                        loading="lazy"
+                      />
+                      <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-muted/30">
+                        <div
+                          class="h-full rounded-full"
+                          :style="{
+                            width: `${((creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) / 10) * 100}%`,
+                            backgroundColor:
+                              (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
+                                ? JOB_COLORS[job.toLowerCase()]
+                                : 'transparent',
+                          }"
+                        />
+                      </div>
+                      <span
+                        class="w-3 shrink-0 text-right font-mono text-[10px] font-semibold"
+                        :class="
+                          (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
+                            ? 'text-muted-foreground'
+                            : 'text-muted-foreground/30'
+                        "
+                      >
+                        {{ creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0 }}
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </RightClickHint>
             </button>
           </div>
         </div>
       </section>
     </div>
+
+    <CreatureDetail
+      :creature="inspectedCreature"
+      :open="creatureDrawerOpen"
+      @close="closeCreatureDrawer"
+    />
   </div>
 </template>

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -416,7 +416,7 @@ function chooseCreature(creature: Creature) {
                   class="relative size-14 overflow-hidden rounded-lg border transition"
                   :class="[
                     slot
-                      ? 'border-border bg-card/50'
+                      ? 'border-border bg-card/50 hover:border-primary/50'
                       : activeSlotIndex === index
                         ? 'border-dashed border-primary bg-primary/10'
                         : 'cursor-pointer border-dashed border-border/50 bg-muted/20 hover:border-accent/45',

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -14,13 +14,16 @@ import {
 } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import PlannerEmptyState from '@/components/planner/PlannerEmptyState.vue'
 import PlannerTreeNode from '@/components/planner/PlannerTreeNode.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import SummoningCreatureFilter from '@/components/summoning-planner/SummoningCreatureFilter.vue'
 import SummoningMaterialTree from '@/components/summoning-planner/SummoningMaterialTree.vue'
 import SummoningObjectiveCard from '@/components/summoning-planner/SummoningObjectiveCard.vue'
 import SummoningTimeline from '@/components/summoning-planner/SummoningTimeline.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useGoldIncome } from '@/composables/useGoldIncome'
@@ -55,6 +58,12 @@ const { creatures } = useCreatures()
 const { ownedCreatureIds, getLevel, isAwakened, collectionLevels } = useCreatureCollection()
 const gameConfig = useGameConfig()
 const { goldPerMinute, breakdown: goldBreakdown } = useGoldIncome()
+const {
+  selectedCreature: inspectedCreature,
+  drawerOpen: creatureDrawerOpen,
+  openCreature: inspectCreature,
+  closeDrawer: closeCreatureDrawer,
+} = useCreatureDrawer()
 
 
 const expeditions = expeditionsData as Expedition[]
@@ -1554,37 +1563,41 @@ const flatGroupedCosts = computed(() => {
                       <!-- Active party -->
                       <div class="flex items-center gap-1.5">
                         <div class="flex min-w-0 flex-1 flex-wrap gap-1.5">
-                          <div
+                          <RightClickHint
                             v-for="member in getActiveExpeditionParty(cost.sortedIndex)!
                               .activeVariant.party"
                             :key="member.creature.id"
-                            class="inline-flex items-center gap-1.5 rounded-lg border py-0.5 pl-0.5 pr-2"
-                            :class="
-                              conflictedCreatureIds.has(member.creature.id)
-                                ? 'cursor-default border-amber-500/50 bg-amber-500/10'
-                                : 'border-border bg-muted/35'
-                            "
-                            @mouseenter="
-                              onConflictEnter(
-                                member.creature.id,
-                                getActiveExpeditionParty(cost.sortedIndex)!.expeditionName,
-                                $event,
-                              )
-                            "
-                            @mouseleave="onConflictLeave"
+                            @contextmenu="inspectCreature(member.creature)"
                           >
-                            <div class="size-5 overflow-hidden rounded-md bg-card">
-                              <img
-                                v-if="getCreatureImage(member.creature)"
-                                :src="getCreatureImage(member.creature)"
-                                :alt="member.creature.name"
-                                class="size-full object-cover"
-                              />
+                            <div
+                              class="inline-flex cursor-default items-center gap-1.5 rounded-lg border py-0.5 pl-0.5 pr-2"
+                              :class="
+                                conflictedCreatureIds.has(member.creature.id)
+                                  ? 'cursor-default border-amber-500/50 bg-amber-500/10'
+                                  : 'border-border bg-muted/35'
+                              "
+                              @mouseenter="
+                                onConflictEnter(
+                                  member.creature.id,
+                                  getActiveExpeditionParty(cost.sortedIndex)!.expeditionName,
+                                  $event,
+                                )
+                              "
+                              @mouseleave="onConflictLeave"
+                            >
+                              <div class="size-5 overflow-hidden rounded-md bg-card">
+                                <img
+                                  v-if="getCreatureImage(member.creature)"
+                                  :src="getCreatureImage(member.creature)"
+                                  :alt="member.creature.name"
+                                  class="size-full object-cover"
+                                />
+                              </div>
+                              <span class="text-[10px] font-semibold text-foreground">{{
+                                member.creature.name
+                              }}</span>
                             </div>
-                            <span class="text-[10px] font-semibold text-foreground">{{
-                              member.creature.name
-                            }}</span>
-                          </div>
+                          </RightClickHint>
                         </div>
                         <div class="flex shrink-0 items-center gap-1.5 font-mono text-xs">
                           <span class="text-muted-foreground">
@@ -1622,23 +1635,27 @@ const flatGroupedCosts = computed(() => {
                               >Alt</span
                             >
                             <div class="flex min-w-0 flex-1 flex-wrap gap-1">
-                              <div
+                              <RightClickHint
                                 v-for="member in variant.party"
                                 :key="member.creature.id"
-                                class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-muted/25 py-0.5 pl-0.5 pr-1.5"
+                                @contextmenu="inspectCreature(member.creature)"
                               >
-                                <div class="size-4 overflow-hidden rounded bg-card">
-                                  <img
-                                    v-if="getCreatureImage(member.creature)"
-                                    :src="getCreatureImage(member.creature)"
-                                    :alt="member.creature.name"
-                                    class="size-full object-cover"
-                                  />
+                                <div
+                                  class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-muted/25 py-0.5 pl-0.5 pr-1.5"
+                                >
+                                  <div class="size-4 overflow-hidden rounded bg-card">
+                                    <img
+                                      v-if="getCreatureImage(member.creature)"
+                                      :src="getCreatureImage(member.creature)"
+                                      :alt="member.creature.name"
+                                      class="size-full object-cover"
+                                    />
+                                  </div>
+                                  <span class="text-[9px] font-semibold text-muted-foreground">{{
+                                    member.creature.name
+                                  }}</span>
                                 </div>
-                                <span class="text-[9px] font-semibold text-muted-foreground">{{
-                                  member.creature.name
-                                }}</span>
-                              </div>
+                              </RightClickHint>
                             </div>
                             <span class="shrink-0 font-mono text-[10px] text-muted-foreground">
                               {{ formatDuration(variant.totalTime) }}
@@ -1739,6 +1756,12 @@ const flatGroupedCosts = computed(() => {
         </div>
       </Transition>
     </Teleport>
+
+    <CreatureDetail
+      :creature="inspectedCreature"
+      :open="creatureDrawerOpen"
+      @close="closeCreatureDrawer"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Description

Implements consistent creature inspection across all pages by extracting a reusable `useCreatureDrawer` composable and `RightClickHint` component. Creature tiles and chips throughout the app now afford interaction — right-click to inspect on creature selectors and expedition chips, left-click on party slots where no competing action exists. Party slot X buttons are redesigned with a corner-flush destructive hover style for clearer distinction from the inspection action. Closes #67

## Summary

- Add `RightClickHint` component that shows a cursor-following tooltip on hover and emits a contextmenu event, replacing the browser default right-click
- Extract `useCreatureDrawer` composable from `BeastiaryView` so any page can open the `CreatureDetail` drawer
- Add right-click creature inspection to `CreatureSelector` (name, type badges, trait chip), expedition card creature chips, and creature selector rows on Dungeons and Sanctuary pages
- Add right-click creature inspection to `SummoningTimeline`, `SummoningExpeditionPlan`, and `SummoningPlannerView` tree view creature chips
- Add right-click creature inspection to level planner components (`PartyCreatureTile`, `LevelPlannerCreaturePicker`, `LevelPlannerTimelineStep`, `PartyPlannerGantt`)
- Add left-click creature inspection to party slot images and names on Expeditions, Dungeons, and Sanctuary pages
- Add click-through creature inspection from `ItemDetail` summoning section creature tiles to `ItemsView`
- Redesign party slot X buttons across Expeditions, Dungeons, Sanctuary, and Configs with corner-flush style and `hover:bg-destructive`
- Add `hover:border-primary/50` to filled party slot containers for hover affordance
- Add `cursor-default` and `select-none` to creature chips and party slot name overlays to prevent text-select cursor
- Remove `cursor-not-allowed` from disabled creature selector rows so right-click remains accessible
- Replace duplicate local `typeColor` functions in `DungeonsView` and `SanctuaryView` with shared import from `@/utils/format`