### PR TITLE
Centralize expedition state and filter unawakened sanctuary creatures

### DIFF
--- a/e2e/configs.spec.ts
+++ b/e2e/configs.spec.ts
@@ -392,17 +392,18 @@ test.describe('reset all', () => {
     await expect(page.getByText('No garden flowers configured.')).toBeVisible()
     await expect(page.getByText('Yield +0, Duration -0%').first()).toBeVisible()
 
-    // Verify expedition setup keys are cleared
+    // Verify expedition setup keys are cleared (useLocalStorage writes the
+    // default value rather than removing the key, so we check for empty objects)
     const expeditionKeys = await page.evaluate(() => ({
-      parties: localStorage.getItem('expedition-parties'),
-      tiers: localStorage.getItem('expedition-tiers'),
-      levels: localStorage.getItem('expedition-creature-levels'),
-      loopCounts: localStorage.getItem('expedition-loop-counts'),
+      parties: JSON.parse(localStorage.getItem('expedition-parties') ?? '{}'),
+      tiers: JSON.parse(localStorage.getItem('expedition-tiers') ?? '{}'),
+      levels: JSON.parse(localStorage.getItem('expedition-creature-levels') ?? '{}'),
+      loopCounts: JSON.parse(localStorage.getItem('expedition-loop-counts') ?? '{}'),
     }))
-    expect(expeditionKeys.parties).toBeNull()
-    expect(expeditionKeys.tiers).toBeNull()
-    expect(expeditionKeys.levels).toBeNull()
-    expect(expeditionKeys.loopCounts).toBeNull()
+    expect(expeditionKeys.parties).toEqual({})
+    expect(expeditionKeys.tiers).toEqual({})
+    expect(expeditionKeys.levels).toEqual({})
+    expect(expeditionKeys.loopCounts).toEqual({})
   })
 })
 

--- a/src/components/level-planner/PartyPlannerResults.vue
+++ b/src/components/level-planner/PartyPlannerResults.vue
@@ -4,6 +4,7 @@ import { ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
+import { useGameConfig } from '@/composables/useGameConfig'
 import biomesData from '@/data/biomes.json'
 import type { PartyLevelingPlan, Creature, PartyPlanStep, PlannerStrategy } from '@/types'
 import type { Biome } from '@/types'
@@ -31,6 +32,16 @@ const props = defineProps<{
 
 
 const router = useRouter()
+const {
+  expeditionParties,
+  expeditionCreatureLevels,
+  expeditionTiers,
+  expeditionLoopCounts,
+  setExpeditionParties,
+  setExpeditionCreatureLevels,
+  setExpeditionTiers,
+  setExpeditionLoopCounts,
+} = useGameConfig()
 const viewMode = ref<'timeline' | 'steps' | 'chart'>('timeline')
 const expandedIndex = ref<number | null>(null)
 const copied = ref(false)
@@ -262,18 +273,10 @@ const stepsAsPlanSteps = computed(() => {
 
 
 function writeExpeditionSetup(steps: PartyPlanStep[], merge: boolean) {
-  const parties: Record<string, string[]> = merge
-    ? JSON.parse(localStorage.getItem('expedition-parties') ?? '{}')
-    : {}
-  const levels: Record<string, number> = merge
-    ? JSON.parse(localStorage.getItem('expedition-creature-levels') ?? '{}')
-    : {}
-  const tiers: Record<string, number> = merge
-    ? JSON.parse(localStorage.getItem('expedition-tiers') ?? '{}')
-    : {}
-  const loopCounts: Record<string, number> = merge
-    ? JSON.parse(localStorage.getItem('expedition-loop-counts') ?? '{}')
-    : {}
+  const parties: Record<string, string[]> = merge ? { ...expeditionParties.value } : {}
+  const levels: Record<string, number> = merge ? { ...expeditionCreatureLevels.value } : {}
+  const tiers: Record<string, number> = merge ? { ...expeditionTiers.value } : {}
+  const loopCounts: Record<string, number> = merge ? { ...expeditionLoopCounts.value } : {}
 
 
   for (const step of steps) {
@@ -302,10 +305,10 @@ function writeExpeditionSetup(steps: PartyPlanStep[], merge: boolean) {
   }
 
 
-  localStorage.setItem('expedition-parties', JSON.stringify(parties))
-  localStorage.setItem('expedition-creature-levels', JSON.stringify(levels))
-  localStorage.setItem('expedition-tiers', JSON.stringify(tiers))
-  localStorage.setItem('expedition-loop-counts', JSON.stringify(loopCounts))
+  setExpeditionParties(parties)
+  setExpeditionCreatureLevels(levels)
+  setExpeditionTiers(tiers)
+  setExpeditionLoopCounts(loopCounts)
 }
 
 

--- a/src/composables/__tests__/useGameConfig.test.ts
+++ b/src/composables/__tests__/useGameConfig.test.ts
@@ -2,9 +2,8 @@ import { useGameConfig } from '@/composables/useGameConfig'
 
 describe('useGameConfig', () => {
   beforeEach(() => {
-    const { resetGameConfig, expeditionParties } = useGameConfig()
+    const { resetGameConfig } = useGameConfig()
     resetGameConfig()
-    expeditionParties.value = {}
   })
 
   test('excludedCreatureIds combines sanctuary, helper, machine, and expedition IDs', () => {
@@ -221,5 +220,62 @@ describe('useGameConfig', () => {
     expect(machineLevels.value).toEqual({})
     expect(machineRecipes.value).toEqual({})
     expect(fabricationAllocations.value).toEqual({})
+  })
+
+  test('resetGameConfig clears every settable field back to defaults', () => {
+    const config = useGameConfig()
+
+    // Set every piece of state to a non-default value
+    config.setSanctuaryCreatures(['c1', 'c2'])
+    config.setHelperCreatures(['h1'])
+    config.setMachineCreatures(['m1'])
+    config.setExpeditionToolXpBonus(1.25)
+    config.setInventory('twig', 10)
+    config.setGardenFlowerEntries('fire-flower', [{ level: 3, count: 2 }])
+    config.setAwakenGatherYieldBonus('Chopping', 2)
+    config.setAwakenGatherDurationTier('Mining', 3)
+    config.setAwakenSpeedTier('Furnace', 4)
+    config.setAwakenGoldLevel(3)
+    config.setExpeditionCompletions({ 'expedition-type-1': { 1: 5 } })
+    config.setExpeditionParties({ 'expedition-type-1': ['c1', 'c2'] })
+    config.setExpeditionTiers({ 'expedition-type-1': 3 })
+    config.setExpeditionCreatureLevels({ c1: 50, c2: 30 })
+    config.setExpeditionLoopCounts({ 'expedition-type-1': 10 })
+    config.setToolLevels({ axe: 5 })
+    config.setToolSpeedModes({ Furnace: true })
+    config.setMachineLevels({ smelter: 3 })
+    config.setMachineRecipes({ smelter: 'copper-ore' })
+    config.setFabricationAllocations({ 'pine-log': 2 })
+    config.setSkillLevels({ mining: 5 })
+    config.setQueuedAmounts({ Furnace: { 'copper-bar': 10 } })
+    config.setQueuedTimes({ Furnace: 5000 })
+
+    // Reset everything
+    config.resetGameConfig()
+
+    // Verify every field is back to its default
+    expect(config.sanctuaryCreatureIds.value).toEqual([])
+    expect(config.helperCreatureIds.value).toEqual([])
+    expect(config.machineCreatureIds.value).toEqual([])
+    expect(config.expeditionToolXpBonus.value).toBe(1)
+    expect(config.inventoryAmounts.value).toEqual({})
+    expect(config.gardenFlowers.value['fire-flower']).toEqual([])
+    expect(config.awakenGatherUpgrades.value['Chopping'].yieldBonus).toBe(0)
+    expect(config.awakenGatherUpgrades.value['Mining'].durationTier).toBe(0)
+    expect(config.awakenSpeedTiers.value['Furnace']).toBe(0)
+    expect(config.awakenGoldLevel.value).toBe(0)
+    expect(config.expeditionCompletions.value).toEqual({})
+    expect(config.expeditionParties.value).toEqual({})
+    expect(config.expeditionTiers.value).toEqual({})
+    expect(config.expeditionCreatureLevels.value).toEqual({})
+    expect(config.expeditionLoopCounts.value).toEqual({})
+    expect(config.toolLevels.value).toEqual({})
+    expect(config.toolSpeedModes.value).toEqual({})
+    expect(config.machineLevels.value).toEqual({})
+    expect(config.machineRecipes.value).toEqual({})
+    expect(config.fabricationAllocations.value).toEqual({})
+    expect(config.skillLevels.value).toEqual({})
+    expect(config.queuedAmounts.value).toEqual({})
+    expect(config.queuedTimes.value).toEqual({})
   })
 })

--- a/src/composables/__tests__/useSanctuary.test.ts
+++ b/src/composables/__tests__/useSanctuary.test.ts
@@ -1,3 +1,4 @@
+import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useSanctuary } from '@/composables/useSanctuary'
@@ -7,6 +8,8 @@ describe('useSanctuary', () => {
   beforeEach(() => {
     const { resetGameConfig } = useGameConfig()
     resetGameConfig()
+    const { resetCollection } = useCreatureCollection()
+    resetCollection()
     localStorage.removeItem('sanctuary-target-tiers')
   })
 
@@ -305,6 +308,70 @@ describe('useSanctuary', () => {
       for (const job of SANCTUARY_JOBS) {
         expect(maxAchievableTiers.value[job]).toBeLessThanOrEqual(5)
       }
+    })
+
+    test('excludes owned-but-unawakened creatures from calculation', () => {
+      const { creatures } = useCreatures()
+      const { setOwned, setAwakened } = useCreatureCollection()
+
+      // Pick a creature with non-zero job scores
+      const creature = creatures.value.find((c) => Object.values(c.jobs).some((v) => v > 0))!
+
+      // Owned but NOT awakened — should be excluded from tier calc
+      setOwned(creature.id, true)
+
+      const { maxAchievableTiers } = useSanctuary()
+      const tiersExcluded = { ...maxAchievableTiers.value }
+
+      // Now awaken — should be included
+      setAwakened(creature.id, true)
+      const tiersIncluded = { ...maxAchievableTiers.value }
+
+      // Tiers should be at least as high when the creature is available
+      for (const job of SANCTUARY_JOBS) {
+        expect(tiersIncluded[job]).toBeGreaterThanOrEqual(tiersExcluded[job])
+      }
+    })
+  })
+
+  describe('owned-but-unawakened filtering', () => {
+    test('recommendedCreatures excludes owned-but-unawakened creatures', () => {
+      const { creatures } = useCreatures()
+      const { setOwned } = useCreatureCollection()
+      const { recommendedCreatures } = useSanctuary()
+      const creature = creatures.value[0]
+
+      // Mark as owned but not awakened (awakened defaults to false)
+      setOwned(creature.id, true)
+
+      const ids = recommendedCreatures.value.map(({ creature: c }) => c.id)
+      expect(ids).not.toContain(creature.id)
+    })
+
+    test('recommendedCreatures shows owned-but-unawakened when showExcludedCreatures is on', () => {
+      const { creatures } = useCreatures()
+      const { setOwned } = useCreatureCollection()
+      const { recommendedCreatures, showExcludedCreatures } = useSanctuary()
+      const creature = creatures.value[0]
+
+      setOwned(creature.id, true)
+      showExcludedCreatures.value = true
+
+      const ids = recommendedCreatures.value.map(({ creature: c }) => c.id)
+      expect(ids).toContain(creature.id)
+    })
+
+    test('recommendedCreatures includes owned-and-awakened creatures', () => {
+      const { creatures } = useCreatures()
+      const { setOwned, setAwakened } = useCreatureCollection()
+      const { recommendedCreatures } = useSanctuary()
+      const creature = creatures.value[0]
+
+      setOwned(creature.id, true)
+      setAwakened(creature.id, true)
+
+      const ids = recommendedCreatures.value.map(({ creature: c }) => c.id)
+      expect(ids).toContain(creature.id)
     })
   })
 })

--- a/src/composables/useExpeditions.ts
+++ b/src/composables/useExpeditions.ts
@@ -1,4 +1,3 @@
-import { useLocalStorage } from '@vueuse/core'
 import { ref, computed, watch } from 'vue'
 
 import biomesData from '@/data/biomes.json'
@@ -24,16 +23,22 @@ const expeditions = ref<Expedition[]>(expeditionsData as Expedition[])
 const biomes = ref<Biome[]>(biomesData as Biome[])
 
 export function useExpeditions(creatures: Creature[]) {
-  const { excludedCreatureIds, expeditionToolXpBonus, expeditionParties } = useGameConfig()
+  const {
+    excludedCreatureIds,
+    expeditionToolXpBonus,
+    expeditionParties,
+    expeditionTiers,
+    expeditionCreatureLevels,
+    expeditionLoopCounts,
+  } = useGameConfig()
   const showExcludedCreatures = ref(false)
   const searchQuery = ref('')
   const biomeFilter = ref<string | 'all'>('all')
   const selectedExpedition = ref<Expedition | null>(null)
-  const expeditionTiers = useLocalStorage<Record<string, number>>('expedition-tiers', {})
   const selectedTier = ref(1)
   const partySlots = ref<(Creature | null)[]>([])
   const activeSlotIndex = ref<number | null>(null)
-  const creatureLevels = useLocalStorage<Record<string, number>>('expedition-creature-levels', {})
+  const creatureLevels = expeditionCreatureLevels
 
   const filteredExpeditions = computed(() => {
     return expeditions.value
@@ -251,8 +256,6 @@ export function useExpeditions(creatures: Creature[]) {
     if (difficultyRating.value <= 0 || partyScore.value <= 0) return null
     return partyScore.value / difficultyRating.value
   })
-
-  const expeditionLoopCounts = useLocalStorage<Record<string, number>>('expedition-loop-counts', {})
 
   const loopCount = computed({
     get: () =>

--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -15,6 +15,12 @@ const helperCreatureIds = useLocalStorage<string[]>('config-helper-creatures', [
 const machineCreatureIds = useLocalStorage<string[]>('config-machine-creature-ids', [])
 const expeditionToolXpBonus = useLocalStorage<number>('config-tool-xp-bonus', 1)
 const expeditionParties = useLocalStorage<Record<string, string[]>>('expedition-parties', {})
+const expeditionTiers = useLocalStorage<Record<string, number>>('expedition-tiers', {})
+const expeditionCreatureLevels = useLocalStorage<Record<string, number>>(
+  'expedition-creature-levels',
+  {},
+)
+const expeditionLoopCounts = useLocalStorage<Record<string, number>>('expedition-loop-counts', {})
 
 const inventoryAmounts = useLocalStorage<Record<string, number>>('config-inventory', {})
 const gardenFlowers = useLocalStorage<Record<string, GardenFlowerEntry[]>>(
@@ -202,6 +208,29 @@ export function useGameConfig() {
     queuedTimes.value = {}
   }
 
+  function setExpeditionParties(parties: Record<string, string[]>) {
+    expeditionParties.value = parties
+  }
+
+  function setExpeditionTiers(tiers: Record<string, number>) {
+    expeditionTiers.value = tiers
+  }
+
+  function setExpeditionCreatureLevels(levels: Record<string, number>) {
+    expeditionCreatureLevels.value = levels
+  }
+
+  function setExpeditionLoopCounts(counts: Record<string, number>) {
+    expeditionLoopCounts.value = counts
+  }
+
+  function resetExpeditionSetup() {
+    expeditionParties.value = {}
+    expeditionTiers.value = {}
+    expeditionCreatureLevels.value = {}
+    expeditionLoopCounts.value = {}
+  }
+
   function resetGameConfig() {
     sanctuaryCreatureIds.value = []
     helperCreatureIds.value = []
@@ -210,12 +239,13 @@ export function useGameConfig() {
     resetInventory()
     resetGarden()
     resetAwaken()
+    awakenGoldLevel.value = 0
     expeditionCompletions.value = {}
+    resetExpeditionSetup()
     resetToolLevels()
     resetMachines()
     resetFabrication()
     resetQueuedAmounts()
-    awakenGoldLevel.value = 0
     resetSkillLevels()
   }
 
@@ -224,6 +254,9 @@ export function useGameConfig() {
     helperCreatureIds,
     machineCreatureIds,
     expeditionParties,
+    expeditionTiers,
+    expeditionCreatureLevels,
+    expeditionLoopCounts,
     expeditionCreatureIds,
     excludedCreatureIds,
     jobTiers,
@@ -241,6 +274,11 @@ export function useGameConfig() {
     setHelperCreatures,
     setMachineCreatures,
     setExpeditionCompletions,
+    setExpeditionParties,
+    setExpeditionTiers,
+    setExpeditionCreatureLevels,
+    setExpeditionLoopCounts,
+    resetExpeditionSetup,
     setInventory,
     resetInventory,
     setGardenFlowerEntries,

--- a/src/composables/useSanctuary.ts
+++ b/src/composables/useSanctuary.ts
@@ -153,6 +153,7 @@ export function useSanctuary() {
     const available = creatures.value.filter((c) => {
       if (partyCreatureIds.value.has(c.id)) return false
       if (ownedOnly.value && !isOwned(c.id)) return false
+      if (isOwned(c.id) && !isAwakened(c.id)) return false
       return true
     })
 
@@ -206,6 +207,7 @@ export function useSanctuary() {
     const browsable = creatures.value.filter((c) => {
       if (partyCreatureIds.value.has(c.id)) return false
       if (!showExcludedCreatures.value && excludedCreatureIds.value.has(c.id)) return false
+      if (isOwned(c.id) && !isAwakened(c.id)) return showExcludedCreatures.value
       return true
     })
 

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -960,6 +960,9 @@ function resetAll() {
   resetExpeditions()
   resetSkillLevels()
   resetCollection()
+  localStorage.removeItem('dungeon-party')
+  localStorage.removeItem('dungeon-creature-levels')
+  localStorage.removeItem('summoning-planner-selection')
 }
 
 

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -91,6 +91,11 @@ const {
   setQueuedAmounts,
   setQueuedTimes,
   resetQueuedAmounts,
+  setExpeditionParties,
+  setExpeditionTiers,
+  setExpeditionCreatureLevels,
+  setExpeditionLoopCounts,
+  resetExpeditionSetup,
 } = useGameConfig()
 
 
@@ -814,19 +819,10 @@ function applyExpeditionCompletions() {
 
 function applyExpedition() {
   if (!saveConfig.value) return
-  localStorage.setItem(
-    'expedition-parties',
-    JSON.stringify(saveConfig.value.currentExpedition.parties),
-  )
-  localStorage.setItem(
-    'expedition-creature-levels',
-    JSON.stringify(saveConfig.value.currentExpedition.levels),
-  )
-  localStorage.setItem('expedition-tiers', JSON.stringify(saveConfig.value.currentExpedition.tiers))
-  localStorage.setItem(
-    'expedition-loop-counts',
-    JSON.stringify(saveConfig.value.currentExpedition.loopCounts),
-  )
+  setExpeditionParties({ ...saveConfig.value.currentExpedition.parties })
+  setExpeditionCreatureLevels({ ...saveConfig.value.currentExpedition.levels })
+  setExpeditionTiers({ ...saveConfig.value.currentExpedition.tiers })
+  setExpeditionLoopCounts({ ...saveConfig.value.currentExpedition.loopCounts })
 }
 
 
@@ -884,10 +880,7 @@ function resetAwaken() {
 
 function resetExpeditions() {
   expeditionCompletions.value = {}
-  localStorage.removeItem('expedition-parties')
-  localStorage.removeItem('expedition-creature-levels')
-  localStorage.removeItem('expedition-tiers')
-  localStorage.removeItem('expedition-loop-counts')
+  resetExpeditionSetup()
 }
 
 
@@ -956,9 +949,12 @@ function toggleExpeditionTier(expeditionId: string, tier: number) {
 function resetAll() {
   resetExclusions()
   resetInventory()
+  resetQueuedAmounts()
   resetGarden()
   resetAwaken()
+  setAwakenGoldLevel(0)
   resetToolLevels()
+  setExpeditionToolXpBonus(1)
   resetMachines()
   resetFabrication()
   resetExpeditions()

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -8,6 +8,7 @@ import summonedIcon from '@/assets/icons/summoned.webp'
 import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import AppTooltip from '@/components/shared/AppTooltip.vue'
 import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useSanctuary } from '@/composables/useSanctuary'
@@ -798,6 +799,16 @@ function chooseCreature(creature: Creature) {
                       "
                       >★</span
                     >
+                    <AppTooltip
+                      v-if="isOwned(creature.id) && !isAwakened(creature.id)"
+                      text="Must be awakened to place in Sanctuary in-game"
+                      position="top"
+                    >
+                      <span
+                        class="shrink-0 cursor-help rounded border border-amber-500/30 bg-amber-500/10 px-1 py-px text-[9px] font-semibold text-amber-500 dark:text-amber-400"
+                        >Not Awakened</span
+                      >
+                    </AppTooltip>
                     <span
                       v-if="score > 0"
                       class="ml-auto shrink-0 font-mono text-sm font-semibold text-primary"


### PR DESCRIPTION
## Description

Centralizes scattered expedition localStorage state (tiers, creature levels, loop counts) into `useGameConfig` with proper setters and reset functions, then uses that centralized state to filter owned-but-unawakened creatures from Sanctuary recommendations since they can't be placed in-game.

## Summary
- Move `expeditionTiers`, `expeditionCreatureLevels`, and `expeditionLoopCounts` from local `useLocalStorage` calls in `useExpeditions` into `useGameConfig` with setters and `resetExpeditionSetup`
- Replace raw `localStorage` reads/writes in `ConfigsView` and `PartyPlannerResults` with the new config setters
- Fix `resetAll` in `ConfigsView` to also clear queued amounts, awaken gold level, and expedition tool XP bonus
- Filter owned-but-unawakened creatures from `recommendedCreatures` and `maxAchievableTiers` in `useSanctuary`
- Add "Not Awakened" tooltip badge in `SanctuaryView` creature browser
- Add comprehensive `resetGameConfig` test covering every settable field and sanctuary tests for the awakened filtering behavior