### PR TITLE
Redesign sanctuary job display and add sort-by-job

### DIFF
--- a/src/utils/__tests__/sanctuaryHelpers.test.ts
+++ b/src/utils/__tests__/sanctuaryHelpers.test.ts
@@ -1,0 +1,151 @@
+import {
+  tierBenefitType,
+  tierIncrementalLabel,
+  progressPercent,
+  targetPercent,
+  isScoreAtThreshold,
+  TIER_THRESHOLDS_RAW,
+  MAX_TIER,
+  MAX_SCORE,
+  SCORE_DIVISOR,
+} from '@/utils/sanctuaryConstants'
+
+describe('MAX_SCORE', () => {
+  test('equals the last tier threshold', () => {
+    expect(MAX_SCORE).toBe(TIER_THRESHOLDS_RAW[TIER_THRESHOLDS_RAW.length - 1])
+  })
+
+  test('equals 0.9 * SCORE_DIVISOR', () => {
+    expect(MAX_SCORE).toBe(0.9 * SCORE_DIVISOR)
+  })
+})
+
+describe('tierBenefitType', () => {
+  test('returns "xp" for out-of-range tiers', () => {
+    expect(tierBenefitType(0)).toBe('xp')
+    expect(tierBenefitType(-1)).toBe('xp')
+    expect(tierBenefitType(6)).toBe('xp')
+  })
+
+  test('tier 1 is xp (first XP bonus)', () => {
+    expect(tierBenefitType(1)).toBe('xp')
+  })
+
+  test('tier 2 is duration (first duration reduction)', () => {
+    expect(tierBenefitType(2)).toBe('duration')
+  })
+
+  test('tier 3 is xp (XP increases again)', () => {
+    expect(tierBenefitType(3)).toBe('xp')
+  })
+
+  test('tier 4 is duration (duration increases again)', () => {
+    expect(tierBenefitType(4)).toBe('duration')
+  })
+
+  test('tier 5 is yield (first yield bonus)', () => {
+    expect(tierBenefitType(5)).toBe('yield')
+  })
+})
+
+describe('tierIncrementalLabel', () => {
+  test('returns empty string for out-of-range tiers', () => {
+    expect(tierIncrementalLabel(0)).toBe('')
+    expect(tierIncrementalLabel(-1)).toBe('')
+    expect(tierIncrementalLabel(6)).toBe('')
+  })
+
+  test('tier 1 shows XP increase', () => {
+    expect(tierIncrementalLabel(1)).toBe('+20% XP')
+  })
+
+  test('tier 2 shows duration reduction', () => {
+    expect(tierIncrementalLabel(2)).toBe('-10% Dur')
+  })
+
+  test('tier 3 shows XP increase', () => {
+    expect(tierIncrementalLabel(3)).toBe('+20% XP')
+  })
+
+  test('tier 4 shows duration reduction', () => {
+    expect(tierIncrementalLabel(4)).toBe('-10% Dur')
+  })
+
+  test('tier 5 shows yield bonus', () => {
+    expect(tierIncrementalLabel(5)).toBe('+1 Yield')
+  })
+})
+
+describe('progressPercent', () => {
+  test('returns 0 for score 0', () => {
+    expect(progressPercent(0)).toBe(0)
+  })
+
+  test('returns 100 for max score', () => {
+    expect(progressPercent(MAX_SCORE)).toBe(100)
+  })
+
+  test('caps at 100 for scores above max', () => {
+    expect(progressPercent(MAX_SCORE + 10)).toBe(100)
+  })
+
+  test('returns correct percentage for intermediate scores', () => {
+    const half = MAX_SCORE / 2
+    expect(progressPercent(half)).toBeCloseTo(50)
+  })
+})
+
+describe('targetPercent', () => {
+  test('returns 0 for tier 0 or below', () => {
+    expect(targetPercent(0)).toBe(0)
+    expect(targetPercent(-1)).toBe(0)
+  })
+
+  test('returns 0 for tiers above MAX_TIER', () => {
+    expect(targetPercent(MAX_TIER + 1)).toBe(0)
+  })
+
+  test('returns correct percentage for each tier', () => {
+    for (let t = 1; t <= MAX_TIER; t++) {
+      const expected = (TIER_THRESHOLDS_RAW[t - 1] / MAX_SCORE) * 100
+      expect(targetPercent(t)).toBeCloseTo(expected)
+    }
+  })
+
+  test('tier 1 is the smallest non-zero percentage', () => {
+    expect(targetPercent(1)).toBeGreaterThan(0)
+    expect(targetPercent(1)).toBeLessThan(targetPercent(2))
+  })
+
+  test('percentages are strictly ascending', () => {
+    for (let t = 2; t <= MAX_TIER; t++) {
+      expect(targetPercent(t)).toBeGreaterThan(targetPercent(t - 1))
+    }
+  })
+})
+
+describe('isScoreAtThreshold', () => {
+  test('returns true for each threshold value', () => {
+    for (const threshold of TIER_THRESHOLDS_RAW) {
+      if (threshold < MAX_SCORE) {
+        expect(isScoreAtThreshold(threshold)).toBe(true)
+      }
+    }
+  })
+
+  test('returns false for max score (bar fills completely)', () => {
+    expect(isScoreAtThreshold(MAX_SCORE)).toBe(false)
+  })
+
+  test('returns false for scores between thresholds', () => {
+    expect(isScoreAtThreshold(TIER_THRESHOLDS_RAW[0] + 1)).toBe(false)
+  })
+
+  test('returns false for 0', () => {
+    expect(isScoreAtThreshold(0)).toBe(false)
+  })
+
+  test('returns false for scores above max', () => {
+    expect(isScoreAtThreshold(MAX_SCORE + 10)).toBe(false)
+  })
+})

--- a/src/utils/sanctuaryConstants.ts
+++ b/src/utils/sanctuaryConstants.ts
@@ -36,7 +36,7 @@ export function jobTierLabel(tier: number, shortDuration = false): string {
 
 export const MAX_SCORE = TIER_THRESHOLDS_RAW[TIER_THRESHOLDS_RAW.length - 1]
 
-export type BenefitType = 'xp' | 'duration' | 'yield'
+type BenefitType = 'xp' | 'duration' | 'yield'
 
 export function tierBenefitType(tier: number): BenefitType {
   if (tier < 1 || tier > MAX_TIER) return 'xp'

--- a/src/utils/sanctuaryConstants.ts
+++ b/src/utils/sanctuaryConstants.ts
@@ -34,6 +34,44 @@ export function jobTierLabel(tier: number, shortDuration = false): string {
   return parts.join(', ')
 }
 
+export const MAX_SCORE = TIER_THRESHOLDS_RAW[TIER_THRESHOLDS_RAW.length - 1]
+
+export type BenefitType = 'xp' | 'duration' | 'yield'
+
+export function tierBenefitType(tier: number): BenefitType {
+  if (tier < 1 || tier > MAX_TIER) return 'xp'
+  const curr = JOB_TIER_BENEFITS[tier]
+  const prev = JOB_TIER_BENEFITS[tier - 1]
+  if (curr.xpBonus > prev.xpBonus) return 'xp'
+  if (curr.durationReduction > prev.durationReduction) return 'duration'
+  return 'yield'
+}
+
+export function tierIncrementalLabel(tier: number): string {
+  if (tier < 1 || tier > MAX_TIER) return ''
+  const curr = JOB_TIER_BENEFITS[tier]
+  const prev = JOB_TIER_BENEFITS[tier - 1]
+  if (curr.xpBonus > prev.xpBonus) return `+${curr.xpBonus - prev.xpBonus}% XP`
+  if (curr.durationReduction > prev.durationReduction)
+    return `-${curr.durationReduction - prev.durationReduction}% Dur`
+  if (curr.yieldBonus > prev.yieldBonus) return `+${curr.yieldBonus - prev.yieldBonus} Yield`
+  return ''
+}
+
+export function progressPercent(score: number): number {
+  return Math.min(100, (score / MAX_SCORE) * 100)
+}
+
+export function targetPercent(targetTier: number): number {
+  if (targetTier <= 0 || targetTier > MAX_TIER) return 0
+  return (TIER_THRESHOLDS_RAW[targetTier - 1] / MAX_SCORE) * 100
+}
+
+export function isScoreAtThreshold(score: number): boolean {
+  if (score >= MAX_SCORE) return false
+  return TIER_THRESHOLDS_RAW.includes(score)
+}
+
 export const JOB_COLORS: Record<string, string> = {
   chopping: '#59e843',
   mining: '#c9c9c9',

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -815,11 +815,12 @@ function chooseCreature(creature: Creature) {
                       >{{ score }}</span
                     >
                   </div>
-                  <div class="mt-1 flex gap-1">
+                  <div class="mt-1 flex gap-1 divide-x divide-border">
                     <div
-                      v-for="job in SANCTUARY_JOBS"
+                      v-for="(job, ji) in SANCTUARY_JOBS"
                       :key="job"
                       class="flex flex-1 items-center gap-[2px]"
+                      :class="ji > 0 ? 'pl-1' : ''"
                       :title="`${job}: ${creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0}`"
                     >
                       <img
@@ -828,6 +829,16 @@ function chooseCreature(creature: Creature) {
                         class="size-3.5 shrink-0 opacity-60"
                         loading="lazy"
                       />
+                      <span
+                        class="w-3 shrink-0 font-mono text-[10px] font-semibold"
+                        :class="
+                          (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
+                            ? 'text-muted-foreground'
+                            : 'text-muted-foreground/30'
+                        "
+                      >
+                        {{ creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0 }}
+                      </span>
                       <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-muted/30">
                         <div
                           class="h-full rounded-full"
@@ -840,16 +851,6 @@ function chooseCreature(creature: Creature) {
                           }"
                         />
                       </div>
-                      <span
-                        class="w-3 shrink-0 text-right font-mono text-[10px] font-semibold"
-                        :class="
-                          (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
-                            ? 'text-muted-foreground'
-                            : 'text-muted-foreground/30'
-                        "
-                      >
-                        {{ creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0 }}
-                      </span>
                     </div>
                   </div>
                 </div>

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -86,6 +86,7 @@ const selectedCreatureType = ref<ElementType | 'all'>('all')
 const selectedCreatureTiers = ref<number[]>([])
 const showMoreCreatureFilters = ref(false)
 const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
+const sortByJob = ref<string>('recommended')
 
 
 const creatureTierOptions = computed(() => {
@@ -133,9 +134,14 @@ const filteredRecommended = computed(() => {
 
 
 const displayRecommended = computed(() => {
-  if (ownedOnly.value)
-    return filteredRecommended.value.filter(({ creature }) => isOwned(creature.id))
-  return filteredRecommended.value
+  const list = ownedOnly.value
+    ? filteredRecommended.value.filter(({ creature }) => isOwned(creature.id))
+    : filteredRecommended.value
+
+  if (sortByJob.value === 'recommended') return list
+
+  const jobKey = sortByJob.value.toLowerCase() as keyof Jobs
+  return [...list].toSorted((a, b) => (b.creature.jobs[jobKey] ?? 0) - (a.creature.jobs[jobKey] ?? 0))
 })
 
 
@@ -242,6 +248,7 @@ function clearCreatureFilters() {
   selectedCreatureTiers.value = [...creatureTierOptions.value]
   ownedOnly.value = true
   showExcludedCreatures.value = false
+  sortByJob.value = 'recommended'
 }
 
 
@@ -717,6 +724,44 @@ function chooseCreature(creature: Creature) {
             @remove="removeCreatureFilter"
             @clear-all="clearCreatureFilters"
           />
+        </div>
+
+        <!-- Sort row -->
+        <div class="flex items-center gap-3 border-b border-border/70 py-1.5 pl-[20px] pr-[20px]">
+          <AppTooltip text="Recommended" position="top">
+            <button
+              class="focus-ring inline-flex w-12 shrink-0 items-center justify-center rounded-md border px-1 py-1 text-[10px] font-medium transition"
+              :class="
+                sortByJob === 'recommended'
+                  ? 'border-transparent bg-primary text-primary-foreground shadow-glow'
+                  : 'border-border bg-muted/40 text-muted-foreground'
+              "
+              @click="sortByJob = 'recommended'"
+            >
+              Rec.
+            </button>
+          </AppTooltip>
+          <div class="flex min-w-0 flex-1 gap-1">
+            <button
+              v-for="job in SANCTUARY_JOBS"
+              :key="job"
+              class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded-md border px-1 py-1 text-[10px] font-medium transition"
+              :class="
+                sortByJob === job
+                  ? 'border-transparent bg-primary text-primary-foreground shadow-glow'
+                  : 'border-border bg-muted/40 text-muted-foreground'
+              "
+              @click="sortByJob = sortByJob === job ? 'recommended' : job"
+            >
+              <img
+                :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
+                :alt="job"
+                class="size-3"
+                loading="lazy"
+              />
+              <span class="hidden sm:inline">{{ job }}</span>
+            </button>
+          </div>
         </div>
 
         <!-- Creature list -->

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -482,21 +482,36 @@ function chooseCreature(creature: Creature) {
               <h3 class="text-xs font-bold uppercase tracking-[0.14em] text-muted-foreground">
                 Skill Benefits
               </h3>
-              <div
-                v-if="unreachableTargets.length > 0"
-                class="flex items-center gap-1 text-[10px] font-semibold text-amber-600 dark:text-amber-400"
-              >
-                <AlertCircle class="size-3 shrink-0" />
-                <template v-for="(job, i) in unreachableTargets" :key="job">
-                  <span v-if="i > 0">,</span>
-                  <img
-                    :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
-                    :alt="job"
-                    class="size-3"
-                  />
-                  <span>{{ job }}</span>
-                </template>
-                <span>unreachable</span>
+              <div class="flex items-center gap-2">
+                <AppTooltip
+                  v-if="unreachableTargets.length > 0"
+                  text="These targets cannot be reached with the current selectable creatures"
+                  position="bottom"
+                >
+                  <div
+                    class="flex items-center gap-1 text-[10px] font-semibold text-amber-600 dark:text-amber-400"
+                  >
+                    <AlertCircle class="size-3 shrink-0" />
+                    <template v-for="(job, i) in unreachableTargets" :key="job">
+                      <span v-if="i > 0">,</span>
+                      <img
+                        :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
+                        :alt="job"
+                        class="size-3"
+                      />
+                      <span>{{ job }}</span>
+                    </template>
+                    <span>unreachable</span>
+                  </div>
+                </AppTooltip>
+                <button
+                  class="focus-ring inline-flex items-center gap-1 rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1 text-[10px] font-semibold text-red-400 transition hover:bg-red-500/20"
+                  :class="hasTargets ? '' : 'invisible'"
+                  @click="setAllTargets(0)"
+                >
+                  <X class="size-3" />
+                  Clear Targets
+                </button>
               </div>
             </div>
             <div class="space-y-2">
@@ -506,7 +521,7 @@ function chooseCreature(creature: Creature) {
                 class="rounded-lg border border-border/50 bg-muted/10 px-3 py-2.5"
               >
                 <!-- Header: icon + name + active benefit pills -->
-                <div class="mb-1.5 flex items-center gap-1.5">
+                <div class="mb-1.5 flex min-h-7 items-center gap-1.5">
                   <img
                     :src="jobIcons[jp.job.toLowerCase() as keyof typeof jobIcons]"
                     :alt="jp.job"
@@ -514,7 +529,7 @@ function chooseCreature(creature: Creature) {
                     loading="lazy"
                   />
                   <span class="text-sm font-semibold">{{ jp.job }}</span>
-                  <div v-if="jp.tier > 0" class="ml-auto flex gap-1">
+                  <div v-if="jp.tier > 0" class="ml-auto flex flex-wrap justify-end gap-1">
                     <span
                       v-if="JOB_TIER_BENEFITS[jp.tier].xpBonus > 0"
                       class="inline-flex items-center gap-0.5 rounded-full border border-emerald-500/25 bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
@@ -544,27 +559,30 @@ function chooseCreature(creature: Creature) {
 
                 <!-- Progress bar with tier markers -->
                 <div class="space-y-0.5">
-                  <div
-                    class="relative h-3 overflow-hidden rounded-full border border-border/40 bg-muted/30 dark:border-transparent"
-                  >
+                  <div class="relative">
                     <div
-                      class="absolute inset-y-0 left-0 rounded-full transition-all duration-500"
-                      :style="{
-                        width: `${progressPercent(jp.score)}%`,
-                        backgroundColor: JOB_COLORS[jp.job.toLowerCase()],
-                      }"
-                    />
-                    <!-- Tier threshold markers -->
+                      class="relative h-3 overflow-hidden rounded-full border border-border/40 bg-muted/30 dark:border-transparent"
+                    >
+                      <div
+                        class="absolute inset-y-0 left-0 transition-all duration-500"
+                        :class="isScoreAtThreshold(jp.score) ? 'rounded-l-full' : 'rounded-full'"
+                        :style="{
+                          width: `${progressPercent(jp.score)}%`,
+                          backgroundColor: JOB_COLORS[jp.job.toLowerCase()],
+                        }"
+                      />
+                    </div>
+                    <!-- Tier threshold markers (overlaid on top of bar) -->
                     <div
                       v-for="t in [1, 2, 3, 4, 5]"
                       :key="t"
-                      class="absolute inset-y-0 w-px bg-foreground/30"
+                      class="absolute inset-y-0 w-px -translate-x-1/2 bg-foreground/30"
                       :style="{ left: `${targetPercent(t)}%` }"
                     />
                     <!-- Target marker -->
                     <div
                       v-if="(targetTiers[jp.job] ?? 0) > jp.tier"
-                      class="absolute inset-y-0 w-0.5 bg-primary shadow-sm shadow-primary/50"
+                      class="absolute inset-y-0 w-0.5 -translate-x-1/2 bg-primary shadow-sm shadow-primary/50"
                       :style="{ left: `${targetPercent(targetTiers[jp.job])}%` }"
                     />
                   </div>
@@ -610,29 +628,35 @@ function chooseCreature(creature: Creature) {
                 </div>
 
                 <!-- Target selector -->
-                <div class="mt-1.5 flex gap-[3px]">
-                  <button
-                    v-for="t in [1, 2, 3, 4, 5]"
-                    :key="t"
-                    class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded px-0.5 py-1 text-[10px] font-semibold transition"
-                    :class="
-                      (targetTiers[jp.job] ?? 0) === t
-                        ? 'bg-primary text-primary-foreground'
-                        : jp.tier >= t
-                          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400'
-                          : 'bg-muted/50 text-muted-foreground hover:text-foreground'
-                    "
-                    :title="`Tier ${t}: ${jobTierLabel(t)}`"
-                    @click="setTargetTier(jp.job, (targetTiers[jp.job] ?? 0) === t ? 0 : t)"
+                <div class="mt-2">
+                  <span
+                    class="mb-1 block text-[10px] font-bold uppercase tracking-widest text-muted-foreground"
+                    >Set Target</span
                   >
-                    <template v-if="jp.tier >= t">✓</template>
-                    <template v-else>
-                      <Zap v-if="tierBenefitType(t) === 'xp'" class="size-2.5" />
-                      <Clock3 v-else-if="tierBenefitType(t) === 'duration'" class="size-2.5" />
-                      <Layers v-else class="size-2.5" />
-                      <span class="hidden sm:inline">{{ tierIncrementalLabel(t) }}</span>
-                    </template>
-                  </button>
+                  <div class="flex gap-1">
+                    <button
+                      v-for="t in [1, 2, 3, 4, 5]"
+                      :key="t"
+                      class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded-md border px-1 py-1 text-[10px] font-medium transition"
+                      :class="
+                        (targetTiers[jp.job] ?? 0) === t
+                          ? 'border-transparent bg-primary text-primary-foreground shadow-glow'
+                          : jp.tier >= t
+                            ? 'border-emerald-500/30 bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400'
+                            : 'border-border bg-muted/40 text-muted-foreground hover:border-primary/50 hover:text-foreground'
+                      "
+                      :title="`Tier ${t}: ${jobTierLabel(t)}`"
+                      @click="setTargetTier(jp.job, (targetTiers[jp.job] ?? 0) === t ? 0 : t)"
+                    >
+                      <template v-if="jp.tier >= t">✓</template>
+                      <template v-else>
+                        <Zap v-if="tierBenefitType(t) === 'xp'" class="size-2.5" />
+                        <Clock3 v-else-if="tierBenefitType(t) === 'duration'" class="size-2.5" />
+                        <Layers v-else class="size-2.5" />
+                      </template>
+                      <span class="hidden text-[9px] sm:inline">{{ tierIncrementalLabel(t) }}</span>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -89,6 +89,21 @@ const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
 const sortByJob = ref<string>('recommended')
 
 
+const hasTargets = computed(() => Object.values(targetTiers.value).some((t) => t > 0))
+
+
+const highlightedJobs = computed<Set<string>>(() => {
+  const jobs = new Set<string>()
+  if (sortByJob.value !== 'recommended') jobs.add(sortByJob.value)
+  if (hasTargets.value) {
+    for (const job of SANCTUARY_JOBS) {
+      if ((targetTiers.value[job] ?? 0) > 0) jobs.add(job)
+    }
+  }
+  return jobs
+})
+
+
 const creatureTierOptions = computed(() => {
   const tiers = new Set(recommendedCreatures.value.map(({ creature }) => creature.tier))
   return Array.from(tiers).toSorted((a, b) => a - b)
@@ -141,7 +156,9 @@ const displayRecommended = computed(() => {
   if (sortByJob.value === 'recommended') return list
 
   const jobKey = sortByJob.value.toLowerCase() as keyof Jobs
-  return [...list].toSorted((a, b) => (b.creature.jobs[jobKey] ?? 0) - (a.creature.jobs[jobKey] ?? 0))
+  return [...list].toSorted(
+    (a, b) => (b.creature.jobs[jobKey] ?? 0) - (a.creature.jobs[jobKey] ?? 0),
+  )
 })
 
 
@@ -854,32 +871,40 @@ function chooseCreature(creature: Creature) {
                         >Not Awakened</span
                       >
                     </AppTooltip>
-                    <span
-                      v-if="score > 0"
-                      class="ml-auto shrink-0 font-mono text-sm font-semibold text-primary"
-                      >{{ score }}</span
-                    >
+                    <span v-if="score > 0" class="ml-auto flex shrink-0 items-baseline gap-1">
+                      <span class="font-mono text-sm font-semibold text-primary">{{ score }}</span>
+                      <span class="text-[10px] text-muted-foreground">{{
+                        hasTargets ? 'value' : 'total'
+                      }}</span>
+                    </span>
                   </div>
                   <div class="mt-1 flex gap-1 divide-x divide-border">
                     <div
                       v-for="(job, ji) in SANCTUARY_JOBS"
                       :key="job"
-                      class="flex flex-1 items-center gap-[2px]"
-                      :class="ji > 0 ? 'pl-1' : ''"
+                      class="flex flex-1 items-center gap-[2px] rounded-md px-0.5 py-0.5 transition"
+                      :class="[
+                        ji > 0 ? 'pl-1' : '',
+                        highlightedJobs.has(job) ? 'bg-primary/10 ring-1 ring-primary/30' : '',
+                        highlightedJobs.size > 0 && !highlightedJobs.has(job) ? 'opacity-25' : '',
+                      ]"
                       :title="`${job}: ${creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0}`"
                     >
                       <img
                         :src="jobIcons[job.toLowerCase() as keyof typeof jobIcons]"
                         :alt="job"
-                        class="size-3.5 shrink-0 opacity-60"
+                        class="size-3.5 shrink-0"
+                        :class="highlightedJobs.has(job) ? 'opacity-100' : 'opacity-60'"
                         loading="lazy"
                       />
                       <span
                         class="w-3 shrink-0 font-mono text-[10px] font-semibold"
                         :class="
-                          (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
-                            ? 'text-muted-foreground'
-                            : 'text-muted-foreground/30'
+                          highlightedJobs.has(job)
+                            ? 'text-primary'
+                            : (creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0) > 0
+                              ? 'text-muted-foreground'
+                              : 'text-muted-foreground/30'
                         "
                       >
                         {{ creature.jobs[job.toLowerCase() as keyof Jobs] ?? 0 }}

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -23,6 +23,11 @@ import {
   JOB_TIER_BENEFITS,
   TIER_THRESHOLDS_RAW,
   jobTierLabel,
+  tierBenefitType,
+  tierIncrementalLabel,
+  progressPercent,
+  targetPercent,
+  isScoreAtThreshold,
 } from '@/utils/sanctuaryConstants'
 
 const route = useRoute()
@@ -288,46 +293,6 @@ function toggleCreatureTier(tier: number) {
   } else {
     selectedCreatureTiers.value = [...selectedCreatureTiers.value, tier]
   }
-}
-
-
-// ── Helpers ──
-const maxScore = TIER_THRESHOLDS_RAW[TIER_THRESHOLDS_RAW.length - 1] // 54
-
-
-type BenefitType = 'xp' | 'duration' | 'yield'
-
-
-function tierBenefitType(tier: number): BenefitType {
-  if (tier < 1 || tier > 5) return 'xp'
-  const curr = JOB_TIER_BENEFITS[tier]
-  const prev = JOB_TIER_BENEFITS[tier - 1]
-  if (curr.xpBonus > prev.xpBonus) return 'xp'
-  if (curr.durationReduction > prev.durationReduction) return 'duration'
-  return 'yield'
-}
-
-
-function tierIncrementalLabel(tier: number): string {
-  if (tier < 1 || tier > 5) return ''
-  const curr = JOB_TIER_BENEFITS[tier]
-  const prev = JOB_TIER_BENEFITS[tier - 1]
-  if (curr.xpBonus > prev.xpBonus) return `+${curr.xpBonus - prev.xpBonus}% XP`
-  if (curr.durationReduction > prev.durationReduction)
-    return `-${curr.durationReduction - prev.durationReduction}% Dur`
-  if (curr.yieldBonus > prev.yieldBonus) return `+${curr.yieldBonus - prev.yieldBonus} Yield`
-  return ''
-}
-
-
-function progressPercent(score: number): number {
-  return Math.min(100, (score / maxScore) * 100)
-}
-
-
-function targetPercent(targetTier: number): number {
-  if (targetTier <= 0 || targetTier > 5) return 0
-  return (TIER_THRESHOLDS_RAW[targetTier - 1] / maxScore) * 100
 }
 
 


### PR DESCRIPTION
## Description

Redesigns the Sanctuary creature browser and skill benefit sections for better usability. Job scores now display next to their icons for clearer association, creatures can be sorted by individual jobs, and the target selector buttons have been restyled to look more obviously interactive.

## Summary
- Moved job score numbers next to icons (before the progress bar) with vertical dividers between sections
- Added sort-by-job row in creature browser with per-job sort buttons and a "Rec." default
- Job sections on creature cards highlight when sorted or targeted, with non-relevant jobs fading out
- Added contextual score label ("value" when targets set, "total" otherwise)
- Redesigned target selector buttons with visible borders, hover states, "Set Target" label, and incremental benefit text
- Improved progress bar milestone alignment by centering markers and conditionally rounding the fill bar edge at thresholds
- Added "Clear Targets" button, AppTooltip on unreachable warning and Rec. button, and min-h-7 on benefit header to prevent layout shift
- Extracted helper functions (tierBenefitType, progressPercent, targetPercent, isScoreAtThreshold, etc.) to sanctuaryConstants for reuse and testability
- Added 28 unit tests covering all extracted helpers