### PR TITLE
Add consistent right-click inspect across all views

### DIFF
--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -113,6 +113,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
         v-if="open && creature"
         class="fixed inset-0 z-50 bg-background/60 backdrop-blur-sm"
         @click="emit('close')"
+        @contextmenu.prevent="emit('close')"
       />
     </Transition>
 

--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -17,7 +17,14 @@ import {
   maxLevelForState,
   statLabels,
 } from '@/utils/formulas'
-import { jobIcons, sanctuaryIcon, helpersIcon, machinesIcon, dungeonsIcon } from '@/utils/icons'
+import {
+  jobIcons,
+  sanctuaryIcon,
+  helpersIcon,
+  machinesIcon,
+  dungeonsIcon,
+  expeditionsIcon,
+} from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 
 import ProficiencyRing from './ProficiencyRing.vue'
@@ -37,8 +44,13 @@ const emit = defineEmits<{
 
 const { isOwned, isAwakened, toggleOwned, setAwakened, getLevel, stepLevel, normalizeLevelOnBlur } =
   useCreatureCollection()
-const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds, dungeonParty } =
-  useGameConfig()
+const {
+  sanctuaryCreatureIds,
+  helperCreatureIds,
+  machineCreatureIds,
+  dungeonParty,
+  expeditionCreatureIds,
+} = useGameConfig()
 
 
 const maxJobLevel = 10
@@ -51,6 +63,7 @@ const assignmentBadge = computed(() => {
   if (helperCreatureIds.value.includes(id)) return { icon: helpersIcon, label: 'Helper' }
   if (machineCreatureIds.value.includes(id)) return { icon: machinesIcon, label: 'Machine' }
   if (dungeonParty.value.includes(id)) return { icon: dungeonsIcon, label: 'Dungeon' }
+  if (expeditionCreatureIds.value.has(id)) return { icon: expeditionsIcon, label: 'Expedition' }
   return null
 })
 

--- a/src/components/expeditions/ExpeditionDetail.vue
+++ b/src/components/expeditions/ExpeditionDetail.vue
@@ -2,6 +2,7 @@
 import { ChevronDown, Compass, Minus, Plus, X } from 'lucide-vue-next'
 import { ref } from 'vue'
 
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import type { Creature, Expedition, ExpeditionStatWeights } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { TIER_UNLOCK_REQUIREMENTS } from '@/utils/expeditionUnlocks'
@@ -128,26 +129,29 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
           Recommended Creatures
         </h4>
         <div class="flex flex-wrap gap-2">
-          <div
+          <RightClickHint
             v-for="{ creature, percent } in topRecommendedCreatures"
             :key="creature.id"
-            class="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/35 py-1 pl-1 pr-3 transition hover:border-accent/45 hover:bg-muted/50"
-            @click="emit('inspect-creature', creature)"
+            @contextmenu="emit('inspect-creature', creature)"
           >
-            <div class="size-6 overflow-hidden rounded-full bg-card">
-              <img
-                :src="getCreatureImage(creature)"
-                :alt="creature.name"
-                class="size-full object-cover"
-                loading="lazy"
-              />
-            </div>
-            <span class="text-xs font-semibold">{{ creature.name }}</span>
-            <span
-              class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary"
-              >{{ percent }}%</span
+            <div
+              class="inline-flex items-center gap-2 rounded-lg border border-border bg-muted/35 py-1 pl-1 pr-3 transition hover:border-accent/45 hover:bg-muted/50"
             >
-          </div>
+              <div class="size-6 overflow-hidden rounded-full bg-card">
+                <img
+                  :src="getCreatureImage(creature)"
+                  :alt="creature.name"
+                  class="size-full object-cover"
+                  loading="lazy"
+                />
+              </div>
+              <span class="text-xs font-semibold">{{ creature.name }}</span>
+              <span
+                class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary"
+                >{{ percent }}%</span
+              >
+            </div>
+          </RightClickHint>
         </div>
       </div>
 
@@ -312,26 +316,24 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
               @click="!slot ? emit('set-active-slot', index) : undefined"
             >
               <template v-if="slot">
-                <img
-                  :src="getCreatureImage(slot)"
-                  :alt="`${slot.name} artwork`"
-                  class="size-full cursor-pointer object-cover"
-                  loading="lazy"
-                  @click="emit('inspect-creature', slot)"
-                />
-                <span
-                  class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
-                >
-                  {{ getCreatureSlotRating(slot) }}
-                </span>
-                <div
-                  class="absolute inset-x-0 bottom-0 cursor-pointer select-none bg-black/75 px-1.5 py-1"
-                  @click="emit('inspect-creature', slot)"
-                >
-                  <p class="truncate text-center text-[10px] font-semibold text-white">
-                    {{ slot.name }}
-                  </p>
-                </div>
+                <RightClickHint @contextmenu="emit('inspect-creature', slot)">
+                  <img
+                    :src="getCreatureImage(slot)"
+                    :alt="`${slot.name} artwork`"
+                    class="size-full object-cover"
+                    loading="lazy"
+                  />
+                  <span
+                    class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
+                  >
+                    {{ getCreatureSlotRating(slot) }}
+                  </span>
+                  <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1.5 py-1">
+                    <p class="truncate text-center text-[10px] font-semibold text-white">
+                      {{ slot.name }}
+                    </p>
+                  </div>
+                </RightClickHint>
                 <button
                   class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                   @click.stop="emit('remove-creature', index)"

--- a/src/components/items/ItemDetail.vue
+++ b/src/components/items/ItemDetail.vue
@@ -2,6 +2,7 @@
 import { X, ChevronRight, ChevronDown, GitBranch } from 'lucide-vue-next'
 import { computed, ref } from 'vue'
 
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useItems } from '@/composables/useItems'
 import expeditionsData from '@/data/expeditions.json'
 import { summoningIndex } from '@/data/indexes'
@@ -630,32 +631,34 @@ const jobColorMap: Record<string, string> = {
           Summoning
         </h3>
         <div class="grid grid-cols-4 gap-3">
-          <div
+          <RightClickHint
             v-for="creature in summoningCreatures"
             :key="creature.id"
-            role="button"
-            class="relative aspect-square cursor-pointer overflow-hidden rounded-lg bg-muted/20 transition hover:ring-1 hover:ring-accent/40"
-            @click="emit('select-creature', creature.id)"
+            @contextmenu="emit('select-creature', creature.id)"
           >
-            <img
-              v-if="getCreatureImage({ id: creature.id, image: '' })"
-              :src="getCreatureImage({ id: creature.id, image: '' })"
-              :alt="`${creature.name} artwork`"
-              class="size-full object-cover"
-              loading="lazy"
-            />
             <div
-              v-else
-              class="flex size-full items-center justify-center text-2xl font-bold text-muted-foreground/50"
+              class="relative aspect-square overflow-hidden rounded-lg bg-muted/20 transition hover:ring-1 hover:ring-accent/40"
             >
-              {{ creature.name.charAt(0) }}
+              <img
+                v-if="getCreatureImage({ id: creature.id, image: '' })"
+                :src="getCreatureImage({ id: creature.id, image: '' })"
+                :alt="`${creature.name} artwork`"
+                class="size-full object-cover"
+                loading="lazy"
+              />
+              <div
+                v-else
+                class="flex size-full items-center justify-center text-2xl font-bold text-muted-foreground/50"
+              >
+                {{ creature.name.charAt(0) }}
+              </div>
+              <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
+                <p class="truncate text-center text-[10px] font-semibold text-white">
+                  {{ creature.name }}
+                </p>
+              </div>
             </div>
-            <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
-              <p class="truncate text-center text-[10px] font-semibold text-white">
-                {{ creature.name }}
-              </p>
-            </div>
-          </div>
+          </RightClickHint>
         </div>
       </section>
     </div>

--- a/src/components/level-planner/LevelPlannerCreaturePicker.vue
+++ b/src/components/level-planner/LevelPlannerCreaturePicker.vue
@@ -35,7 +35,7 @@ const { creatures } = useCreatures()
 const {
   selectedCreature: drawerCreature,
   drawerOpen,
-  openCreature,
+  toggleCreature,
   closeDrawer,
 } = useCreatureDrawer()
 const { ownedCreatureIds, getLevel, isAwakened } = useCreatureCollection()
@@ -116,7 +116,7 @@ function close() {
       @click="toggle"
     >
       <template v-if="selected">
-        <RightClickHint @contextmenu="openCreature(selected)">
+        <RightClickHint @contextmenu="toggleCreature(selected)">
           <img
             :src="getCreatureImage(selected)"
             :alt="selected.name"
@@ -210,7 +210,7 @@ function close() {
             "
             @click.stop="pick(creature)"
           >
-            <RightClickHint @contextmenu="openCreature(creature)">
+            <RightClickHint @contextmenu="toggleCreature(creature)">
               <img
                 :src="getCreatureImage(creature)"
                 :alt="creature.name"

--- a/src/components/level-planner/LevelPlannerTimelineStep.vue
+++ b/src/components/level-planner/LevelPlannerTimelineStep.vue
@@ -12,6 +12,7 @@ import {
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
 import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
@@ -55,7 +56,7 @@ defineEmits<{
 }>()
 
 
-const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
+const { selectedCreature, drawerOpen, toggleCreature, closeDrawer } = useCreatureDrawer()
 
 
 function nodeColor(status: 'advantage' | 'disadvantage' | 'neutral'): string {
@@ -114,14 +115,17 @@ function formatDelta(value: number): string {
         class="surface-card w-full overflow-hidden border-pink-500/30 bg-gradient-to-r from-pink-500/10 to-amber-500/10"
       >
         <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4 sm:py-3">
-          <img
+          <RightClickHint
             v-if="partyMembers?.[0]?.creature"
-            :src="getCreatureImage(partyMembers[0].creature)"
-            :alt="creatureName"
-            class="size-10 shrink-0 cursor-pointer rounded-lg border border-pink-500/30 object-cover transition hover:ring-1 hover:ring-pink-500/50 sm:size-12"
-            loading="lazy"
-            @click.stop="openCreature(partyMembers[0].creature!)"
-          />
+            @contextmenu="toggleCreature(partyMembers[0].creature!)"
+          >
+            <img
+              :src="getCreatureImage(partyMembers[0].creature)"
+              :alt="creatureName"
+              class="size-10 shrink-0 rounded-lg border border-pink-500/30 object-cover transition hover:ring-1 hover:ring-pink-500/50 sm:size-12"
+              loading="lazy"
+            />
+          </RightClickHint>
           <div class="min-w-0 flex-1">
             <div class="flex items-center gap-2">
               <div class="flex min-w-0 flex-1 items-center gap-2">
@@ -226,31 +230,46 @@ function formatDelta(value: number): string {
                     highlightCreatureId && member.creatureId === highlightCreatureId
                       ? 'border-primary ring-2 ring-primary/50'
                       : 'border-border',
-                    member.creature
-                      ? 'cursor-pointer transition hover:ring-1 hover:ring-accent/40'
-                      : '',
+                    member.creature ? 'transition hover:ring-1 hover:ring-accent/40' : '',
                   ]"
-                  @click="member.creature ? openCreature(member.creature) : undefined"
                 >
-                  <img
+                  <RightClickHint
                     v-if="member.creature"
-                    :src="getCreatureImage(member.creature)"
-                    :alt="member.creature?.name ?? member.creatureId"
-                    class="size-full object-cover"
-                    loading="lazy"
-                  />
-                  <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-0.5">
-                    <p
-                      class="truncate text-center text-[10px] font-semibold"
-                      :class="
-                        highlightCreatureId && member.creatureId === highlightCreatureId
-                          ? 'text-primary'
-                          : 'text-white'
-                      "
-                    >
-                      {{ member.creature?.name ?? member.creatureId }}
-                    </p>
-                  </div>
+                    @contextmenu="toggleCreature(member.creature)"
+                  >
+                    <img
+                      :src="getCreatureImage(member.creature)"
+                      :alt="member.creature?.name ?? member.creatureId"
+                      class="size-full object-cover"
+                      loading="lazy"
+                    />
+                    <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-0.5">
+                      <p
+                        class="truncate text-center text-[10px] font-semibold"
+                        :class="
+                          highlightCreatureId && member.creatureId === highlightCreatureId
+                            ? 'text-primary'
+                            : 'text-white'
+                        "
+                      >
+                        {{ member.creature?.name ?? member.creatureId }}
+                      </p>
+                    </div>
+                  </RightClickHint>
+                  <template v-else>
+                    <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-0.5">
+                      <p
+                        class="truncate text-center text-[10px] font-semibold"
+                        :class="
+                          highlightCreatureId && member.creatureId === highlightCreatureId
+                            ? 'text-primary'
+                            : 'text-white'
+                        "
+                      >
+                        {{ member.creatureId }}
+                      </p>
+                    </div>
+                  </template>
                 </div>
                 <span
                   class="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-semibold text-foreground"

--- a/src/components/level-planner/PartyCreatureTile.vue
+++ b/src/components/level-planner/PartyCreatureTile.vue
@@ -22,7 +22,7 @@ defineEmits<{
 }>()
 
 
-const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
+const { selectedCreature, drawerOpen, toggleCreature, closeDrawer } = useCreatureDrawer()
 
 
 function tileBorderClass(): string {
@@ -60,7 +60,7 @@ function levelBadgeClass(): string {
       :title="`${creature.name} — LVL ${level}${awakened ? ' ★' : ''}${titleSuffix ?? ''}`"
       @click="$emit('toggle')"
     >
-      <RightClickHint @contextmenu="openCreature(creature)">
+      <RightClickHint @contextmenu="toggleCreature(creature)">
         <img
           v-if="getCreatureImage(creature)"
           :src="getCreatureImage(creature)"

--- a/src/components/level-planner/PartyPlannerGantt.vue
+++ b/src/components/level-planner/PartyPlannerGantt.vue
@@ -35,7 +35,7 @@ const props = withDefaults(
 const {
   selectedCreature: ganttInspectedCreature,
   drawerOpen: ganttDrawerOpen,
-  openCreature: ganttInspectCreature,
+  toggleCreature: ganttToggleCreature,
   closeDrawer: ganttCloseDrawer,
 } = useCreatureDrawer()
 
@@ -396,7 +396,7 @@ const activeBarScoreRatio = computed(() => {
             >
               <RightClickHint
                 v-if="marker.creature"
-                @contextmenu="ganttInspectCreature(marker.creature)"
+                @contextmenu="ganttToggleCreature(marker.creature)"
               >
                 <img
                   :src="getCreatureImage(marker.creature)"
@@ -452,7 +452,7 @@ const activeBarScoreRatio = computed(() => {
               <RightClickHint
                 v-for="cId in bar.creatureIds.slice(0, 3)"
                 :key="cId"
-                @contextmenu="ganttInspectCreature(creatures.get(cId)!)"
+                @contextmenu="ganttToggleCreature(creatures.get(cId)!)"
               >
                 <img
                   :src="getCreatureImage(creatures.get(cId)!)"
@@ -602,14 +602,17 @@ const activeBarScoreRatio = computed(() => {
                 :key="member.creatureId"
                 class="flex items-center gap-2"
               >
-                <img
+                <RightClickHint
                   v-if="creatures.get(member.creatureId)"
-                  :src="getCreatureImage(creatures.get(member.creatureId)!)"
-                  :alt="creatures.get(member.creatureId)?.name"
-                  class="size-7 shrink-0 cursor-pointer rounded-full border border-border object-cover transition hover:ring-1 hover:ring-accent/40"
-                  loading="lazy"
-                  @click="ganttInspectCreature(creatures.get(member.creatureId)!)"
-                />
+                  @contextmenu="ganttToggleCreature(creatures.get(member.creatureId)!)"
+                >
+                  <img
+                    :src="getCreatureImage(creatures.get(member.creatureId)!)"
+                    :alt="creatures.get(member.creatureId)?.name"
+                    class="size-7 shrink-0 rounded-full border border-border object-cover transition hover:ring-1 hover:ring-accent/40"
+                    loading="lazy"
+                  />
+                </RightClickHint>
                 <div class="min-w-0 flex-1">
                   <p class="truncate text-xs font-semibold text-foreground">
                     {{ creatures.get(member.creatureId)?.name ?? member.creatureId }}
@@ -646,22 +649,25 @@ const activeBarScoreRatio = computed(() => {
         >
           <div class="px-4 py-3">
             <div class="flex items-center gap-3">
-              <div
-                class="size-10 shrink-0 cursor-pointer overflow-hidden rounded-full border-2 border-pink-500 bg-card transition hover:ring-1 hover:ring-pink-500/50"
-                @click="
-                  activeAwakenMarker.creature
-                    ? ganttInspectCreature(activeAwakenMarker.creature)
-                    : undefined
-                "
+              <RightClickHint
+                v-if="activeAwakenMarker.creature"
+                @contextmenu="ganttToggleCreature(activeAwakenMarker.creature)"
               >
-                <img
-                  v-if="activeAwakenMarker.creature"
-                  :src="getCreatureImage(activeAwakenMarker.creature)"
-                  :alt="activeAwakenMarker.creature.name"
-                  class="size-full object-cover"
-                  loading="lazy"
-                />
-              </div>
+                <div
+                  class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-pink-500 bg-card transition hover:ring-1 hover:ring-pink-500/50"
+                >
+                  <img
+                    :src="getCreatureImage(activeAwakenMarker.creature)"
+                    :alt="activeAwakenMarker.creature.name"
+                    class="size-full object-cover"
+                    loading="lazy"
+                  />
+                </div>
+              </RightClickHint>
+              <div
+                v-else
+                class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-pink-500 bg-card"
+              />
               <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-1.5">
                   <img

--- a/src/components/summoning-planner/SummoningExpeditionPlan.vue
+++ b/src/components/summoning-planner/SummoningExpeditionPlan.vue
@@ -17,7 +17,7 @@ defineProps<{
 }>()
 
 
-const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
+const { selectedCreature, drawerOpen, toggleCreature, closeDrawer } = useCreatureDrawer()
 </script>
 
 <template>
@@ -95,7 +95,7 @@ const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureD
             <RightClickHint
               v-for="member in plan.party"
               :key="member.creature.id"
-              @contextmenu="openCreature(member.creature)"
+              @contextmenu="toggleCreature(member.creature)"
             >
               <div
                 class="inline-flex cursor-default items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"

--- a/src/components/summoning-planner/SummoningTimeline.vue
+++ b/src/components/summoning-planner/SummoningTimeline.vue
@@ -26,7 +26,7 @@ const props = defineProps<{
 }>()
 
 
-const { selectedCreature, drawerOpen, openCreature, closeDrawer } = useCreatureDrawer()
+const { selectedCreature, drawerOpen, toggleCreature, closeDrawer } = useCreatureDrawer()
 
 
 /** Kinds that are passive / non-actionable — hide from priority steps */
@@ -226,7 +226,7 @@ function copyScheduleJson() {
                 <RightClickHint
                   v-for="member in expeditionParties[card.itemId].party"
                   :key="member.creature.id"
-                  @contextmenu="openCreature(member.creature)"
+                  @contextmenu="toggleCreature(member.creature)"
                 >
                   <div
                     class="inline-flex cursor-default items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"

--- a/src/composables/useCreatureDrawer.ts
+++ b/src/composables/useCreatureDrawer.ts
@@ -17,9 +17,17 @@ export function useCreatureDrawer() {
     selectedCreature.value = creature
   }
 
-  function openCreatureById(id: string) {
+  function toggleCreature(creature: Creature) {
+    if (drawerOpen.value && selectedCreature.value?.id === creature.id) {
+      closeDrawer()
+    } else {
+      openCreature(creature)
+    }
+  }
+
+  function toggleCreatureById(id: string) {
     const creature = creatures.find((c) => c.id === id)
-    if (creature) selectedCreature.value = creature
+    if (creature) toggleCreature(creature)
   }
 
   function closeDrawer() {
@@ -27,5 +35,12 @@ export function useCreatureDrawer() {
     selectedCreature.value = null
   }
 
-  return { selectedCreature, drawerOpen, openCreature, openCreatureById, closeDrawer }
+  return {
+    selectedCreature,
+    drawerOpen,
+    openCreature,
+    toggleCreature,
+    toggleCreatureById,
+    closeDrawer,
+  }
 }

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -33,7 +33,7 @@ const { isOwned, isAwakened, collectionLevels } = useCreatureCollection()
 const {
   selectedCreature: inspectedCreature,
   drawerOpen: creatureDrawerOpen,
-  openCreature: inspectCreature,
+  toggleCreature: toggleInspectCreature,
   closeDrawer: closeCreatureDrawer,
 } = useCreatureDrawer()
 
@@ -672,26 +672,24 @@ const tierLevelReq = computed(() => {
                   @click="!slot ? setActiveSlot(index) : undefined"
                 >
                   <template v-if="slot">
-                    <img
-                      :src="getCreatureImage(slot)"
-                      :alt="`${slot.name} artwork`"
-                      class="size-full cursor-pointer object-cover"
-                      loading="lazy"
-                      @click="inspectCreature(slot)"
-                    />
-                    <span
-                      class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
-                    >
-                      {{ getCreatureSlotScore(slot) }}
-                    </span>
-                    <div
-                      class="absolute inset-x-0 bottom-0 cursor-pointer select-none bg-black/75 px-1.5 py-1"
-                      @click="inspectCreature(slot)"
-                    >
-                      <p class="truncate text-center text-[10px] font-semibold text-white">
-                        {{ slot.name }}
-                      </p>
-                    </div>
+                    <RightClickHint @contextmenu="toggleInspectCreature(slot)">
+                      <img
+                        :src="getCreatureImage(slot)"
+                        :alt="`${slot.name} artwork`"
+                        class="size-full object-cover"
+                        loading="lazy"
+                      />
+                      <span
+                        class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
+                      >
+                        {{ getCreatureSlotScore(slot) }}
+                      </span>
+                      <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1.5 py-1">
+                        <p class="truncate text-center text-[10px] font-semibold text-white">
+                          {{ slot.name }}
+                        </p>
+                      </div>
+                    </RightClickHint>
                     <button
                       class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                       @click.stop="removeCreatureFromSlot(index)"
@@ -946,7 +944,7 @@ const tierLevelReq = computed(() => {
             @click="chooseCreature(creature)"
           >
             <div class="flex items-start gap-3">
-              <RightClickHint @contextmenu="inspectCreature(creature)">
+              <RightClickHint @contextmenu="toggleInspectCreature(creature)">
                 <div class="relative shrink-0">
                   <img
                     :src="getCreatureImage(creature)"

--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -307,7 +307,7 @@ function chooseCreature(creature: Creature) {
 const {
   selectedCreature: inspectedCreature,
   drawerOpen: creatureDrawerOpen,
-  openCreature: inspectCreature,
+  toggleCreature: toggleInspectCreature,
   closeDrawer: closeCreatureDrawer,
 } = useCreatureDrawer()
 
@@ -514,7 +514,7 @@ function rowSelected(id: string): boolean {
                   <RightClickHint
                     v-for="creature in getPartyCreatures(expedition.id)"
                     :key="creature.id"
-                    @contextmenu="inspectCreature(creature)"
+                    @contextmenu="toggleInspectCreature(creature)"
                   >
                     <div
                       class="inline-flex cursor-default items-center gap-1.5 rounded-lg border border-border bg-muted/35 py-0.5 pl-0.5 pr-2"
@@ -588,7 +588,7 @@ function rowSelected(id: string): boolean {
         @update:loop-count="loopCount = $event"
         @set-active-slot="setActiveSlot"
         @remove-creature="removeCreatureFromSlot"
-        @inspect-creature="inspectCreature"
+        @inspect-creature="toggleInspectCreature"
       />
 
       <!-- Column 3: Creature Selector -->
@@ -606,7 +606,7 @@ function rowSelected(id: string): boolean {
         :show-excluded-creatures="showExcludedCreatures"
         @update:show-excluded-creatures="showExcludedCreatures = $event"
         @choose-creature="chooseCreature"
-        @inspect-creature="inspectCreature"
+        @inspect-creature="toggleInspectCreature"
         @step-level="stepCreatureLevel"
         @normalize-level="normalizeLevelOnBlur"
       />

--- a/src/views/ItemsView.vue
+++ b/src/views/ItemsView.vue
@@ -31,7 +31,7 @@ const {
 const {
   selectedCreature: drawerCreature,
   drawerOpen: creatureDrawerOpen,
-  openCreatureById,
+  toggleCreatureById,
   closeDrawer: closeCreatureDrawer,
 } = useCreatureDrawer()
 
@@ -539,7 +539,7 @@ onMounted(() => {
               :item="selectedItem"
               @close="closeDetail"
               @select-item="selectItemById"
-              @select-creature="openCreatureById"
+              @select-creature="toggleCreatureById"
             />
           </div>
         </aside>
@@ -576,7 +576,7 @@ onMounted(() => {
                 :item="selectedItem"
                 @close="closeDetail"
                 @select-item="selectItemById"
-                @select-creature="openCreatureById"
+                @select-creature="toggleCreatureById"
               />
             </div>
           </Transition>

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -60,7 +60,7 @@ const {
 const {
   selectedCreature: inspectedCreature,
   drawerOpen: creatureDrawerOpen,
-  openCreature: inspectCreature,
+  toggleCreature: toggleInspectCreature,
   closeDrawer: closeCreatureDrawer,
 } = useCreatureDrawer()
 
@@ -406,21 +406,21 @@ function chooseCreature(creature: Creature) {
                   @click="!slot ? setActiveSlot(index) : undefined"
                 >
                   <template v-if="slot">
-                    <img
-                      :src="getCreatureImage(slot)"
-                      :alt="slot.name"
-                      class="size-full cursor-pointer object-cover"
-                      loading="lazy"
-                      @click="inspectCreature(slot)"
-                    />
-                    <div
-                      class="absolute inset-x-0 bottom-0 cursor-pointer select-none bg-black/75 px-0.5 py-0.5"
-                      @click="inspectCreature(slot)"
-                    >
-                      <p class="truncate text-center text-[8px] font-semibold text-white">
-                        {{ slot.name }}
-                      </p>
-                    </div>
+                    <RightClickHint @contextmenu="toggleInspectCreature(slot)">
+                      <img
+                        :src="getCreatureImage(slot)"
+                        :alt="slot.name"
+                        class="size-full object-cover"
+                        loading="lazy"
+                      />
+                      <div
+                        class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-0.5 py-0.5"
+                      >
+                        <p class="truncate text-center text-[8px] font-semibold text-white">
+                          {{ slot.name }}
+                        </p>
+                      </div>
+                    </RightClickHint>
                     <button
                       class="focus-ring absolute right-0 top-0 rounded-bl rounded-tr-lg bg-black/70 p-0.5 text-white/80 transition hover:bg-destructive hover:text-white"
                       @click.stop="removeCreatureFromSlot(index)"
@@ -790,7 +790,7 @@ function chooseCreature(creature: Creature) {
               "
               @click="chooseCreature(creature)"
             >
-              <RightClickHint @contextmenu="inspectCreature(creature)">
+              <RightClickHint @contextmenu="toggleInspectCreature(creature)">
                 <!-- Image + assignment badge -->
                 <div class="relative size-12 shrink-0">
                   <img

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -55,7 +55,7 @@ const { goldPerMinute, breakdown: goldBreakdown } = useGoldIncome()
 const {
   selectedCreature: inspectedCreature,
   drawerOpen: creatureDrawerOpen,
-  openCreature: inspectCreature,
+  toggleCreature: toggleInspectCreature,
   closeDrawer: closeCreatureDrawer,
 } = useCreatureDrawer()
 
@@ -1515,7 +1515,7 @@ const flatGroupedCosts = computed(() => {
                             v-for="member in getActiveExpeditionParty(cost.sortedIndex)!
                               .activeVariant.party"
                             :key="member.creature.id"
-                            @contextmenu="inspectCreature(member.creature)"
+                            @contextmenu="toggleInspectCreature(member.creature)"
                           >
                             <div
                               class="inline-flex cursor-default items-center gap-1.5 rounded-lg border py-0.5 pl-0.5 pr-2"
@@ -1586,7 +1586,7 @@ const flatGroupedCosts = computed(() => {
                               <RightClickHint
                                 v-for="member in variant.party"
                                 :key="member.creature.id"
-                                @contextmenu="inspectCreature(member.creature)"
+                                @contextmenu="toggleInspectCreature(member.creature)"
                               >
                                 <div
                                   class="inline-flex items-center gap-1 rounded-md border border-border/40 bg-muted/25 py-0.5 pl-0.5 pr-1.5"


### PR DESCRIPTION
## Description

Standardizes creature inspection to use right-click (contextmenu) across all views, replacing the inconsistent mix of left-click and right-click handlers. Adds toggle behavior so a second right-click on the same creature dismisses the drawer, and introduces an expedition assignment badge in the creature detail panel.

## Summary

- Add `toggleCreature` and `toggleCreatureById` to `useCreatureDrawer` composable — a second right-click on the same creature now closes the drawer instead of no-oping
- Switch all consumer views and components from `openCreature`/`openCreatureById` to the new toggle variants
- Wrap creature images in `RightClickHint` with `@contextmenu` handlers in ExpeditionDetail, ItemDetail, LevelPlannerTimelineStep, PartyPlannerGantt, DungeonsView, and SanctuaryView — replacing old `@click` handlers and removing `cursor-pointer` classes
- Show an expedition assignment badge in CreatureDetail, consistent with existing sanctuary/helper/machine/dungeon badges
- Close the creature detail drawer when right-clicking the backdrop overlay