### PR TITLE
Fix summoning planner queue and completed-item handling

### DIFF
--- a/src/components/planner/PlannerListRow.vue
+++ b/src/components/planner/PlannerListRow.vue
@@ -77,7 +77,7 @@ function onChipLeave() {
 }
 
 
-const totalNeeded = computed(() => props.node.requiredAmount + props.inventoryAmount)
+const totalNeeded = computed(() => props.node.grossAmount)
 
 
 const ownedPct = computed(() =>

--- a/src/components/planner/PlannerListRow.vue
+++ b/src/components/planner/PlannerListRow.vue
@@ -77,11 +77,14 @@ function onChipLeave() {
 }
 
 
+// inventoryAmount is a merged pool (raw + queued) from the planner graph.
+// Derive the raw (non-queued) portion so the progress bar shows owned vs queued correctly.
+const rawInventory = computed(() => Math.max(0, props.inventoryAmount - (props.queuedAmount ?? 0)))
 const totalNeeded = computed(() => props.node.grossAmount)
 
 
 const ownedPct = computed(() =>
-  Math.min(100, Math.round((props.inventoryAmount / Math.max(1, totalNeeded.value)) * 100)),
+  Math.min(100, Math.round((rawInventory.value / Math.max(1, totalNeeded.value)) * 100)),
 )
 
 
@@ -239,7 +242,7 @@ function onSegmentLeave() {
         <div class="flex items-center gap-1.5 px-3 py-2">
           <template v-if="barPopoverSegment === 'owned'">
             <span class="font-mono text-xs font-bold text-amber-600 dark:text-amber-400">
-              {{ inventoryAmount.toLocaleString() }}
+              {{ rawInventory.toLocaleString() }}
             </span>
             <span class="text-[11px] text-muted-foreground">have</span>
           </template>

--- a/src/components/planner/PlannerTreeNode.vue
+++ b/src/components/planner/PlannerTreeNode.vue
@@ -293,7 +293,10 @@ function forwardPinMethod(nodeId: string, methodId: string) {
             <div class="mt-1.5 flex items-baseline justify-between">
               <span class="font-mono text-[11px] font-semibold">
                 <span class="text-[10px] font-normal text-muted-foreground/50">Have </span>
-                <span class="text-foreground">{{ stockOnHand.toLocaleString() }}</span>
+                <span class="text-foreground"
+                  >{{ stockOnHand.toLocaleString()
+                  }}<sup v-if="queuedForItem > 0" class="text-sky-500">*</sup></span
+                >
                 <span class="text-muted-foreground/50"> / {{ totalNeeded.toLocaleString() }}</span>
                 <span class="text-[10px] font-normal text-muted-foreground/50"> Total</span>
               </span>

--- a/src/components/planner/PlannerTreeNode.vue
+++ b/src/components/planner/PlannerTreeNode.vue
@@ -39,10 +39,16 @@ const props = withDefaults(
 )
 
 
-const stockOnHand = computed(() => props.inventoryAmounts[props.node.itemId] ?? 0)
 const queuedForItem = computed(() => props.queuedAmounts?.[props.node.itemId] ?? 0)
+// inventoryAmounts is a merged pool (raw + queued) used by the planner graph.
+// Derive the raw (non-queued) portion so the progress bar shows owned vs queued correctly.
+const stockOnHand = computed(() => {
+  const merged = props.inventoryAmounts[props.node.itemId] ?? 0
+  return Math.max(0, merged - queuedForItem.value)
+})
 const totalNeeded = computed(() => props.node.grossAmount)
-const deficit = computed(() => Math.max(0, props.node.requiredAmount - queuedForItem.value))
+// requiredAmount is already net of all claimed stock (raw + queued), so it IS the deficit.
+const deficit = computed(() => props.node.requiredAmount)
 
 
 const activeMethod = computed(() => {

--- a/src/components/planner/PlannerTreeNode.vue
+++ b/src/components/planner/PlannerTreeNode.vue
@@ -41,7 +41,7 @@ const props = withDefaults(
 
 const stockOnHand = computed(() => props.inventoryAmounts[props.node.itemId] ?? 0)
 const queuedForItem = computed(() => props.queuedAmounts?.[props.node.itemId] ?? 0)
-const totalNeeded = computed(() => props.node.requiredAmount + stockOnHand.value)
+const totalNeeded = computed(() => props.node.grossAmount)
 const deficit = computed(() => Math.max(0, props.node.requiredAmount - queuedForItem.value))
 
 

--- a/src/components/summoning-planner/SummoningObjectiveCard.vue
+++ b/src/components/summoning-planner/SummoningObjectiveCard.vue
@@ -87,6 +87,8 @@ function onSegmentLeave() {
 }
 
 
+// Only fulfilled when raw inventory alone covers the need — queued items
+// shouldn't mark an objective as complete since they're still being crafted.
 const fulfilled = computed(() => props.inventoryAmount >= props.totalNeeded)
 
 
@@ -187,9 +189,9 @@ function fmt(n: number): string {
                 { 'rounded-r-full': !queuedAmount || queuedAmount === 0 },
               ]"
               :style="{ width: `${progressPct}%` }"
-              @mouseenter="onSegmentEnter('owned', $event)"
-              @mousemove="onSegmentMove"
-              @mouseleave="onSegmentLeave"
+              @mouseenter="!fulfilled && onSegmentEnter('owned', $event)"
+              @mousemove="!fulfilled && onSegmentMove($event)"
+              @mouseleave="!fulfilled && onSegmentLeave()"
             />
             <div
               v-if="queuedAmount && queuedAmount > 0"
@@ -197,9 +199,9 @@ function fmt(n: number): string {
               :style="{
                 width: `${Math.min(100 - progressPct, Math.round((queuedAmount / Math.max(1, totalNeeded)) * 100))}%`,
               }"
-              @mouseenter="onSegmentEnter('queued', $event)"
-              @mousemove="onSegmentMove"
-              @mouseleave="onSegmentLeave"
+              @mouseenter="!fulfilled && onSegmentEnter('queued', $event)"
+              @mousemove="!fulfilled && onSegmentMove($event)"
+              @mouseleave="!fulfilled && onSegmentLeave()"
             />
           </div>
         </div>
@@ -209,7 +211,10 @@ function fmt(n: number): string {
           <span class="font-mono text-xs font-semibold">
             <span class="text-[10px] font-normal text-muted-foreground/50">Have </span>
             <span :class="fulfilled ? 'text-emerald-600 dark:text-emerald-400' : 'text-foreground'">
-              {{ fmt(inventoryAmount) }}
+              {{ fmt(inventoryAmount)
+              }}<sup v-if="!fulfilled && queuedAmount && queuedAmount > 0" class="text-sky-500"
+                >*</sup
+              >
             </span>
             <span class="text-muted-foreground/50"> / {{ fmt(totalNeeded) }} </span>
             <span class="text-[10px] font-normal text-muted-foreground/50"> Total</span>

--- a/src/composables/useCraftPlanner.ts
+++ b/src/composables/useCraftPlanner.ts
@@ -189,6 +189,7 @@ export function buildPlannerGraph(
   ): PlannerNode {
     const item = itemById.get(itemId)
     const nodeId = path
+    const grossAmount = requiredAmount
 
     // Skip inventory deduction for the root target in craft planner (we want to build
     // *additional* items). Summoning planner passes deductRootInventory=true since
@@ -203,6 +204,7 @@ export function buildPlannerGraph(
         itemName: item?.name ?? toTitleCase(itemId),
         itemType: item?.type ?? 'Gathered',
         requiredAmount: 0,
+        grossAmount,
         depth,
         defaultMethodId: null,
         methods: [],
@@ -222,6 +224,7 @@ export function buildPlannerGraph(
         itemName: toTitleCase(itemId),
         itemType: 'Gathered',
         requiredAmount,
+        grossAmount,
         depth,
         defaultMethodId: null,
         methods: [],
@@ -253,6 +256,7 @@ export function buildPlannerGraph(
         itemName: item.name,
         itemType: item.type,
         requiredAmount,
+        grossAmount,
         depth,
         defaultMethodId: cycleMethod.id,
         methods: [cycleMethod],
@@ -925,6 +929,7 @@ export function buildPlannerGraph(
       itemName: item.name,
       itemType: item.type,
       requiredAmount,
+      grossAmount,
       depth,
       defaultMethodId,
       methods,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -213,7 +213,10 @@ export interface PlannerNode {
   itemId: string
   itemName: string
   itemType: ItemType
+  /** Amount still needed after inventory/queue stock was claimed. */
   requiredAmount: number
+  /** Original amount before any stock was claimed (the from-scratch cost). */
+  grossAmount: number
   depth: number
   defaultMethodId: string | null
   methods: PlannerMethod[]

--- a/src/utils/parseSave.ts
+++ b/src/utils/parseSave.ts
@@ -103,7 +103,17 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
   const { machineLevels, machineRecipes } = parseMachineDetails(save)
   const fabricationAllocations = parseFabricationAllocations(save)
   const skillLevels = parseSkillLevels(save)
-  const { queuedAmounts, queuedTimes } = parseWorkstationQueues(save)
+  const { queuedAmounts, queuedTimes, completedOutputs } = parseWorkstationQueues(save)
+
+  // The game save includes completed-but-uncollected workstation items in the
+  // inventory array. Subtract them so "Have" reflects actual bag contents —
+  // completed items are already counted in queuedAmounts (sky bar) instead.
+  for (const [itemId, amount] of Object.entries(completedOutputs)) {
+    if (inventory[itemId]) {
+      inventory[itemId] = Math.max(0, inventory[itemId] - amount)
+      if (inventory[itemId] === 0) delete inventory[itemId]
+    }
+  }
 
   const currentExpedition = buildExpeditionData(save, creatures)
 
@@ -421,9 +431,11 @@ interface SaveWorkstationState {
 function parseWorkstationQueues(save: Record<string, unknown>): {
   queuedAmounts: Record<string, Record<string, number>>
   queuedTimes: Record<string, number>
+  completedOutputs: Record<string, number>
 } {
   const queuedAmounts: Record<string, Record<string, number>> = {}
   const queuedTimes: Record<string, number> = {}
+  const completedOutputs: Record<string, number> = {}
 
   for (const ws of ['furnace', 'stove', 'workbench']) {
     const wsState = save[ws] as SaveWorkstationState | undefined
@@ -443,12 +455,24 @@ function parseWorkstationQueues(save: Record<string, unknown>): {
       const itemId = entry.itemId ?? entry.item?.id
       if (!itemId || typeof entry.amount !== 'number' || entry.amount <= 0) continue
       const outputAmount = entry.recipe?.outputAmount ?? 1
-      const crafts = i === 0 ? Math.max(0, entry.amount - completed) : entry.amount
-      if (crafts > 0) {
-        stationItems[itemId] = (stationItems[itemId] ?? 0) + crafts * outputAmount
-        // singleItemDuration is already speed-adjusted by the game
+
+      // Queued amounts include ALL items at the workstation (completed + remaining)
+      // so they show in the sky "queued" bar. Time only counts remaining crafts.
+      stationItems[itemId] = (stationItems[itemId] ?? 0) + entry.amount * outputAmount
+
+      // Track completed outputs so we can subtract them from inventory — the game
+      // save includes them in the inventory array but the player hasn't collected them.
+      if (i === 0 && completed > 0) {
+        const completedAmount = Math.min(completed, entry.amount) * outputAmount
+        if (completedAmount > 0) {
+          completedOutputs[itemId] = (completedOutputs[itemId] ?? 0) + completedAmount
+        }
+      }
+
+      const remainingCrafts = i === 0 ? Math.max(0, entry.amount - completed) : entry.amount
+      if (remainingCrafts > 0) {
         const duration = typeof entry.singleItemDuration === 'number' ? entry.singleItemDuration : 0
-        stationTime += crafts * duration
+        stationTime += remainingCrafts * duration
       }
     }
 
@@ -460,5 +484,5 @@ function parseWorkstationQueues(save: Record<string, unknown>): {
     }
   }
 
-  return { queuedAmounts, queuedTimes }
+  return { queuedAmounts, queuedTimes, completedOutputs }
 }

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -572,6 +572,14 @@ const inventoryDiff = computed(() => {
 })
 
 
+const inventoryList = computed(() =>
+  Object.entries(inventoryAmounts.value)
+    .filter(([, amount]) => amount > 0)
+    .map(([id, amount]) => ({ id, name: itemById.get(id)?.name ?? toTitleCase(id), amount }))
+    .toSorted((a, b) => a.name.localeCompare(b.name)),
+)
+
+
 function flattenQueued(nested: Record<string, Record<string, number>>): Record<string, number> {
   const flat: Record<string, number> = {}
   for (const items of Object.values(nested)) {
@@ -1929,6 +1937,30 @@ function updateAwakenSpeed(ws: string, delta: number) {
           <p v-else class="text-sm text-muted-foreground">
             {{ Object.keys(inventoryAmounts).length }} items tracked. Upload a save file to compare.
           </p>
+
+          <!-- Full inventory list -->
+          <div
+            v-if="inventoryList.length > 0"
+            class="mt-3 max-h-72 space-y-0.5 overflow-y-auto rounded-lg border border-border/50 pr-1"
+          >
+            <div
+              v-for="item in inventoryList"
+              :key="item.id"
+              class="flex items-center justify-between px-2 py-1.5 text-sm odd:bg-muted/20"
+            >
+              <div class="flex items-center gap-2">
+                <img
+                  v-if="getItemImage({ id: item.id })"
+                  :src="getItemImage({ id: item.id })"
+                  :alt="item.name"
+                  class="size-5 object-contain"
+                  loading="lazy"
+                />
+                <span class="font-medium">{{ item.name }}</span>
+              </div>
+              <span class="tabular-nums text-foreground">{{ item.amount.toLocaleString() }}</span>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -19,6 +19,7 @@ import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useTools } from '@/composables/useTools'
 import expeditionsData from '@/data/expeditions.json'
+import { itemById } from '@/data/indexes'
 import type { Expedition, GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { decryptSave } from '@/utils/decrypt'
@@ -562,7 +563,7 @@ const inventoryDiff = computed(() => {
   return [...allKeys]
     .map((id) => ({
       id,
-      name: toTitleCase(id),
+      name: itemById.get(id)?.name ?? toTitleCase(id),
       current: inventoryAmounts.value[id] ?? 0,
       save: saveInv[id] ?? 0,
     }))
@@ -590,7 +591,7 @@ const queuedDiff = computed(() => {
   return [...allKeys]
     .map((id) => ({
       id,
-      name: toTitleCase(id),
+      name: itemById.get(id)?.name ?? toTitleCase(id),
       current: currentFlat[id] ?? 0,
       save: saveFlat[id] ?? 0,
     }))
@@ -611,7 +612,7 @@ const queuedByStation = computed(() =>
       station,
       items: Object.entries(items)
         .filter(([, amount]) => amount > 0)
-        .map(([id, amount]) => ({ id, name: toTitleCase(id), amount }))
+        .map(([id, amount]) => ({ id, name: itemById.get(id)?.name ?? toTitleCase(id), amount }))
         .toSorted((a, b) => a.name.localeCompare(b.name)),
     }))
     .toSorted((a, b) => a.station.localeCompare(b.station)),

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -1006,7 +1006,7 @@ const flatListEntries = computed(() => {
     const existing = merged.get(node.itemId)
 
     if (existing) {
-      existing.totalNeeded += node.requiredAmount
+      existing.totalNeeded += node.grossAmount
       existing.maxDepth = Math.max(existing.maxDepth, node.depth)
     } else {
       const source = getNodeSource(node, treeIndex)
@@ -1020,7 +1020,7 @@ const flatListEntries = computed(() => {
         itemId: node.itemId,
         itemName: node.itemName,
         itemType: node.itemType,
-        totalNeeded: node.requiredAmount + available,
+        totalNeeded: node.grossAmount,
         inventoryAmount: available,
         queuedAmount: queued,
         sourceLabel: source.label,

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -1002,7 +1002,6 @@ const flatListEntries = computed(() => {
   ) {
     const inv = gameConfig.inventoryAmounts.value[node.itemId] ?? 0
     const queued = flatQueuedAmounts.value[node.itemId] ?? 0
-    const available = inv + queued
     const existing = merged.get(node.itemId)
 
     if (existing) {
@@ -1021,7 +1020,7 @@ const flatListEntries = computed(() => {
         itemName: node.itemName,
         itemType: node.itemType,
         totalNeeded: node.grossAmount,
-        inventoryAmount: available,
+        inventoryAmount: inv,
         queuedAmount: queued,
         sourceLabel: source.label,
         sourceIcon: source.icon,


### PR DESCRIPTION
## Description

The summoning cost planner had a few overlapping accounting bugs around workstation queues, completed items, and display math. Required amounts for sub-items did not always reflect that parent items were already queued, completed-but-uncollected items were both inflating the inventory total and disappearing from queue counts, and progress bars were silently double-counting queued amounts as both "owned" and "queued." 

This PR fixes the data layer so completed workstation outputs read correctly, captures each planner node's pre-claim cost so totals can no longer balloon past the actual summoning requirement, and tightens the display so "Have" tracks the player's bag while a sky-blue marker calls out when queued items are pulling the rest of the weight. Two configs page improvements ride along: the inventory and queue lists now resolve real item names from game data, and the configs inventory section finally shows a scrollable list of every item the player owns.

## Summary

- Move completed workstation outputs out of the parsed inventory and into queued amounts so "Have" reflects what's actually in the bag and the sky bar shows everything sitting at the workstation (`parseSave.ts`).
- Add `grossAmount` to `PlannerNode` so flat-list aggregation, planner tree nodes, and planner list rows can show the true from-scratch summoning cost instead of the inflated `requiredAmount + available` reconstruction (`useCraftPlanner.ts`, `types/index.ts`, `SummoningPlannerView.vue`, `PlannerTreeNode.vue`, `PlannerListRow.vue`).
- Pass raw inventory through the summoning planner's flat list, derive raw vs queued portions inside `PlannerTreeNode` and `PlannerListRow`, and stop double-subtracting queued amounts in deficit math.
- Show a sky-blue `*` superscript on "Have" when queued items are still contributing toward the total, hide it once the objective is fulfilled, and suppress the progress-bar hover popover for completed objective cards (`SummoningObjectiveCard.vue`, `PlannerTreeNode.vue`).
- Look up item names through `itemById` (with `toTitleCase` fallback) in the configs inventory diff, queue diff, and queued-by-station mappers so labels match the canonical game names instead of kebab-case titles.
- Add a sorted, scrollable inventory list with item icons and amounts to the configs inventory section so users can see exactly what they have on hand (`ConfigsView.vue`).