### PR TITLE
Add dungeon party parsing from save file

### DIFF
--- a/src/composables/__tests__/useGameConfig.test.ts
+++ b/src/composables/__tests__/useGameConfig.test.ts
@@ -227,6 +227,19 @@ describe('useGameConfig', () => {
     expect(fabricationAllocations.value).toEqual({})
   })
 
+  test('setDungeonParty updates the dungeon party ref', () => {
+    const { dungeonParty, setDungeonParty } = useGameConfig()
+    setDungeonParty(['pudge', 'finn', 'kroko'])
+    expect(dungeonParty.value).toEqual(['pudge', 'finn', 'kroko'])
+  })
+
+  test('resetDungeonParty clears the dungeon party', () => {
+    const { dungeonParty, setDungeonParty, resetDungeonParty } = useGameConfig()
+    setDungeonParty(['pudge', 'finn'])
+    resetDungeonParty()
+    expect(dungeonParty.value).toEqual([])
+  })
+
   test('resetGameConfig clears every settable field back to defaults', () => {
     const config = useGameConfig()
 
@@ -254,7 +267,7 @@ describe('useGameConfig', () => {
     config.setSkillLevels({ mining: 5 })
     config.setQueuedAmounts({ Furnace: { 'copper-bar': 10 } })
     config.setQueuedTimes({ Furnace: 5000 })
-    config.dungeonParty.value = ['c1', 'c2']
+    config.setDungeonParty(['c1', 'c2'])
 
     // Reset everything
     config.resetGameConfig()

--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -233,6 +233,10 @@ export function useGameConfig() {
     expeditionLoopCounts.value = {}
   }
 
+  function setDungeonParty(party: string[]) {
+    dungeonParty.value = party
+  }
+
   function resetDungeonParty() {
     dungeonParty.value = []
   }
@@ -287,6 +291,7 @@ export function useGameConfig() {
     setExpeditionLoopCounts,
     resetExpeditionSetup,
     dungeonParty,
+    setDungeonParty,
     resetDungeonParty,
     setInventory,
     resetInventory,

--- a/src/utils/__tests__/parseSave.test.ts
+++ b/src/utils/__tests__/parseSave.test.ts
@@ -13,6 +13,7 @@ function baseSave(): Record<string, unknown> {
     fabrication: { allocations: {} },
     expeditionCompletions: {},
     activeExpeditions: [],
+    dungeons: { activeDungeons: [] },
   }
 }
 
@@ -191,5 +192,92 @@ describe('parseSave — skillLevels', () => {
 
     const config = extractSaveConfig(save)
     expect(config.skillLevels).toEqual({ Chopping: 5 })
+  })
+})
+
+describe('parseSave — currentDungeon', () => {
+  test('parses active dungeon with creature mapping', () => {
+    const save = baseSave()
+    save.creatures = [
+      { id: 'inst-1', species: 'pudge', experience: 5000 },
+      { id: 'inst-2', species: 'finn', experience: 20000 },
+    ]
+    save.dungeons = {
+      activeDungeons: [
+        {
+          tier: 4,
+          focus: 'combat',
+          gatheringSkill: null,
+          creatures: ['inst-1', 'inst-2'],
+        },
+      ],
+    }
+
+    const config = extractSaveConfig(save)
+    expect(config.currentDungeon).toEqual({
+      party: ['pudge', 'finn'],
+      tier: 4,
+      focus: 'combat',
+      gatheringSkill: null,
+      levels: { pudge: 10, finn: 20 },
+    })
+  })
+
+  test('parses gathering dungeon with sub-focus', () => {
+    const save = baseSave()
+    save.creatures = [{ id: 'inst-1', species: 'kroko', experience: 5000 }]
+    save.dungeons = {
+      activeDungeons: [
+        {
+          tier: 2,
+          focus: 'gathering',
+          gatheringSkill: 'Mining',
+          creatures: ['inst-1'],
+        },
+      ],
+    }
+
+    const config = extractSaveConfig(save)
+    expect(config.currentDungeon).toEqual({
+      party: ['kroko'],
+      tier: 2,
+      focus: 'gathering',
+      gatheringSkill: 'Mining',
+      levels: { kroko: 10 },
+    })
+  })
+
+  test('returns null when no active dungeons', () => {
+    const save = baseSave()
+
+    const config = extractSaveConfig(save)
+    expect(config.currentDungeon).toBeNull()
+  })
+
+  test('returns null when dungeons key is missing', () => {
+    const save = baseSave()
+    delete save.dungeons
+
+    const config = extractSaveConfig(save)
+    expect(config.currentDungeon).toBeNull()
+  })
+
+  test('filters out creatures not found in creature map', () => {
+    const save = baseSave()
+    save.creatures = [{ id: 'inst-1', species: 'pudge', experience: 5000 }]
+    save.dungeons = {
+      activeDungeons: [
+        {
+          tier: 1,
+          focus: 'combat',
+          gatheringSkill: null,
+          creatures: ['inst-1', 'missing-id'],
+        },
+      ],
+    }
+
+    const config = extractSaveConfig(save)
+    expect(config.currentDungeon!.party).toEqual(['pudge'])
+    expect(config.currentDungeon!.levels).toEqual({ pudge: 10 })
   })
 })

--- a/src/utils/parseSave.ts
+++ b/src/utils/parseSave.ts
@@ -57,6 +57,7 @@ export interface SaveConfig {
   queuedAmounts: Record<string, Record<string, number>>
   queuedTimes: Record<string, number>
   currentExpedition: ExpeditionData
+  currentDungeon: DungeonData
 }
 
 type ExpeditionData = {
@@ -65,6 +66,14 @@ type ExpeditionData = {
   loopCounts: Record<string, number>
   levels: Record<string, number>
 }
+
+type DungeonData = {
+  party: string[]
+  tier: number
+  focus: string
+  gatheringSkill: string | null
+  levels: Record<string, number>
+} | null
 
 const GATHER_JOBS = new Set(['Chopping', 'Mining', 'Digging', 'Exploring', 'Fishing', 'Farming'])
 const WORKSTATIONS = new Set(['Furnace', 'Stove', 'Workbench'])
@@ -106,6 +115,7 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
   const { queuedAmounts, queuedTimes } = parseWorkstationQueues(save)
 
   const currentExpedition = buildExpeditionData(save, creatures)
+  const currentDungeon = buildDungeonData(save, creatures)
 
   return {
     sanctuary,
@@ -129,6 +139,7 @@ export function extractSaveConfig(save: Record<string, unknown>): SaveConfig {
     queuedAmounts,
     queuedTimes,
     currentExpedition,
+    currentDungeon,
   }
 }
 
@@ -159,6 +170,33 @@ function buildExpeditionData(save: Record<string, any>, creatureMap: SaveCreatur
   })
 
   return result
+}
+
+function buildDungeonData(save: Record<string, any>, creatureMap: SaveCreature[]): DungeonData {
+  const dungeons = save.dungeons
+  if (!dungeons?.activeDungeons?.length) return null
+
+  const dungeon = dungeons.activeDungeons[0]
+  const levels: Record<string, number> = {}
+
+  const party = dungeon.creatures
+    .map((id: string) => {
+      const creature = creatureMap.find((c) => c.id === id)
+      if (creature) {
+        levels[creature.species] = levelFromXp(creature.experience)
+        return creature.species
+      }
+      return undefined
+    })
+    .filter((s: string | undefined): s is string => s != null)
+
+  return {
+    party,
+    tier: dungeon.tier,
+    focus: dungeon.focus,
+    gatheringSkill: dungeon.gatheringSkill ?? null,
+    levels,
+  }
 }
 
 function parseInventory(inventory: SaveInventoryItem[]): Record<string, number> {

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -96,6 +96,7 @@ const {
   setExpeditionCreatureLevels,
   setExpeditionLoopCounts,
   resetExpeditionSetup,
+  setDungeonParty,
   resetDungeonParty,
 } = useGameConfig()
 
@@ -827,6 +828,19 @@ function applyExpedition() {
 }
 
 
+function applyDungeon() {
+  if (!saveConfig.value?.currentDungeon) return
+  const d = saveConfig.value.currentDungeon
+  setDungeonParty(d.party)
+  localStorage.setItem('dungeon-creature-levels', JSON.stringify(d.levels))
+  localStorage.setItem('dungeon-tier', String(d.tier))
+  localStorage.setItem('dungeon-focus', d.focus)
+  if (d.gatheringSkill) {
+    localStorage.setItem('dungeon-sub-focus', d.gatheringSkill)
+  }
+}
+
+
 function applyAll() {
   applyCreatureCollection()
   applyExclusions()
@@ -840,6 +854,7 @@ function applyAll() {
   applyFabrication()
   applyExpeditionCompletions()
   applyExpedition()
+  applyDungeon()
 }
 
 


### PR DESCRIPTION
## Description

Creatures actively running dungeons were not being parsed from save files, so importing a save would lose the active dungeon party, tier, focus, and creature levels. This adds dungeon parsing to `parseSave` and wires it into the config apply flow so dungeon state is restored alongside expeditions.

## Summary
- Add `DungeonData` type and `buildDungeonData` to extract active dungeon party, tier, focus, gathering skill, and creature levels from `save.dungeons.activeDungeons`
- Add `setDungeonParty` setter to `useGameConfig` for consistency with other config setters
- Add `applyDungeon` to ConfigsView and wire it into `applyAll` so dungeon state is restored on save import
- Add 7 tests covering dungeon parsing (combat/gathering, missing data, unresolved creatures) and the new setter