### PR TITLE
Fix dungeon creatures missing from excluded lists

### DIFF
--- a/src/components/expeditions/CreatureSelector.vue
+++ b/src/components/expeditions/CreatureSelector.vue
@@ -12,7 +12,13 @@ import type { Creature, ElementType, Expedition, ExpeditionStatWeights } from '@
 import { getCreatureImage } from '@/utils/creatureImages'
 import { toTitleCase, typeColor } from '@/utils/format'
 import { statAbbreviations } from '@/utils/formulas'
-import { sanctuaryIcon, helpersIcon, machinesIcon, expeditionsIcon } from '@/utils/icons'
+import {
+  sanctuaryIcon,
+  helpersIcon,
+  machinesIcon,
+  expeditionsIcon,
+  dungeonsIcon,
+} from '@/utils/icons'
 
 const props = defineProps<{
   recommendedCreatures: {
@@ -28,6 +34,7 @@ const props = defineProps<{
   helperCreatureIds: string[]
   machineCreatureIds: string[]
   expeditionCreatureIds: Set<string>
+  dungeonParty: string[]
   expeditionToolXpBonus: number
   showExcludedCreatures: boolean
 }>()
@@ -374,6 +381,13 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
                 v-else-if="expeditionCreatureIds.has(creature.id)"
                 :src="expeditionsIcon"
                 alt="Expedition"
+                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                loading="lazy"
+              />
+              <img
+                v-else-if="dungeonParty.includes(creature.id)"
+                :src="dungeonsIcon"
+                alt="Dungeon"
                 class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
                 loading="lazy"
               />

--- a/src/composables/__tests__/useSanctuary.test.ts
+++ b/src/composables/__tests__/useSanctuary.test.ts
@@ -238,6 +238,13 @@ describe('useSanctuary', () => {
       const { getCreatureStatus } = useSanctuary()
       expect(getCreatureStatus('e1')).toBe('expedition')
     })
+
+    test('returns "dungeon" for dungeon party creatures', () => {
+      const { setDungeonParty } = useGameConfig()
+      setDungeonParty(['d1'])
+      const { getCreatureStatus } = useSanctuary()
+      expect(getCreatureStatus('d1')).toBe('dungeon')
+    })
   })
 
   describe('recommendedCreatures', () => {

--- a/src/composables/useSanctuary.ts
+++ b/src/composables/useSanctuary.ts
@@ -32,6 +32,7 @@ export function useSanctuary() {
     machineCreatureIds,
     excludedCreatureIds,
     expeditionCreatureIds,
+    dungeonParty,
     jobTiers,
     setSanctuaryCreatures,
   } = useGameConfig()
@@ -309,10 +310,11 @@ export function useSanctuary() {
     setSanctuaryCreatures([])
   }
 
-  function getCreatureStatus(id: string): 'helper' | 'machine' | 'expedition' | null {
+  function getCreatureStatus(id: string): 'helper' | 'machine' | 'expedition' | 'dungeon' | null {
     if (helperCreatureIds.value.includes(id)) return 'helper'
     if (machineCreatureIds.value.includes(id)) return 'machine'
     if (expeditionCreatureIds.value.has(id)) return 'expedition'
+    if (dungeonParty.value.includes(id)) return 'dungeon'
     return null
   }
 

--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -42,6 +42,7 @@ const {
   helperCreatureIds,
   machineCreatureIds,
   expeditionCreatureIds,
+  dungeonParty,
   expeditionToolXpBonus,
 } = useGameConfig()
 const {
@@ -602,6 +603,7 @@ function rowSelected(id: string): boolean {
         :helper-creature-ids="helperCreatureIds"
         :machine-creature-ids="machineCreatureIds"
         :expedition-creature-ids="expeditionCreatureIds"
+        :dungeon-party="dungeonParty"
         :expedition-tool-xp-bonus="expeditionToolXpBonus"
         :show-excluded-creatures="showExcludedCreatures"
         @update:show-excluded-creatures="showExcludedCreatures = $event"

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -15,7 +15,7 @@ import { useSanctuary } from '@/composables/useSanctuary'
 import type { Creature, ElementType, Jobs } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { typeColor } from '@/utils/format'
-import { helpersIcon, machinesIcon, expeditionsIcon, jobIcons } from '@/utils/icons'
+import { helpersIcon, machinesIcon, expeditionsIcon, dungeonsIcon, jobIcons } from '@/utils/icons'
 import {
   MAX_SANCTUARY_SLOTS,
   SANCTUARY_JOBS,
@@ -823,6 +823,13 @@ function chooseCreature(creature: Creature) {
                     v-else-if="getCreatureStatus(creature.id) === 'expedition'"
                     :src="expeditionsIcon"
                     alt="Expedition"
+                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    loading="lazy"
+                  />
+                  <img
+                    v-else-if="getCreatureStatus(creature.id) === 'dungeon'"
+                    :src="dungeonsIcon"
+                    alt="Dungeon"
                     class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />


### PR DESCRIPTION
## Description

Dungeon party creatures were not shown as excluded in the Sanctuary or Expeditions creature selectors. The `getCreatureStatus` function in `useSanctuary` only checked for helper, machine, and expedition assignments, so dungeon creatures appeared without an assignment badge when "Show Excluded" was toggled on. The Expeditions `CreatureSelector` had the same gap in its badge template.

## Summary
- Add `'dungeon'` case to `getCreatureStatus` in `useSanctuary` so it returns the correct status for dungeon party creatures
- Add dungeon assignment badge to `SanctuaryView` creature list, matching the existing helper/machine/expedition pattern
- Add `dungeonParty` prop to the Expeditions `CreatureSelector` and render the dungeon badge alongside the other assignment icons
- Add test for `getCreatureStatus` returning `'dungeon'`