### PR TITLE
Fix item name consistency across display sites

### DIFF
--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -9,7 +9,7 @@ import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, CreatureStats, Jobs } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { toTitleCase, typeColor, typeColorVar } from '@/utils/format'
+import { itemName, toTitleCase, typeColor, typeColorVar } from '@/utils/format'
 import {
   getBestExpeditionsForCreature,
   jobColors,
@@ -394,7 +394,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                         getItemImage({ id: entry.expedition.rewards[0].itemId })
                       "
                       :src="getItemImage({ id: entry.expedition.rewards[0].itemId })"
-                      :alt="toTitleCase(entry.expedition.rewards[0].itemId)"
+                      :alt="itemName(entry.expedition.rewards[0].itemId)"
                       class="size-5 shrink-0 object-contain"
                       loading="lazy"
                     />

--- a/src/components/expeditions/ExpeditionDetail.vue
+++ b/src/components/expeditions/ExpeditionDetail.vue
@@ -6,7 +6,7 @@ import RightClickHint from '@/components/shared/RightClickHint.vue'
 import type { Creature, Expedition, ExpeditionStatWeights } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { TIER_UNLOCK_REQUIREMENTS } from '@/utils/expeditionUnlocks'
-import { formatDuration, toTitleCase } from '@/utils/format'
+import { formatDuration, itemName, toTitleCase } from '@/utils/format'
 import { statLabels, tierModifiers } from '@/utils/formulas'
 import { expeditionTierIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
@@ -113,12 +113,12 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             <img
               v-if="getItemImage({ id: reward.itemId })"
               :src="getItemImage({ id: reward.itemId })"
-              :alt="toTitleCase(reward.itemId)"
+              :alt="itemName(reward.itemId)"
               class="size-4 object-contain"
               loading="lazy"
             />
             {{ reward.amount * tierModifiers.loot[selectedTier - 1] }}x
-            {{ toTitleCase(reward.itemId) }}
+            {{ itemName(reward.itemId) }}
           </span>
         </div>
       </div>

--- a/src/components/level-planner/LevelPlannerTimelineStep.vue
+++ b/src/components/level-planner/LevelPlannerTimelineStep.vue
@@ -16,7 +16,7 @@ import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Creature } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { formatDuration } from '@/utils/format'
+import { formatDuration, itemName } from '@/utils/format'
 import { expeditionTierIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 import type { PlanStep } from '@/utils/levelPlanner'
@@ -179,7 +179,7 @@ function formatDelta(value: number): string {
                     getItemImage({ id: step.expedition.rewards[0].itemId })
                   "
                   :src="getItemImage({ id: step.expedition.rewards[0].itemId })"
-                  :alt="step.expedition.rewards[0].itemId"
+                  :alt="itemName(step.expedition.rewards[0].itemId)"
                   loading="lazy"
                   class="size-5 shrink-0 object-contain"
                 />
@@ -443,7 +443,7 @@ function formatDelta(value: number): string {
                       getItemImage({ id: alt.expedition.rewards[0].itemId })
                     "
                     :src="getItemImage({ id: alt.expedition.rewards[0].itemId })"
-                    :alt="alt.expedition.rewards[0].itemId"
+                    :alt="itemName(alt.expedition.rewards[0].itemId)"
                     loading="lazy"
                     class="size-4 shrink-0 object-contain"
                   />

--- a/src/components/level-planner/PartyExpeditionFilter.vue
+++ b/src/components/level-planner/PartyExpeditionFilter.vue
@@ -3,6 +3,7 @@ import { ChevronDown, RotateCcw } from 'lucide-vue-next'
 import { computed, ref } from 'vue'
 
 import type { Expedition } from '@/types'
+import { itemName } from '@/utils/format'
 import { expeditionTierIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 
@@ -160,7 +161,7 @@ function handleRowClick(expeditionId: string) {
             <img
               v-if="exp.rewards.length > 0 && getItemImage({ id: exp.rewards[0].itemId })"
               :src="getItemImage({ id: exp.rewards[0].itemId })"
-              :alt="exp.rewards[0].itemId"
+              :alt="itemName(exp.rewards[0].itemId)"
               loading="lazy"
               class="size-5 shrink-0 object-contain"
             />

--- a/src/components/summoning-planner/SummoningExpeditionPlan.vue
+++ b/src/components/summoning-planner/SummoningExpeditionPlan.vue
@@ -7,7 +7,7 @@ import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import type { Expedition } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import type { ExpeditionPlan } from '@/utils/expeditionOptimizer'
-import { formatDuration, toTitleCase } from '@/utils/format'
+import { formatDuration, itemName, toTitleCase } from '@/utils/format'
 import { expeditionTierIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
 
@@ -63,7 +63,7 @@ const { selectedCreature, drawerOpen, toggleCreature, closeDrawer } = useCreatur
                 expedition.rewards.length > 0 && getItemImage({ id: expedition.rewards[0].itemId })
               "
               :src="getItemImage({ id: expedition.rewards[0].itemId })"
-              :alt="expedition.rewards[0].itemId"
+              :alt="itemName(expedition.rewards[0].itemId)"
               class="size-5 shrink-0 object-contain"
             />
             <p class="truncate text-sm font-semibold text-foreground">{{ expedition.name }}</p>

--- a/src/composables/useCraftPlanner.ts
+++ b/src/composables/useCraftPlanner.ts
@@ -26,7 +26,12 @@ import type {
   PlannerTimeBreakdown,
   ScheduledTask,
 } from '@/types'
-import { formatChance, formatDuration, methodKindLabel, toTitleCase } from '@/utils/format'
+import {
+  formatChance,
+  formatDuration,
+  itemName as resolveItemName,
+  methodKindLabel,
+} from '@/utils/format'
 import { tierModifiers } from '@/utils/formulas'
 import { computeGoldPerMinute, goldToSeconds } from '@/utils/goldIncome'
 
@@ -69,7 +74,7 @@ const gardenSourcesByItem = new Map<string, GardenSource>(
     itemId,
     {
       flowerItemId,
-      flowerItemName: itemById.get(flowerItemId)?.name ?? toTitleCase(flowerItemId),
+      flowerItemName: resolveItemName(flowerItemId),
       cycleSeconds: 60,
       yieldPerCycle: 1,
     },
@@ -201,7 +206,7 @@ export function buildPlannerGraph(
       const fulfilledNode: PlannerNode = {
         id: nodeId,
         itemId,
-        itemName: item?.name ?? toTitleCase(itemId),
+        itemName: resolveItemName(itemId),
         itemType: item?.type ?? 'Gathered',
         requiredAmount: 0,
         grossAmount,
@@ -221,7 +226,7 @@ export function buildPlannerGraph(
       const unknownNode: PlannerNode = {
         id: nodeId,
         itemId,
-        itemName: toTitleCase(itemId),
+        itemName: resolveItemName(itemId),
         itemType: 'Gathered',
         requiredAmount,
         grossAmount,
@@ -1089,8 +1094,7 @@ export function computeSchedule(
     collectItems(root)
 
     for (const itemId of treeItemIds) {
-      const item = itemById.get(itemId)
-      const itemName = item?.name ?? itemId
+      const itemName = resolveItemName(itemId)
       const activeKinds = activeMethodKindByItem.get(itemId) ?? new Set()
 
       // Machine passive lanes (one per unique machine)

--- a/src/composables/useSummoningPlanner.ts
+++ b/src/composables/useSummoningPlanner.ts
@@ -2,8 +2,7 @@ import { ref, computed, watch } from 'vue'
 
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
-import { itemById } from '@/data/indexes'
-import { toTitleCase } from '@/utils/format'
+import { itemName as resolveItemName } from '@/utils/format'
 
 const STORAGE_KEY = 'summoning-planner-selection'
 
@@ -64,10 +63,9 @@ export function useSummoningPlanner() {
         if (existing) {
           existing.amount += cost.amount
         } else {
-          const item = itemById.get(cost.id)
           totals.set(cost.id, {
             itemId: cost.id,
-            itemName: item?.name ?? toTitleCase(cost.id),
+            itemName: resolveItemName(cost.id),
             amount: cost.amount,
           })
         }

--- a/src/data/indexes.ts
+++ b/src/data/indexes.ts
@@ -30,15 +30,13 @@ for (const item of items) {
   itemById.set(item.id, item)
 }
 
-export const tools = toolsData.tools as Tool[]
 export const toolById = new Map<string, Tool>()
-for (const tool of tools) {
+for (const tool of toolsData.tools as Tool[]) {
   toolById.set(tool.id, tool)
 }
 
-export const machines = machinesData.machines as Machine[]
 export const machineById = new Map<string, Machine>()
-for (const machine of machines) {
+for (const machine of machinesData.machines as Machine[]) {
   machineById.set(machine.id, machine)
 }
 

--- a/src/data/indexes.ts
+++ b/src/data/indexes.ts
@@ -3,13 +3,16 @@ import expeditionsData from '@/data/expeditions.json'
 import itemsData from '@/data/items.json'
 import jobsData from '@/data/jobs.json'
 import machinesData from '@/data/machines.json'
+import toolsData from '@/data/tools.json'
 import type {
   Creature,
   ContainerSource,
   Item,
   JobActivitySource,
+  Machine,
   RecipeUsage,
   SummoningReference,
+  Tool,
 } from '@/types'
 
 interface ExpeditionSource {
@@ -25,6 +28,18 @@ const creatures = creaturesData as Creature[]
 export const itemById = new Map<string, Item>()
 for (const item of items) {
   itemById.set(item.id, item)
+}
+
+export const tools = toolsData.tools as Tool[]
+export const toolById = new Map<string, Tool>()
+for (const tool of tools) {
+  toolById.set(tool.id, tool)
+}
+
+export const machines = machinesData.machines as Machine[]
+export const machineById = new Map<string, Machine>()
+for (const machine of machines) {
+  machineById.set(machine.id, machine)
 }
 
 export const jobActivityIndex = new Map<string, JobActivitySource[]>()

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,10 +1,13 @@
 import {
   formatChance,
   formatDuration,
+  itemName,
+  machineName,
   methodKindClasses,
   methodKindColor,
   methodKindLabel,
   sourceLabel,
+  toolName,
   toTitleCase,
 } from '@/utils/format'
 
@@ -198,5 +201,35 @@ describe('methodKindColor', () => {
 
   test('fabrication kind returns violet color', () => {
     expect(methodKindColor('fabrication')).toBe('rgb(167, 139, 250)')
+  })
+})
+
+describe('itemName', () => {
+  test('returns canonical name for known item id (regression: dungeon-rune is Chronicle Rune, not Dungeon Rune)', () => {
+    expect(itemName('dungeon-rune')).toBe('Chronicle Rune')
+  })
+
+  test('falls back to title-cased id for unknown id', () => {
+    expect(itemName('totally-fake-item')).toBe('Totally Fake Item')
+  })
+})
+
+describe('toolName', () => {
+  test('returns canonical name for known tool id', () => {
+    expect(toolName('axe')).toBe('Axe')
+  })
+
+  test('falls back to title-cased id for unknown id', () => {
+    expect(toolName('totally-fake-tool')).toBe('Totally Fake Tool')
+  })
+})
+
+describe('machineName', () => {
+  test('returns canonical name for known machine id', () => {
+    expect(machineName('stone-quarry')).toBe('Stone Quarry')
+  })
+
+  test('falls back to title-cased id for unknown id', () => {
+    expect(machineName('totally-fake-machine')).toBe('Totally Fake Machine')
   })
 })

--- a/src/utils/__tests__/nameConsistency.test.ts
+++ b/src/utils/__tests__/nameConsistency.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const SRC_ROOT = join(__dirname, '..', '..')
+const REPO_ROOT = join(SRC_ROOT, '..')
+
+const SKIP_DIRS = new Set(['__tests__', 'data', 'types', 'test'])
+const SKIP_FILES = new Set(['format.ts'])
+
+const ANTI_PATTERNS: { regex: RegExp; fix: string }[] = [
+  {
+    regex: /toTitleCase\([^)]*\b(?:itemId|toolId|machineId|requiresItem)\b/,
+    fix: 'use itemName/toolName/machineName from @/utils/format instead of toTitleCase on an *Id value',
+  },
+  {
+    regex: /\b(?:itemId|toolId|machineId)\b\s*\.replace\(\s*\/-\/g/,
+    fix: 'use itemName/toolName/machineName from @/utils/format instead of replacing hyphens on an *Id value',
+  },
+  {
+    regex: /:(?:alt|title|aria-label)\s*=\s*"[^"]*\.(?:itemId|toolId|machineId)\s*"/,
+    fix: 'wrap the *Id value with itemName/toolName/machineName before binding it to alt/title/aria-label',
+  },
+]
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue
+      collectSourceFiles(full, acc)
+      continue
+    }
+    if (!stat.isFile()) continue
+    if (SKIP_FILES.has(entry)) continue
+    if (!/\.(?:vue|ts)$/.test(entry)) continue
+    acc.push(full)
+  }
+  return acc
+}
+
+interface Violation {
+  file: string
+  line: number
+  text: string
+  fix: string
+}
+
+function findViolations(): Violation[] {
+  const violations: Violation[] = []
+  for (const file of collectSourceFiles(SRC_ROOT)) {
+    const lines = readFileSync(file, 'utf8').split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      for (const { regex, fix } of ANTI_PATTERNS) {
+        if (regex.test(lines[i])) {
+          violations.push({
+            file: relative(REPO_ROOT, file),
+            line: i + 1,
+            text: lines[i].trim(),
+            fix,
+          })
+        }
+      }
+    }
+  }
+  return violations
+}
+
+describe('item / tool / machine name consistency', () => {
+  test('no source file uses toTitleCase or .replace on an *Id value for display', () => {
+    const violations = findViolations()
+    if (violations.length > 0) {
+      const message = violations
+        .map((v) => `  ${v.file}:${v.line}\n    ${v.text}\n    → ${v.fix}`)
+        .join('\n')
+      throw new Error(`Found ${violations.length} item-name anti-pattern violation(s):\n${message}`)
+    }
+    expect(violations).toEqual([])
+  })
+})

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,4 +1,4 @@
-import { itemById } from '@/data/indexes'
+import { itemById, machineById, toolById } from '@/data/indexes'
 import type { ElementType, ItemType, PlannerMethodKind } from '@/types'
 
 export function typeColor(type: ElementType): string {
@@ -110,6 +110,14 @@ export function formatChance(chance: number): string {
 
 export function itemName(id: string): string {
   return itemById.get(id)?.name ?? toTitleCase(id.replace(/-/g, ' '))
+}
+
+export function toolName(id: string): string {
+  return toolById.get(id)?.name ?? toTitleCase(id.replace(/-/g, ' '))
+}
+
+export function machineName(id: string): string {
+  return machineById.get(id)?.name ?? toTitleCase(id.replace(/-/g, ' '))
 }
 
 export function toTitleCase(str: string): string {

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -28,7 +28,7 @@ import {
   getMaxUnlockedTier,
   TIER_UNLOCK_REQUIREMENTS,
 } from '@/utils/expeditionUnlocks'
-import { formatDuration, toTitleCase } from '@/utils/format'
+import { formatDuration, itemName, machineName, toTitleCase, toolName } from '@/utils/format'
 import { levelFromXp, getPlayerLevel, getPlayerLevelXpBonus, SKILLING_IDS } from '@/utils/formulas'
 import {
   sourceIcons,
@@ -2730,7 +2730,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
             :key="toolId"
             class="flex items-center justify-between rounded-lg px-2 py-1.5 text-sm"
           >
-            <span class="flex items-center gap-2 font-medium capitalize">
+            <span class="flex items-center gap-2 font-medium">
               <img
                 v-if="toolIcons[toolId]"
                 :src="toolIcons[toolId]"
@@ -2738,7 +2738,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
                 class="size-5"
                 loading="lazy"
               />
-              {{ toolId.replace(/-/g, ' ') }}
+              {{ toolName(toolId) }}
             </span>
             <span class="flex items-center gap-2">
               <span class="text-xs tabular-nums text-muted-foreground"> Level {{ level }}/10 </span>
@@ -2944,15 +2944,15 @@ function updateAwakenSpeed(ws: string, delta: number) {
             :key="machineId"
             class="flex items-center justify-between rounded-lg px-2 py-1.5 text-sm"
           >
-            <span class="flex items-center gap-2 font-medium capitalize">
+            <span class="flex items-center gap-2 font-medium">
               <img
-                v-if="sourceIcons[toTitleCase(machineId)]"
-                :src="sourceIcons[toTitleCase(machineId)]"
+                v-if="sourceIcons[machineName(machineId)]"
+                :src="sourceIcons[machineName(machineId)]"
                 alt=""
                 class="size-5"
                 loading="lazy"
               />
-              {{ machineId.replace(/-/g, ' ') }}
+              {{ machineName(machineId) }}
             </span>
             <span class="text-xs tabular-nums text-muted-foreground"> Level {{ level }}/10 </span>
           </div>
@@ -3024,7 +3024,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
                 class="size-4"
                 loading="lazy"
               />
-              <span class="font-medium capitalize">{{ itemId.replace(/-/g, ' ') }}</span>
+              <span class="font-medium">{{ itemName(itemId) }}</span>
             </div>
             <span class="text-xs tabular-nums text-muted-foreground">
               {{ amount }}/5 points &middot; {{ amount }} per cycle

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -19,7 +19,6 @@ import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useTools } from '@/composables/useTools'
 import expeditionsData from '@/data/expeditions.json'
-import { itemById } from '@/data/indexes'
 import type { Expedition, GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
 import { decryptSave } from '@/utils/decrypt'
@@ -564,7 +563,7 @@ const inventoryDiff = computed(() => {
   return [...allKeys]
     .map((id) => ({
       id,
-      name: itemById.get(id)?.name ?? toTitleCase(id),
+      name: itemName(id),
       current: inventoryAmounts.value[id] ?? 0,
       save: saveInv[id] ?? 0,
     }))
@@ -576,7 +575,7 @@ const inventoryDiff = computed(() => {
 const inventoryList = computed(() =>
   Object.entries(inventoryAmounts.value)
     .filter(([, amount]) => amount > 0)
-    .map(([id, amount]) => ({ id, name: itemById.get(id)?.name ?? toTitleCase(id), amount }))
+    .map(([id, amount]) => ({ id, name: itemName(id), amount }))
     .toSorted((a, b) => a.name.localeCompare(b.name)),
 )
 
@@ -600,7 +599,7 @@ const queuedDiff = computed(() => {
   return [...allKeys]
     .map((id) => ({
       id,
-      name: itemById.get(id)?.name ?? toTitleCase(id),
+      name: itemName(id),
       current: currentFlat[id] ?? 0,
       save: saveFlat[id] ?? 0,
     }))
@@ -621,7 +620,7 @@ const queuedByStation = computed(() =>
       station,
       items: Object.entries(items)
         .filter(([, amount]) => amount > 0)
-        .map(([id, amount]) => ({ id, name: itemById.get(id)?.name ?? toTitleCase(id), amount }))
+        .map(([id, amount]) => ({ id, name: itemName(id), amount }))
         .toSorted((a, b) => a.name.localeCompare(b.name)),
     }))
     .toSorted((a, b) => a.station.localeCompare(b.station)),

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -3135,7 +3135,7 @@ function updateAwakenSpeed(ws: string, delta: number) {
                   getItemImage({ id: item.expedition.rewards[0].itemId })
                 "
                 :src="getItemImage({ id: item.expedition.rewards[0].itemId })"
-                :alt="item.expedition.rewards[0].itemId"
+                :alt="itemName(item.expedition.rewards[0].itemId)"
                 loading="lazy"
                 class="size-5 shrink-0 object-contain"
               />

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -16,7 +16,7 @@ import { useDungeons } from '@/composables/useDungeons'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, ElementType, ExpeditionStatKey, GatheringSubFocus } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { toTitleCase, typeColor } from '@/utils/format'
+import { itemName, toTitleCase, typeColor } from '@/utils/format'
 import { statAbbreviations, statLabels } from '@/utils/formulas'
 import { sanctuaryIcon, helpersIcon, machinesIcon, expeditionsIcon, jobIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
@@ -554,9 +554,7 @@ const tierLevelReq = computed(() => {
           <div class="rounded-lg border border-border bg-muted/30 p-3">
             <p class="text-[11px] text-muted-foreground">
               Requires
-              <span class="font-semibold text-foreground">{{
-                toTitleCase(config.requiresItem)
-              }}</span>
+              <span class="font-semibold text-foreground">{{ itemName(config.requiresItem) }}</span>
               to enter (1 per creature). Duration:
               <span class="font-semibold text-foreground">{{ config.duration / 60 }} minutes</span>.
             </p>
@@ -608,12 +606,12 @@ const tierLevelReq = computed(() => {
                 <img
                   v-if="getItemImage({ id: config.requiresItem })"
                   :src="getItemImage({ id: config.requiresItem })"
-                  :alt="toTitleCase(config.requiresItem)"
+                  :alt="itemName(config.requiresItem)"
                   class="size-4 object-contain"
                   loading="lazy"
                 />
                 {{ partySlots.filter((s) => s !== null).length || 0 }}x
-                {{ toTitleCase(config.requiresItem) }}
+                {{ itemName(config.requiresItem) }}
               </p>
             </div>
           </div>
@@ -639,12 +637,12 @@ const tierLevelReq = computed(() => {
                 <img
                   v-if="getItemImage({ id: reward.itemId })"
                   :src="getItemImage({ id: reward.itemId })"
-                  :alt="toTitleCase(reward.itemId)"
+                  :alt="itemName(reward.itemId)"
                   class="size-4 object-contain"
                   loading="lazy"
                 />
                 {{ reward.amount }}x
-                {{ toTitleCase(reward.itemId) }}
+                {{ itemName(reward.itemId) }}
               </span>
             </div>
           </div>

--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -26,7 +26,7 @@ import { useExpeditions } from '@/composables/useExpeditions'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, ExpeditionStatWeights } from '@/types'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { formatDuration, toTitleCase } from '@/utils/format'
+import { formatDuration, itemName, toTitleCase } from '@/utils/format'
 import { getLoopXpBonus, getRecommendedCreatures } from '@/utils/formulas'
 import { expeditionTierIcons, toolIcons } from '@/utils/icons'
 import { getItemImage } from '@/utils/itemImages'
@@ -463,7 +463,7 @@ function rowSelected(id: string): boolean {
                     getItemImage({ id: expedition.rewards[0].itemId })
                   "
                   :src="getItemImage({ id: expedition.rewards[0].itemId })"
-                  :alt="expedition.rewards[0].itemId"
+                  :alt="itemName(expedition.rewards[0].itemId)"
                   loading="lazy"
                   class="size-5 shrink-0 object-contain"
                 />

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -34,7 +34,7 @@ import { expeditionSourceIndex, itemById, jobActivityIndex } from '@/data/indexe
 import type { Expedition, PlannerNode } from '@/types'
 import { applyByProductCreditsToSchedule, computeByProductCredits } from '@/utils/byProductCredits'
 import { getCreatureImage } from '@/utils/creatureImages'
-import { formatDuration, toTitleCase } from '@/utils/format'
+import { formatDuration, itemName, toTitleCase } from '@/utils/format'
 import {
   calculateDuration,
   calculatePartyScore,
@@ -928,7 +928,7 @@ function getNodeSource(
   }
   const flowerId = essenceFlowerMap[node.itemId]
   if (flowerId) {
-    const flowerName = itemById.get(flowerId)?.name ?? flowerId
+    const flowerName = itemName(flowerId)
     return { label: flowerName, icon: getItemImage({ id: flowerId }) ?? null }
   }
   return { label: '', icon: null }


### PR DESCRIPTION
## Description

Several views were rendering kebab-case item IDs (or naively title-casing them) instead of looking up the canonical `name` field from `items.json`. The visible bug: the Dungeons page showed "Dungeon Rune" because it ran `toTitleCase(reward.itemId)`, but the item's actual name is "Chronicle Rune". A handful of expedition reward `:alt` bindings were even worse — they piped the raw `dungeon-rune` straight into the alt attribute. This PR funnels every item / tool / machine display path through a single canonical helper, and adds a CI guardrail so the regression cannot reappear silently.

## Summary

- Added `toolName(id)` and `machineName(id)` to `src/utils/format.ts` mirroring the existing `itemName(id)`, plus matching `toolById` / `machineById` indexes in `src/data/indexes.ts`.
- Replaced `toTitleCase(*Id)` display calls with the canonical helpers in `DungeonsView.vue`, `ExpeditionDetail.vue`, `CreatureDetail.vue`, and the tool/machine/item rows in `ConfigsView.vue` (the rune now reads "Chronicle Rune").
- Wrapped raw `:alt="…itemId"` bindings with `itemName(...)` in `ExpeditionsView.vue`, `SummoningExpeditionPlan.vue`, `PartyExpeditionFilter.vue`, `LevelPlannerTimelineStep.vue`, and `ConfigsView.vue` so screen readers and broken-image tooltips show the real name.
- Consolidated 8 hand-rolled `itemById.get(id)?.name ?? toTitleCase(id)` lookups (one of which silently fell back to the raw kebab-case ID) in `ConfigsView.vue`, `SummoningPlannerView.vue`, `useCraftPlanner.ts`, and `useSummoningPlanner.ts` to call `itemName()` directly; dropped the resulting dead imports and locals.
- Added `src/utils/__tests__/nameConsistency.test.ts` — a guardrail test that scans every `.vue` / `.ts` file under `src/` and fails CI on `toTitleCase(*Id)`, `*Id.replace(/-/g, …)`, or raw `:alt | :title | :aria-label` bindings ending in `.itemId | toolId | machineId`.
- Added unit tests for `itemName` / `toolName` / `machineName`, including `itemName('dungeon-rune') === 'Chronicle Rune'` so the original regression has a direct test.