### PR TITLE
Fix summoning cost double-counting across material trees

### DIFF
--- a/src/components/summoning-planner/SummoningDebugPanel.vue
+++ b/src/components/summoning-planner/SummoningDebugPanel.vue
@@ -1,0 +1,363 @@
+<script setup lang="ts">
+import { Bug, X } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+
+import { useGameConfig } from '@/composables/useGameConfig'
+import { itemById } from '@/data/indexes'
+import type { PlannerNode } from '@/types'
+import { getItemImage } from '@/utils/itemImages'
+
+import type SummoningMaterialTree from './SummoningMaterialTree.vue'
+
+const props = defineProps<{
+  open: boolean
+  treeRefs: InstanceType<typeof SummoningMaterialTree>[]
+}>()
+
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+
+const gameConfig = useGameConfig()
+
+
+type Tab = 'inventory' | 'nodes'
+const activeTab = ref<Tab>('inventory')
+const filter = ref('')
+
+
+interface InventoryEntry {
+  itemId: string
+  itemName: string
+  owned: number
+  queued: number
+  total: number
+}
+
+
+const flatQueuedAmounts = computed(() => {
+  const flat: Record<string, number> = {}
+  for (const items of Object.values(gameConfig.queuedAmounts.value)) {
+    for (const [id, amount] of Object.entries(items)) {
+      if (amount > 0) flat[id] = (flat[id] ?? 0) + amount
+    }
+  }
+  return flat
+})
+
+
+const inventoryEntries = computed<InventoryEntry[]>(() => {
+  const seenIds = new Set<string>()
+  const entries: InventoryEntry[] = []
+
+  for (const id of Object.keys(gameConfig.inventoryAmounts.value)) {
+    seenIds.add(id)
+  }
+  for (const id of Object.keys(flatQueuedAmounts.value)) {
+    seenIds.add(id)
+  }
+
+  for (const id of seenIds) {
+    const owned = gameConfig.inventoryAmounts.value[id] ?? 0
+    const queued = flatQueuedAmounts.value[id] ?? 0
+    if (owned <= 0 && queued <= 0) continue
+    const item = itemById.get(id)
+    entries.push({
+      itemId: id,
+      itemName: item?.name ?? id,
+      owned,
+      queued,
+      total: owned + queued,
+    })
+  }
+
+  return entries.toSorted((a, b) => a.itemName.localeCompare(b.itemName))
+})
+
+
+const filteredInventory = computed(() => {
+  if (!filter.value) return inventoryEntries.value
+  const q = filter.value.toLowerCase()
+  return inventoryEntries.value.filter(
+    (e) => e.itemName.toLowerCase().includes(q) || e.itemId.toLowerCase().includes(q),
+  )
+})
+
+
+interface NodeEntry {
+  treeRoot: string
+  nodeId: string
+  itemId: string
+  itemName: string
+  depth: number
+  grossAmount: number
+  requiredAmount: number
+  fulfilled: boolean
+  methodCount: number
+  defaultMethodKind: string | null
+}
+
+
+function collectTreeNodes(treeRefs: InstanceType<typeof SummoningMaterialTree>[]): NodeEntry[] {
+  const entries: NodeEntry[] = []
+
+
+  for (const tree of treeRefs) {
+    if (!tree?.rootNode || !tree?.nodesById) continue
+    const treeRoot = tree.rootNode.itemName ?? tree.rootNode.itemId
+
+
+    function walkNode(node: PlannerNode) {
+      const activeMethodId = tree.activeMethodIdByNode[node.id]
+      const activeMethod = activeMethodId ? node.methods.find((m) => m.id === activeMethodId) : null
+
+
+      entries.push({
+        treeRoot,
+        nodeId: node.id,
+        itemId: node.itemId,
+        itemName: node.itemName,
+        depth: node.depth,
+        grossAmount: node.grossAmount,
+        requiredAmount: node.requiredAmount,
+        fulfilled: node.fulfilled,
+        methodCount: node.methods.length,
+        defaultMethodKind: activeMethod?.kind ?? null,
+      })
+
+
+      // Recurse into children of active method
+      if (!node.fulfilled && activeMethod) {
+        for (const child of activeMethod.children) {
+          const childNode = tree.nodesById[child.nodeId]
+          if (childNode) walkNode(childNode)
+        }
+      }
+    }
+
+
+    walkNode(tree.rootNode)
+  }
+
+
+  return entries
+}
+
+
+const filteredNodes = computed(() => {
+  const nodes = collectTreeNodes(props.treeRefs)
+  if (!filter.value) return nodes
+  const q = filter.value.toLowerCase()
+  return nodes.filter(
+    (n) => n.itemName.toLowerCase().includes(q) || n.itemId.toLowerCase().includes(q),
+  )
+})
+
+
+function fmt(n: number): string {
+  return n.toLocaleString()
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <!-- Drawer panel -->
+    <Transition name="slide">
+      <div
+        v-if="open"
+        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-[520px] flex-col border-l border-border bg-card shadow-2xl"
+      >
+        <!-- Header -->
+        <div class="flex items-center gap-2 border-b border-border px-4 py-3">
+          <Bug class="size-4 text-amber-500" />
+          <span
+            class="text-sm font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400"
+          >
+            Debug Panel
+          </span>
+          <button
+            class="ml-auto rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            @click="emit('close')"
+          >
+            <X class="size-4" />
+          </button>
+        </div>
+
+        <!-- Tabs -->
+        <div class="flex border-b border-border/40">
+          <button
+            class="flex-1 px-4 py-2 text-xs font-medium transition"
+            :class="
+              activeTab === 'inventory'
+                ? 'border-b-2 border-amber-500 text-amber-600 dark:text-amber-400'
+                : 'text-muted-foreground hover:text-foreground'
+            "
+            @click="activeTab = 'inventory'"
+          >
+            Inventory ({{ inventoryEntries.length }})
+          </button>
+          <button
+            class="flex-1 px-4 py-2 text-xs font-medium transition"
+            :class="
+              activeTab === 'nodes'
+                ? 'border-b-2 border-amber-500 text-amber-600 dark:text-amber-400'
+                : 'text-muted-foreground hover:text-foreground'
+            "
+            @click="activeTab = 'nodes'"
+          >
+            Tree Nodes
+          </button>
+        </div>
+
+        <!-- Filter -->
+        <div class="border-b border-border/40 px-4 py-3">
+          <input
+            v-model="filter"
+            type="text"
+            :placeholder="
+              activeTab === 'inventory' ? 'Filter items...' : 'Filter nodes by item name/id...'
+            "
+            class="w-full rounded-lg border border-border/40 bg-background/60 px-3 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/40 focus:border-amber-500/50 focus:outline-none focus:ring-1 focus:ring-amber-500/30"
+          />
+        </div>
+
+        <!-- Content: Inventory tab -->
+        <div v-if="activeTab === 'inventory'" class="flex-1 overflow-y-auto">
+          <p
+            v-if="filteredInventory.length === 0"
+            class="py-8 text-center text-xs text-muted-foreground/50"
+          >
+            {{ filter ? 'No items match filter.' : 'No inventory data.' }}
+          </p>
+
+          <table v-else class="w-full text-xs">
+            <thead class="sticky top-0 bg-card">
+              <tr
+                class="border-b border-border/40 text-left text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60"
+              >
+                <th class="px-4 py-2">Item</th>
+                <th class="px-3 py-2 text-right">Owned</th>
+                <th class="px-3 py-2 text-right">Queued</th>
+                <th class="px-3 py-2 text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-border/20">
+              <tr
+                v-for="entry in filteredInventory"
+                :key="entry.itemId"
+                class="transition hover:bg-foreground/[0.02]"
+              >
+                <td class="px-4 py-1.5">
+                  <div class="flex items-center gap-2">
+                    <img
+                      v-if="getItemImage({ id: entry.itemId })"
+                      :src="getItemImage({ id: entry.itemId })"
+                      :alt="entry.itemName"
+                      class="size-5 shrink-0 object-contain"
+                      loading="lazy"
+                    />
+                    <div class="min-w-0">
+                      <span class="block truncate font-medium text-foreground">
+                        {{ entry.itemName }}
+                      </span>
+                      <span class="block truncate text-[10px] text-muted-foreground/40">
+                        {{ entry.itemId }}
+                      </span>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-3 py-1.5 text-right font-mono">
+                  <span :class="entry.owned > 0 ? 'text-foreground' : 'text-muted-foreground/30'">
+                    {{ fmt(entry.owned) }}
+                  </span>
+                </td>
+                <td class="px-3 py-1.5 text-right font-mono">
+                  <span :class="entry.queued > 0 ? 'text-sky-500' : 'text-muted-foreground/30'">
+                    {{ fmt(entry.queued) }}
+                  </span>
+                </td>
+                <td class="px-3 py-1.5 text-right font-mono font-semibold text-foreground">
+                  {{ fmt(entry.total) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Content: Tree Nodes tab -->
+        <div v-else-if="activeTab === 'nodes'" class="flex-1 overflow-y-auto">
+          <template v-if="treeRefs.length > 0">
+            <div
+              v-for="entry in filteredNodes"
+              :key="entry.nodeId"
+              class="border-b border-border/20 px-4 py-2 transition hover:bg-foreground/[0.02]"
+              :class="entry.depth === 0 ? 'bg-muted/20' : ''"
+            >
+              <div class="flex items-center gap-2">
+                <span
+                  v-if="entry.depth > 0"
+                  class="text-[10px] text-muted-foreground/40"
+                  :style="{ paddingLeft: (entry.depth - 1) * 12 + 'px' }"
+                >
+                  └
+                </span>
+                <img
+                  v-if="getItemImage({ id: entry.itemId })"
+                  :src="getItemImage({ id: entry.itemId })"
+                  :alt="entry.itemName"
+                  class="size-4 shrink-0 object-contain"
+                  loading="lazy"
+                />
+                <span class="text-xs font-medium text-foreground">{{ entry.itemName }}</span>
+                <span
+                  v-if="entry.fulfilled"
+                  class="rounded bg-emerald-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-600 dark:text-emerald-400"
+                >
+                  FULFILLED
+                </span>
+                <span
+                  v-else-if="entry.methodCount === 0"
+                  class="rounded bg-red-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-red-600 dark:text-red-400"
+                >
+                  NO METHODS
+                </span>
+                <span
+                  v-if="entry.depth === 0"
+                  class="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary"
+                >
+                  ROOT
+                </span>
+              </div>
+              <div
+                class="mt-0.5 flex items-center gap-3 text-[10px] text-muted-foreground/60"
+                :style="{ paddingLeft: entry.depth > 0 ? (entry.depth - 1) * 12 + 16 + 'px' : '0' }"
+              >
+                <span>gross: {{ fmt(entry.grossAmount) }}</span>
+                <span>net: {{ fmt(entry.requiredAmount) }}</span>
+                <span v-if="entry.defaultMethodKind">via: {{ entry.defaultMethodKind }}</span>
+                <span>methods: {{ entry.methodCount }}</span>
+                <span class="text-muted-foreground/30">{{ entry.treeRoot }}</span>
+              </div>
+            </div>
+          </template>
+          <p v-else class="py-8 text-center text-xs text-muted-foreground/50">
+            No tree data available.
+          </p>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform 0.25s ease;
+}
+.slide-enter-from,
+.slide-leave-to {
+  transform: translateX(100%);
+}
+</style>

--- a/src/components/summoning-planner/SummoningMaterialTree.vue
+++ b/src/components/summoning-planner/SummoningMaterialTree.vue
@@ -17,11 +17,13 @@ const props = defineProps<{
   ownedCreatures: Creature[]
   creatureLevels: Record<string, number>
   expeditions: Expedition[]
+  inventoryBudget?: Record<string, number> | null
 }>()
 
 
 const targetItemId = toRef(() => props.itemId)
 const targetQuantity = toRef(() => props.quantity)
+const inventoryBudgetRef = toRef(() => props.inventoryBudget ?? null)
 
 
 const {
@@ -34,7 +36,10 @@ const {
   flatQueuedAmounts,
   getActiveMethod,
   setPinnedMethod,
-} = useCraftPlanner(targetItemId, targetQuantity, { deductRootInventory: true })
+} = useCraftPlanner(targetItemId, targetQuantity, {
+  deductRootInventory: true,
+  inventoryBudget: inventoryBudgetRef,
+})
 
 
 function collapseToLeaves() {

--- a/src/composables/useCraftPlanner.ts
+++ b/src/composables/useCraftPlanner.ts
@@ -959,6 +959,49 @@ export function buildPlannerGraph(
   }
 }
 
+/**
+ * Computes per-tree inventory budgets by simulating a shared stock pool across all targets.
+ * Each target is processed sequentially; after each, the consumed amounts are deducted from
+ * the shared pool so that cross-tree items are only counted once.
+ */
+export function computeInventoryBudgets(
+  targets: { itemId: string; quantity: number }[],
+  inventory: Record<string, number>,
+  modifiers: PlannerModifiers,
+): Record<string, Record<string, number>> {
+  const remainingStock = new Map<string, number>(Object.entries(inventory).filter(([, v]) => v > 0))
+  const budgets: Record<string, Record<string, number>> = {}
+
+  for (const target of targets) {
+    // Snapshot the current pool as this tree's budget
+    const currentInventory: Record<string, number> = {}
+    for (const [id, amount] of remainingStock.entries()) {
+      if (amount > 0) currentInventory[id] = amount
+    }
+    budgets[target.itemId] = currentInventory
+
+    // Build the graph to determine what this tree consumes
+    const graph = buildPlannerGraph(
+      target.itemId,
+      target.quantity,
+      currentInventory,
+      modifiers,
+      true,
+    )
+
+    // Deduct what this tree consumed from the shared pool
+    for (const node of Object.values(graph.nodesById)) {
+      const consumed = node.grossAmount - node.requiredAmount
+      if (consumed > 0) {
+        const current = remainingStock.get(node.itemId) ?? 0
+        remainingStock.set(node.itemId, Math.max(0, current - consumed))
+      }
+    }
+  }
+
+  return budgets
+}
+
 const resourceSortPriority = (r: string) =>
   r.startsWith('Machine:')
     ? 1.5
@@ -1177,6 +1220,10 @@ export function computeSchedule(
 interface CraftPlannerOptions {
   /** When true, inventory deduction applies to the root node too (used by summoning planner) */
   deductRootInventory?: boolean
+  /** When provided, overrides the internally-computed inventory (owned + queued) for graph building.
+   *  Used by summoning planner to pass a pre-partitioned inventory budget that accounts for
+   *  cross-tree demands against a shared stock pool. */
+  inventoryBudget?: Readonly<Ref<Record<string, number> | null>>
 }
 
 export function useCraftPlanner(
@@ -1220,7 +1267,7 @@ export function useCraftPlanner(
 
   const rawInventoryAmounts = computed(() => inventoryOverrides.value ?? baseInventory.value)
   const queuedAmounts = computed(() => baseQueuedAmounts.value)
-  const inventoryAmounts = computed(() => {
+  const mergedInventoryAmounts = computed(() => {
     const inv = rawInventoryAmounts.value
     const queued = queuedAmounts.value
     if (Object.keys(queued).length === 0) return inv
@@ -1232,6 +1279,9 @@ export function useCraftPlanner(
     }
     return merged
   })
+  const inventoryAmounts = computed(
+    () => options.inventoryBudget?.value ?? mergedInventoryAmounts.value,
+  )
   const gardenFlowers = computed(() => gardenOverrides.value ?? baseGarden.value)
   const awakenGatherUpgrades = computed(() => awakenGatherOverrides.value ?? baseAwakenGather.value)
   const awakenSpeedTiers = computed(() => awakenSpeedOverrides.value ?? baseAwakenSpeed.value)
@@ -1677,4 +1727,82 @@ export function useCraftPlanner(
     resetAllSettings,
     formatAmount,
   }
+}
+
+/**
+ * Lightweight composable that exposes the merged inventory (owned + queued) and planner modifiers
+ * without building a graph. Used by the summoning planner view to compute cross-tree inventory budgets.
+ */
+export function usePlannerModifiers() {
+  const {
+    inventoryAmounts: baseInventory,
+    queuedAmounts: baseQueuedAmounts,
+    gardenFlowers: baseGarden,
+    awakenGatherUpgrades: baseAwakenGather,
+    awakenSpeedTiers: baseAwakenSpeed,
+    jobTiers: baseJobTiers,
+    machineLevels: baseMachineLevels,
+    fabricationAllocations: baseFabricationAllocations,
+    awakenGoldLevel,
+    toolSpeedModes: baseToolSpeedModes,
+    toolLevels: baseToolLevels,
+  } = useGameConfig()
+
+  const { workstationTools, speedBonusPerLevel } = useTools()
+  const { ownedCreatureIds, isAwakened: isCreatureAwakened } = useCreatureCollection()
+
+  const fabricationSimulated = useLocalStorage<Record<string, number>>('fabrication-simulated', {})
+
+  const mergedInventory = computed(() => {
+    const inv = baseInventory.value
+    const queued = baseQueuedAmounts.value
+    if (Object.keys(queued).length === 0) return inv
+    const merged = { ...inv }
+    for (const stationItems of Object.values(queued)) {
+      for (const [id, amount] of Object.entries(stationItems)) {
+        if (amount > 0) merged[id] = (merged[id] ?? 0) + amount
+      }
+    }
+    return merged
+  })
+
+  const toolSpeedBonuses = computed(() => {
+    const bonuses: Record<string, number> = {}
+    for (const tool of workstationTools.value) {
+      if (baseToolSpeedModes.value[tool.skillId]) {
+        bonuses[tool.skillId] = ((baseToolLevels.value[tool.id] ?? 0) * speedBonusPerLevel) / 100
+      }
+    }
+    return bonuses
+  })
+
+  const awakenedCount = computed(() => {
+    let count = 0
+    for (const id of ownedCreatureIds.value) {
+      if (isCreatureAwakened(id)) count++
+    }
+    return count
+  })
+
+  const goldPerMinute = computed(() =>
+    computeGoldPerMinute(
+      awakenedCount.value,
+      awakenGoldLevel.value,
+      baseGarden.value['gold-flower'] ?? [],
+    ),
+  )
+
+  const modifiers = computed<PlannerModifiers>(() => ({
+    gardenFlowers: baseGarden.value,
+    awakenGatherUpgrades: baseAwakenGather.value,
+    awakenSpeedTiers: baseAwakenSpeed.value,
+    toolSpeedBonuses: toolSpeedBonuses.value,
+    jobTiers: baseJobTiers.value,
+    goldPerMinute: goldPerMinute.value,
+    machineLevels: baseMachineLevels.value,
+    fabricationAllocations: { ...baseFabricationAllocations.value, ...fabricationSimulated.value },
+    expeditionTier: 5,
+  }))
+
+  return { mergedInventory, modifiers }
 }

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -4,6 +4,7 @@ import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Bug,
   ChevronDown,
   ChevronsDownUp,
   ChevronsUpDown,
@@ -19,6 +20,7 @@ import PlannerEmptyState from '@/components/planner/PlannerEmptyState.vue'
 import PlannerTreeNode from '@/components/planner/PlannerTreeNode.vue'
 import RightClickHint from '@/components/shared/RightClickHint.vue'
 import SummoningCreatureFilter from '@/components/summoning-planner/SummoningCreatureFilter.vue'
+import SummoningDebugPanel from '@/components/summoning-planner/SummoningDebugPanel.vue'
 import SummoningMaterialTree from '@/components/summoning-planner/SummoningMaterialTree.vue'
 import SummoningObjectiveCard from '@/components/summoning-planner/SummoningObjectiveCard.vue'
 import SummoningTimeline from '@/components/summoning-planner/SummoningTimeline.vue'
@@ -115,6 +117,10 @@ const viewTabs = [
     description: "The optimal route — what to farm first and how long it'll take.",
   },
 ]
+
+
+// --- Debug drawer state ---
+const debugDrawerOpen = ref(false)
 
 
 // --- Group collapse state ---
@@ -1658,6 +1664,23 @@ const flatGroupedCosts = computed(() => {
         </div>
       </div>
     </div>
+
+    <!-- Debug drawer trigger -->
+    <button
+      v-if="aggregatedCosts.length > 0"
+      class="fixed bottom-4 right-4 z-40 flex items-center gap-1.5 rounded-full border border-amber-500/40 bg-card px-3 py-2 text-xs font-medium text-amber-600 shadow-lg transition hover:bg-amber-500/10 dark:text-amber-400"
+      @click="debugDrawerOpen = true"
+    >
+      <Bug class="size-4" />
+      Debug
+    </button>
+
+    <!-- Debug drawer -->
+    <SummoningDebugPanel
+      :open="debugDrawerOpen"
+      :tree-refs="treeRefs"
+      @close="debugDrawerOpen = false"
+    />
 
     <!-- Hidden trees for data (always rendered so summaries/schedules stay computed) -->
     <div v-if="aggregatedCosts.length > 0" class="hidden">

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -13,14 +13,13 @@ import {
   GanttChart,
   Network,
 } from 'lucide-vue-next'
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 
 import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import PlannerEmptyState from '@/components/planner/PlannerEmptyState.vue'
 import PlannerTreeNode from '@/components/planner/PlannerTreeNode.vue'
 import RightClickHint from '@/components/shared/RightClickHint.vue'
 import SummoningCreatureFilter from '@/components/summoning-planner/SummoningCreatureFilter.vue'
-import SummoningDebugPanel from '@/components/summoning-planner/SummoningDebugPanel.vue'
 import SummoningMaterialTree from '@/components/summoning-planner/SummoningMaterialTree.vue'
 import SummoningObjectiveCard from '@/components/summoning-planner/SummoningObjectiveCard.vue'
 import SummoningTimeline from '@/components/summoning-planner/SummoningTimeline.vue'
@@ -119,8 +118,12 @@ const viewTabs = [
 ]
 
 
-// --- Debug drawer state ---
+// --- Debug drawer state (dev only) ---
+const isDev = import.meta.env.DEV
 const debugDrawerOpen = ref(false)
+const SummoningDebugPanel = isDev
+  ? defineAsyncComponent(() => import('@/components/summoning-planner/SummoningDebugPanel.vue'))
+  : null
 
 
 // --- Group collapse state ---
@@ -1665,22 +1668,22 @@ const flatGroupedCosts = computed(() => {
       </div>
     </div>
 
-    <!-- Debug drawer trigger -->
-    <button
-      v-if="aggregatedCosts.length > 0"
-      class="fixed bottom-4 right-4 z-40 flex items-center gap-1.5 rounded-full border border-amber-500/40 bg-card px-3 py-2 text-xs font-medium text-amber-600 shadow-lg transition hover:bg-amber-500/10 dark:text-amber-400"
-      @click="debugDrawerOpen = true"
-    >
-      <Bug class="size-4" />
-      Debug
-    </button>
-
-    <!-- Debug drawer -->
-    <SummoningDebugPanel
-      :open="debugDrawerOpen"
-      :tree-refs="treeRefs"
-      @close="debugDrawerOpen = false"
-    />
+    <!-- Debug drawer trigger (dev only) -->
+    <template v-if="isDev">
+      <button
+        v-if="aggregatedCosts.length > 0"
+        class="fixed bottom-4 right-4 z-40 flex items-center gap-1.5 rounded-full border border-amber-500/40 bg-card px-3 py-2 text-xs font-medium text-amber-600 shadow-lg transition hover:bg-amber-500/10 dark:text-amber-400"
+        @click="debugDrawerOpen = true"
+      >
+        <Bug class="size-4" />
+        Debug
+      </button>
+      <SummoningDebugPanel
+        :open="debugDrawerOpen"
+        :tree-refs="treeRefs"
+        @close="debugDrawerOpen = false"
+      />
+    </template>
 
     <!-- Hidden trees for data (always rendered so summaries/schedules stay computed) -->
     <div v-if="aggregatedCosts.length > 0" class="hidden">

--- a/src/views/SummoningPlannerView.vue
+++ b/src/views/SummoningPlannerView.vue
@@ -22,6 +22,7 @@ import SummoningCreatureFilter from '@/components/summoning-planner/SummoningCre
 import SummoningMaterialTree from '@/components/summoning-planner/SummoningMaterialTree.vue'
 import SummoningObjectiveCard from '@/components/summoning-planner/SummoningObjectiveCard.vue'
 import SummoningTimeline from '@/components/summoning-planner/SummoningTimeline.vue'
+import { computeInventoryBudgets, usePlannerModifiers } from '@/composables/useCraftPlanner'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
@@ -180,6 +181,18 @@ const sortedCosts = computed(() => {
     return costs.toSorted((a, b) => b.amount - a.amount || a.itemName.localeCompare(b.itemName))
   }
   return costs // already alphabetical from composable
+})
+
+
+// --- Cross-tree inventory budgets (shared stock pool) ---
+const { mergedInventory, modifiers: plannerModifiers } = usePlannerModifiers()
+
+
+const inventoryBudgets = computed(() => {
+  const costs = sortedCosts.value
+  if (costs.length === 0) return {}
+  const targets = costs.map((c) => ({ itemId: c.itemId, quantity: c.amount }))
+  return computeInventoryBudgets(targets, mergedInventory.value, plannerModifiers.value)
 })
 
 
@@ -1661,6 +1674,7 @@ const flatGroupedCosts = computed(() => {
         :owned-creatures="ownedCreaturesList"
         :creature-levels="collectionLevels"
         :expeditions="expeditions"
+        :inventory-budget="inventoryBudgets[cost.itemId]"
         @activate="activeTreeIndex = index"
       />
     </div>


### PR DESCRIPTION
## Description

When the Summoning Cost Planner aggregates costs across multiple selected creatures, each per-creature material tree was deducting from the *full* inventory independently. A single shared stack of materials therefore appeared usable for every target at once, undercounting the true gathering cost. This PR partitions inventory into per-tree budgets sourced from a shared stock pool that is decremented after each tree is built, so cross-tree demands are accounted for exactly once. A small dev-only debug drawer is also added (and gated out of production bundles) for inspecting the new per-tree budgets.

## Summary

- Add `computeInventoryBudgets()` to `useCraftPlanner` that simulates a shared stock pool across summoning targets and returns each tree's pre-partitioned inventory budget.
- Add an `inventoryBudget` option to `CraftPlannerOptions` that overrides the internally-merged inventory when supplied; rename the original computed to `mergedInventoryAmounts` and have `inventoryAmounts` prefer the budget when provided.
- Add `usePlannerModifiers()` lightweight composable exposing merged inventory + planner modifiers without building a graph, used by the summoning view to compute the budgets.
- Wire `SummoningPlannerView` to compute `inventoryBudgets` from `sortedCosts` and pass each budget into the corresponding `SummoningMaterialTree`.
- Add `SummoningDebugPanel.vue` with tabs for inventory budgets and tree-node consumption; gated on `import.meta.env.DEV` via `defineAsyncComponent` so the chunk is excluded from production builds.