### PR TITLE
Re-enable GitHub Pages app for blocked Cloudflare visitors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,22 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: cp dist/index.html dist/404.html
+      - name: Reshape dist for /app/ + root redirect
+        run: |
+          set -euo pipefail
+          # The build is configured with base /k2-wiki/app/, so all asset URLs
+          # already point at /k2-wiki/app/...  Move the build output into an
+          # /app subfolder and place the migration page at the root.
+          mv dist dist-app
+          mkdir dist
+          mv dist-app dist/app
+          cp public/redirect.html dist/index.html
+          cp public/redirect.webp dist/redirect.webp
+          cp public/favicon.svg dist/favicon.svg
+          # GitHub Pages serves /k2-wiki/404.html on any miss under /k2-wiki/.
+          # Use the SPA index so deep links like /k2-wiki/app/items resolve
+          # client-side via Vue Router.
+          cp dist/app/index.html dist/404.html
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
-      - run: |
-          mkdir -p dist
-          cp public/redirect.html dist/index.html
-          cp public/redirect.webp dist/redirect.webp
-          cp public/favicon.svg dist/favicon.svg
-          cp dist/index.html dist/404.html
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: cp dist/index.html dist/404.html
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@playwright/test'
 
-const basePath = process.env.CF_PAGES === '1' ? '/' : '/k2-wiki/'
+const basePath = process.env.CF_PAGES === '1' ? '/' : '/k2-wiki/app/'
 
 export default defineConfig({
   testDir: './e2e',

--- a/public/redirect.html
+++ b/public/redirect.html
@@ -48,7 +48,7 @@
         color: hsl(220, 17%, 66%);
       }
       .banner {
-        margin: 0 0 1.5rem;
+        margin: 0 auto 1.5rem;
         padding: 0.85rem 1rem;
         border-radius: 0.75rem;
         background: hsl(38, 92%, 50%, 0.12);
@@ -57,6 +57,9 @@
         font-size: 0.9rem;
         line-height: 1.4;
         text-align: left;
+        width: 50%;
+        max-width: 100%;
+        box-sizing: border-box;
       }
       .countdown {
         margin-top: 0.5rem;
@@ -105,7 +108,7 @@
       <p class="countdown" id="countdown">Redirecting in 30 seconds</p>
       <div class="actions">
         <a class="btn btn-primary" href="https://k2-wiki.pages.dev">Go to new site</a>
-        <a class="btn btn-secondary" id="stay-link" href="https://ardelato.github.io/k2-wiki/">
+        <a class="btn btn-secondary" id="stay-link" href="https://ardelato.github.io/k2-wiki/app/">
           Continue using GitHub version
         </a>
       </div>
@@ -116,7 +119,7 @@
       if (stayLink) {
         stayLink.setAttribute(
           'href',
-          'https://ardelato.github.io/k2-wiki/' + location.search + location.hash,
+          'https://ardelato.github.io/k2-wiki/app/' + location.search + location.hash,
         )
         stayLink.addEventListener('click', function () {
           clearInterval(timer)

--- a/public/redirect.html
+++ b/public/redirect.html
@@ -114,34 +114,25 @@
       </div>
     </div>
     <script>
-      // Always point at the canonical GitHub Pages app, preserving query/hash for deep links.
-      var stayLink = document.getElementById('stay-link')
-      if (stayLink) {
-        stayLink.setAttribute(
-          'href',
-          'https://ardelato.github.io/k2-wiki/app/' + location.search + location.hash,
-        )
-        stayLink.addEventListener('click', function () {
-          clearInterval(timer)
-        })
-      }
       var seconds = 30
-      var el = document.getElementById('countdown')
+      var countdownEl = document.getElementById('countdown')
       var timer = setInterval(function () {
         seconds--
         if (seconds <= 0) {
           clearInterval(timer)
-          var path = location.pathname.replace('/k2-wiki', '').replace(/\/redirect\.html$/, '/')
-          if (!path || path.charAt(0) !== '/' || path.indexOf('//') === 0) {
-            path = '/'
-          }
-          window.location.replace(
-            'https://k2-wiki.pages.dev' + path + location.search + location.hash,
-          )
+          window.location.replace('https://k2-wiki.pages.dev/' + location.search + location.hash)
         } else {
-          el.textContent = 'Redirecting in ' + seconds + ' second' + (seconds !== 1 ? 's' : '')
+          countdownEl.textContent =
+            'Redirecting in ' + seconds + ' second' + (seconds !== 1 ? 's' : '')
         }
       }, 1000)
+
+      // Preserve query/hash when bouncing into the GitHub-hosted app, and stop the timer.
+      var stayLink = document.getElementById('stay-link')
+      stayLink.href = 'https://ardelato.github.io/k2-wiki/app/' + location.search + location.hash
+      stayLink.addEventListener('click', function () {
+        clearInterval(timer)
+      })
     </script>
   </body>
 </html>

--- a/public/redirect.html
+++ b/public/redirect.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
-    <meta http-equiv="refresh" content="10;url=https://k2-wiki.pages.dev" />
+    <meta http-equiv="refresh" content="30;url=https://k2-wiki.pages.dev" />
     <title>K2 Wiki Has Moved</title>
     <style>
       body {
@@ -47,9 +47,45 @@
       p {
         color: hsl(220, 17%, 66%);
       }
+      .banner {
+        margin: 0 0 1.5rem;
+        padding: 0.85rem 1rem;
+        border-radius: 0.75rem;
+        background: hsl(38, 92%, 50%, 0.12);
+        border: 1px solid hsl(38, 92%, 50%, 0.4);
+        color: hsl(38, 92%, 80%);
+        font-size: 0.9rem;
+        line-height: 1.4;
+        text-align: left;
+      }
       .countdown {
         margin-top: 0.5rem;
         font-variant-numeric: tabular-nums;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: center;
+        margin-top: 1.5rem;
+      }
+      .btn {
+        display: inline-block;
+        padding: 0.6rem 1.1rem;
+        border-radius: 0.6rem;
+        font-weight: 600;
+        text-decoration: none;
+        font-size: 0.95rem;
+        border: 1px solid transparent;
+      }
+      .btn-primary {
+        background: hsl(189, 82%, 56%);
+        color: hsl(225, 38%, 7%);
+      }
+      .btn-secondary {
+        background: transparent;
+        color: hsl(214, 32%, 92%);
+        border-color: hsl(214, 32%, 30%);
       }
     </style>
   </head>
@@ -57,20 +93,43 @@
     <div class="container">
       <img src="./redirect.webp" alt="K2 Wiki has moved to k2-wiki.pages.dev" />
       <h1>K2 Wiki has moved!</h1>
+      <p class="banner">
+        The wiki is now hosted at
+        <a href="https://k2-wiki.pages.dev">k2-wiki.pages.dev</a>, but
+        <strong>some countries' ISPs block <code>pages.dev</code></strong
+        >. If the new site doesn't load, you can keep using this GitHub-hosted version below.
+      </p>
       <p>
         Automatically redirecting to <a href="https://k2-wiki.pages.dev">k2-wiki.pages.dev</a>...
       </p>
-      <p class="countdown" id="countdown">Redirecting in 10 seconds</p>
+      <p class="countdown" id="countdown">Redirecting in 30 seconds</p>
+      <div class="actions">
+        <a class="btn btn-primary" href="https://k2-wiki.pages.dev">Go to new site</a>
+        <a class="btn btn-secondary" id="stay-link" href="https://ardelato.github.io/k2-wiki/">
+          Continue using GitHub version
+        </a>
+      </div>
     </div>
     <script>
-      var seconds = 10
+      // Always point at the canonical GitHub Pages app, preserving query/hash for deep links.
+      var stayLink = document.getElementById('stay-link')
+      if (stayLink) {
+        stayLink.setAttribute(
+          'href',
+          'https://ardelato.github.io/k2-wiki/' + location.search + location.hash,
+        )
+        stayLink.addEventListener('click', function () {
+          clearInterval(timer)
+        })
+      }
+      var seconds = 30
       var el = document.getElementById('countdown')
       var timer = setInterval(function () {
         seconds--
         if (seconds <= 0) {
           clearInterval(timer)
-          var path = location.pathname.replace('/k2-wiki', '') || '/'
-          if (path.charAt(0) !== '/' || path.indexOf('//') === 0) {
+          var path = location.pathname.replace('/k2-wiki', '').replace(/\/redirect\.html$/, '/')
+          if (!path || path.charAt(0) !== '/' || path.indexOf('//') === 0) {
             path = '/'
           }
           window.location.replace(

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useLocalStorage } from '@vueuse/core'
 import { Menu, X } from 'lucide-vue-next'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 
 import AppSidebar from '@/components/layout/AppSidebar.vue'
@@ -9,6 +9,13 @@ import AppSidebar from '@/components/layout/AppSidebar.vue'
 const route = useRoute()
 const mobileMenuOpen = ref(false)
 const sidebarCollapsed = useLocalStorage('sidebar-collapsed', true)
+
+
+const showMoveBanner = computed(() => {
+  if (typeof window === 'undefined') return false
+  if (import.meta.env.DEV) return true
+  return /\.github\.io$/i.test(window.location.hostname)
+})
 
 
 // Close mobile menu on route change
@@ -53,6 +60,23 @@ watch(
         </button>
         <span class="text-sm font-semibold text-foreground">Koltera 2 Wiki</span>
       </header>
+
+      <div
+        v-if="showMoveBanner"
+        class="border-b border-amber-500/40 bg-amber-500/10 px-4 py-2.5 text-center text-sm text-amber-900 dark:text-amber-200 sm:px-6"
+        role="status"
+      >
+        <span class="mx-auto block max-w-app">
+          This wiki has moved to
+          <a
+            href="https://k2-wiki.pages.dev"
+            class="font-semibold underline underline-offset-2 hover:no-underline"
+          >
+            k2-wiki.pages.dev </a
+          >. The new domain may be blocked by some countries' ISPs &mdash; you can keep using this
+          GitHub-hosted version if it's unreachable.
+        </span>
+      </div>
 
       <main class="mx-auto w-full max-w-app flex-1 px-4 py-6 sm:px-6 lg:py-8">
         <RouterView />

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,6 @@ const sidebarCollapsed = useLocalStorage('sidebar-collapsed', true)
 
 
 const showMoveBanner = computed(() => {
-  if (typeof window === 'undefined') return false
   if (import.meta.env.DEV) return true
   return /\.github\.io$/i.test(window.location.hostname)
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [vue()],
-  base: process.env.CF_PAGES === '1' ? '/' : '/k2-wiki/',
+  base: process.env.CF_PAGES === '1' ? '/' : '/k2-wiki/app/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Description

A user reported that the Cloudflare-hosted wiki at `k2-wiki.pages.dev` is unreachable in their region because their ISP blocks `pages.dev`, and the existing GitHub Pages deploy only serves a redirect that funnels visitors back to the same blocked host. This PR re-enables the actual wiki app on GitHub Pages so blocked visitors have a working fallback, while keeping a migration page at `/k2-wiki/` that pushes healthy visitors over to Cloudflare on a 30-second countdown.

## Summary

- Restore the full Vue app build in the GitHub Pages workflow; the static redirect page is no longer the deploy artifact, just one of several files copied alongside the SPA
- Reshape the `dist` tree so `/k2-wiki/` serves the migration page and `/k2-wiki/app/` serves the actual wiki SPA, with the SPA shell copied to `404.html` so deep links resolve client-side via Vue Router
- Update the Vite `base` to `/k2-wiki/app/` for non-Cloudflare builds (Cloudflare still uses `/`)
- Extend the migration page (`public/redirect.html`) with an ISP-block notice and a "Continue using GitHub version" button that targets `/k2-wiki/app/` and cancels the auto-redirect when clicked; bump the auto-redirect timer from 10s to 30s
- Add an amber move banner inside the app, shown on `*.github.io` and in dev, telling users the site moved but Cloudflare may be blocked
- Anti-slop cleanup: drop dead path-rewrite logic and paranoid existence/SSR guards introduced during iteration