### PR TITLE
feat(skill-planner): inventory-aware skill/job planner

### DIFF
--- a/src/components/configs/AssignmentZone.vue
+++ b/src/components/configs/AssignmentZone.vue
@@ -2,7 +2,7 @@
 import { useI18n } from 'vue-i18n'
 
 import RightClickHint from '@/components/shared/RightClickHint.vue'
-import { getCreatureImage } from '@/utils/creatureImages'
+import { getCreatureImage } from '@/utils/images/creatureImages'
 
 const { t } = useI18n()
 
@@ -35,11 +35,11 @@ defineEmits<{
 <template>
   <div class="bg-bg/30 space-y-2 rounded-xl border border-border/70 p-3">
     <div class="flex items-center justify-between gap-1.5">
-      <h3 class="flex items-center gap-1.5 text-[12px] font-extrabold">
+      <h3 class="flex items-center gap-1.5 text-xs font-extrabold">
         <img :src="icon" alt="" class="size-3.5" loading="lazy" />
         {{ label }}
       </h3>
-      <span class="font-mono text-[10px] text-muted-foreground">
+      <span class="font-mono text-3xs text-muted-foreground">
         <template v-if="showDiff && targetCount !== undefined">
           {{ currentCount }} &rarr; {{ targetCount }}
         </template>
@@ -69,13 +69,13 @@ defineEmits<{
               {{ slot.name.charAt(0) }}
             </div>
             <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-px">
-              <p class="truncate text-center text-[9px] font-bold leading-tight text-white">
+              <p class="truncate text-center text-3xs font-bold leading-tight text-white">
                 {{ slot.name }}
               </p>
             </div>
             <span
               v-if="slot.isNew"
-              class="absolute left-0.5 top-0.5 rounded bg-emerald-500/85 px-1 text-[8px] font-bold uppercase leading-none text-white shadow"
+              class="absolute left-0.5 top-0.5 rounded bg-success/85 px-1 text-3xs font-bold uppercase leading-none text-white shadow"
             >
               {{ t('configs.newBadge') }}
             </span>

--- a/src/components/configs/ExpeditionLadderSection.vue
+++ b/src/components/configs/ExpeditionLadderSection.vue
@@ -1,0 +1,345 @@
+<script setup lang="ts">
+import { Info } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+import AppTooltip from '@/components/shared/AppTooltip.vue'
+import type { Expedition } from '@/types'
+import { itemName } from '@/utils/format/format'
+import { expeditionTierIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
+import { TIER_UNLOCK_REQUIREMENTS } from '@/utils/planner/expeditionUnlocks'
+
+interface ExpeditionLadderRow {
+  id: string
+  name: string
+  rewardItemId: string | undefined
+  requiredExpeditionCompletions: number
+  tiers: { tier: number; cleared: boolean; unlocked: boolean; completions: number }[]
+  maxTier: number
+  nextTier: number
+  pct: number
+  have: number
+  need: number
+  remaining: number
+  runs: number
+  locked: boolean
+  maxed: boolean
+}
+
+
+interface NextExpFrontier {
+  name: string
+  rewardItemId: string | undefined
+  have: number
+  need: number
+  remaining: number
+  pct: number
+}
+
+
+interface TierUpFrontier {
+  name: string
+  rewardItemId: string | undefined
+  fromTier: number
+  toTier: number
+  have: number
+  need: number
+  remaining: number
+  pct: number
+}
+
+
+interface ExpeditionDisplay {
+  unlockedCount: number
+  totalTiersUnlocked: number
+}
+
+
+defineProps<{
+  allExpeditions: Expedition[]
+  expeditionDisplay: ExpeditionDisplay
+  expeditionFrontiers: { nextExp: NextExpFrontier | null; tierUps: TierUpFrontier[] }
+  expeditionLadderColumns: ExpeditionLadderRow[][]
+}>()
+
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="rounded-xl border border-border bg-card/50 p-4">
+    <div class="flex items-start justify-between gap-2">
+      <div>
+        <div class="flex items-center gap-1.5">
+          <h3 class="text-sm font-bold">{{ t('configs.zones.expeditions') }}</h3>
+          <AppTooltip :text="t('configs.expeditionsCard.tooltip')">
+            <Info class="size-3.5 text-muted-foreground/70 hover:text-foreground" />
+          </AppTooltip>
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <div class="flex flex-wrap gap-2 text-xs">
+          <span class="rounded-md bg-muted/50 px-2 py-1 font-medium">
+            {{
+              t('configs.expeditions.unlocked', {
+                count: expeditionDisplay.unlockedCount,
+                total: allExpeditions.length,
+              })
+            }}
+          </span>
+          <span class="rounded-md bg-muted/50 px-2 py-1 font-medium">
+            {{
+              t('configs.expeditions.tiers', {
+                count: expeditionDisplay.totalTiersUnlocked,
+                total: allExpeditions.length * 5,
+              })
+            }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-3 space-y-3">
+      <!-- Up Next frontier cards -->
+      <div
+        v-if="expeditionFrontiers.nextExp || expeditionFrontiers.tierUps.length"
+        class="space-y-2"
+      >
+        <div class="text-3xs font-bold uppercase tracking-[0.18em] text-muted-foreground/80">
+          {{ t('configs.expeditionsCard.upNext') }}
+        </div>
+        <div class="grid gap-2 md:grid-cols-3">
+          <div
+            v-if="expeditionFrontiers.nextExp"
+            class="overflow-hidden rounded-xl border border-accent/35 bg-card/60 p-3.5"
+          >
+            <div class="flex items-stretch gap-3">
+              <div
+                class="flex size-14 shrink-0 items-center justify-center rounded-lg bg-warning/10"
+              >
+                <img
+                  v-if="
+                    expeditionFrontiers.nextExp.rewardItemId &&
+                    getItemImage({ id: expeditionFrontiers.nextExp.rewardItemId })
+                  "
+                  :src="getItemImage({ id: expeditionFrontiers.nextExp.rewardItemId })"
+                  :alt="expeditionFrontiers.nextExp.rewardItemId"
+                  class="size-9 object-contain"
+                  loading="lazy"
+                />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="mb-2 flex items-center gap-2">
+                  <span class="min-w-0 truncate text-sm font-semibold text-foreground">
+                    {{ expeditionFrontiers.nextExp.name }}
+                  </span>
+                  <span
+                    class="ml-auto shrink-0 text-3xs font-bold uppercase tracking-[0.18em] text-warning-strong"
+                  >
+                    {{ t('configs.expeditionsCard.next') }}
+                  </span>
+                </div>
+                <div class="h-1.5 overflow-hidden rounded-full bg-border/30">
+                  <div
+                    class="h-full rounded-full bg-warning transition-all"
+                    :style="{ width: `${expeditionFrontiers.nextExp.pct}%` }"
+                  />
+                </div>
+                <div class="mt-1.5 flex items-baseline justify-between gap-2">
+                  <span class="font-mono text-xs font-semibold">
+                    <span class="text-3xs font-normal text-muted-foreground/50"
+                      >{{ t('configs.expeditionsCard.have') }}
+                    </span>
+                    <span class="text-foreground">{{ expeditionFrontiers.nextExp.have }}</span>
+                    <span class="text-muted-foreground/50">
+                      / {{ expeditionFrontiers.nextExp.need }}
+                    </span>
+                    <span class="text-3xs font-normal text-muted-foreground/50">
+                      {{ t('configs.expeditionsCard.total') }}
+                    </span>
+                  </span>
+                  <span class="font-mono text-xs font-semibold text-warning-strong">
+                    <span class="text-3xs font-normal text-warning-strong/70"
+                      >{{ t('configs.expeditionsCard.need') }}
+                    </span>
+                    {{ expeditionFrontiers.nextExp.remaining }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-for="f in expeditionFrontiers.tierUps"
+            :key="f.name"
+            class="overflow-hidden rounded-xl border border-border bg-card/60 p-3.5"
+          >
+            <div class="flex items-stretch gap-3">
+              <div
+                class="flex size-14 shrink-0 items-center justify-center rounded-lg bg-warning/10"
+              >
+                <img
+                  v-if="f.rewardItemId && getItemImage({ id: f.rewardItemId })"
+                  :src="getItemImage({ id: f.rewardItemId })"
+                  :alt="f.rewardItemId"
+                  class="size-9 object-contain"
+                  loading="lazy"
+                />
+              </div>
+              <div class="min-w-0 flex-1">
+                <div class="mb-2 flex items-center gap-2">
+                  <span class="min-w-0 truncate text-sm font-semibold text-foreground">
+                    {{ f.name }}
+                  </span>
+                  <span
+                    class="ml-auto flex shrink-0 items-center gap-1 font-mono text-3xs font-bold uppercase tracking-[0.18em] text-warning-strong"
+                  >
+                    <img
+                      :src="expeditionTierIcons[f.fromTier]"
+                      :alt="`Tier ${f.fromTier}`"
+                      class="size-3.5 object-contain"
+                      loading="lazy"
+                    />
+                    <span>→</span>
+                    <img
+                      :src="expeditionTierIcons[f.toTier]"
+                      :alt="`Tier ${f.toTier}`"
+                      class="size-3.5 object-contain"
+                      loading="lazy"
+                    />
+                  </span>
+                </div>
+                <div class="h-1.5 overflow-hidden rounded-full bg-border/30">
+                  <div
+                    class="h-full rounded-full bg-warning transition-all"
+                    :style="{ width: `${f.pct}%` }"
+                  />
+                </div>
+                <div class="mt-1.5 flex items-baseline justify-between gap-2">
+                  <span class="font-mono text-xs font-semibold">
+                    <span class="text-3xs font-normal text-muted-foreground/50"
+                      >{{ t('configs.expeditionsCard.have') }}
+                    </span>
+                    <span class="text-foreground">{{ f.have }}</span>
+                    <span class="text-muted-foreground/50"> / {{ f.need }} </span>
+                    <span class="text-3xs font-normal text-muted-foreground/50">
+                      {{ t('configs.expeditionsCard.loops') }}</span
+                    >
+                  </span>
+                  <span class="font-mono text-xs font-semibold text-warning-strong">
+                    <span class="text-3xs font-normal text-warning-strong/70"
+                      >{{ t('configs.expeditionsCard.need') }}
+                    </span>
+                    {{ f.remaining }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Compact 2-col ladder -->
+      <div class="mt-2 grid grid-cols-1 gap-x-6 gap-y-0.5 md:grid-cols-2">
+        <div v-for="(col, ci) in expeditionLadderColumns" :key="ci" class="space-y-0.5">
+          <div class="grid grid-cols-[1fr_auto_auto_auto] items-end gap-3 px-2 pb-0.5">
+            <span />
+            <div class="flex gap-0.5">
+              <span class="w-4 text-center font-mono text-3xs text-muted-foreground/60" />
+              <span
+                v-for="t in [2, 3, 4, 5]"
+                :key="t"
+                class="w-4 text-center font-mono text-3xs text-muted-foreground/60"
+              >
+                {{ TIER_UNLOCK_REQUIREMENTS[t] }}
+              </span>
+            </div>
+            <span class="w-[92px]" />
+            <span class="w-16" />
+          </div>
+          <div
+            v-for="row in col"
+            :key="row.id"
+            class="grid grid-cols-[1fr_auto_auto_auto] items-center gap-3 rounded-md px-2 py-1.5"
+            :class="row.locked ? 'opacity-40' : ''"
+          >
+            <div class="flex min-w-0 items-center gap-1.5">
+              <img
+                v-if="row.rewardItemId && getItemImage({ id: row.rewardItemId })"
+                :src="getItemImage({ id: row.rewardItemId })"
+                :alt="itemName(row.rewardItemId)"
+                class="size-4 shrink-0 object-contain"
+                loading="lazy"
+              />
+              <span
+                class="truncate text-xs font-semibold"
+                :class="row.locked ? 'italic text-muted-foreground' : ''"
+              >
+                {{ row.name }}
+                <span
+                  v-if="row.requiredExpeditionCompletions > 0"
+                  class="ml-0.5 font-mono text-3xs font-normal text-muted-foreground/70"
+                >
+                  ({{ row.requiredExpeditionCompletions }})
+                </span>
+              </span>
+            </div>
+            <div class="flex gap-0.5">
+              <img
+                v-for="t in row.tiers"
+                :key="t.tier"
+                :src="expeditionTierIcons[t.tier]"
+                :alt="`Tier ${t.tier}`"
+                class="size-4 object-contain"
+                :class="t.cleared ? '' : t.unlocked ? 'opacity-70' : 'opacity-30 grayscale'"
+                loading="lazy"
+              />
+            </div>
+            <span
+              class="flex w-[92px] items-center justify-end gap-1 font-mono text-3xs font-bold"
+              :class="
+                row.maxed
+                  ? 'text-pink-400'
+                  : row.locked
+                    ? 'text-muted-foreground/40'
+                    : 'text-muted-foreground'
+              "
+            >
+              <template v-if="row.locked">{{ t('configs.ladder.locked') }}</template>
+              <template v-else-if="row.maxed">
+                <img
+                  :src="expeditionTierIcons[5]"
+                  alt="Tier 5"
+                  class="size-3.5 object-contain"
+                  loading="lazy"
+                />
+                <span>{{ t('configs.ladder.maxed') }}</span>
+              </template>
+              <template v-else>
+                <img
+                  :src="expeditionTierIcons[row.maxTier]"
+                  :alt="`Tier ${row.maxTier}`"
+                  class="size-3.5 object-contain"
+                  loading="lazy"
+                />
+                <span>{{ row.have }}/{{ row.need }}</span>
+                <span>→</span>
+                <img
+                  :src="expeditionTierIcons[row.nextTier]"
+                  :alt="`Tier ${row.nextTier}`"
+                  class="size-3.5 object-contain"
+                  loading="lazy"
+                />
+              </template>
+            </span>
+            <span class="w-16 text-right font-mono text-3xs tabular-nums text-muted-foreground/70">
+              <template v-if="row.runs > 0">{{
+                t('configs.ladder.runs', { n: row.runs }, row.runs)
+              }}</template>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/configs/HeroStatsSection.vue
+++ b/src/components/configs/HeroStatsSection.vue
@@ -40,7 +40,7 @@ defineProps<{
 <template>
   <section class="grid gap-3 md:grid-cols-[1.4fr_1fr]">
     <!-- Creatures Collected -->
-    <div class="relative overflow-hidden rounded-2xl border border-border bg-card/50 p-5">
+    <div class="relative overflow-hidden rounded-xl border border-border bg-card/50 p-5">
       <div
         aria-hidden="true"
         class="pointer-events-none absolute -left-12 -top-12 size-48 rounded-full bg-accent/15 blur-3xl"
@@ -63,7 +63,7 @@ defineProps<{
             class="flex items-center gap-2"
           >
             <span
-              class="w-12 shrink-0 text-[10px] font-bold uppercase tracking-wider text-muted-foreground"
+              class="w-12 shrink-0 text-3xs font-bold uppercase tracking-wider text-muted-foreground"
             >
               {{ t('configs.creatures.tier', { n: tierBucket.tier + 1 }) }}
             </span>
@@ -81,7 +81,7 @@ defineProps<{
                 "
               />
             </div>
-            <span class="w-12 shrink-0 text-right font-mono text-[10px] font-bold tabular-nums">
+            <span class="w-12 shrink-0 text-right font-mono text-3xs font-bold tabular-nums">
               {{ tierBucket.owned }}/{{ tierBucket.total }}
             </span>
           </div>
@@ -90,7 +90,7 @@ defineProps<{
     </div>
 
     <!-- Player Level -->
-    <div class="relative overflow-hidden rounded-2xl border border-border bg-card/50 p-5">
+    <div class="relative overflow-hidden rounded-xl border border-border bg-card/50 p-5">
       <div
         aria-hidden="true"
         class="pointer-events-none absolute -right-12 -top-12 size-48 rounded-full bg-primary/15 blur-3xl"
@@ -101,7 +101,7 @@ defineProps<{
           <span class="font-mono text-6xl font-extrabold leading-none text-foreground">
             {{ displayPlayerLevel }}
           </span>
-          <span class="text-sm font-semibold text-emerald-400">
+          <span class="text-sm font-semibold text-success-strong">
             {{
               t('configs.skills.xpBonus', {
                 pct: getPlayerLevelXpBonus(displayPlayerLevel).toFixed(2),
@@ -123,19 +123,19 @@ defineProps<{
               class="size-4 shrink-0 object-contain"
               loading="lazy"
             />
-            <span class="w-16 shrink-0 truncate text-[10px] font-semibold text-muted-foreground">
+            <span class="w-16 shrink-0 truncate text-3xs font-semibold text-muted-foreground">
               {{ sk.id }}
             </span>
             <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-muted/40">
               <div
                 class="h-full"
-                :class="displaySkillLevel(sk.id) >= 99 ? 'bg-amber-400' : 'bg-accent'"
+                :class="displaySkillLevel(sk.id) >= 99 ? 'bg-warning' : 'bg-accent'"
                 :style="{ width: `${Math.min(100, (displaySkillLevel(sk.id) / 99) * 100)}%` }"
               />
             </div>
             <span
-              class="w-5 shrink-0 text-right font-mono text-[10px] font-bold tabular-nums"
-              :class="displaySkillLevel(sk.id) >= 99 ? 'text-amber-400' : ''"
+              class="w-5 shrink-0 text-right font-mono text-3xs font-bold tabular-nums"
+              :class="displaySkillLevel(sk.id) >= 99 ? 'text-warning-strong' : ''"
             >
               {{ displaySkillLevel(sk.id) }}
             </span>

--- a/src/components/configs/InventoryGridSection.vue
+++ b/src/components/configs/InventoryGridSection.vue
@@ -2,7 +2,8 @@
 import { useI18n } from 'vue-i18n'
 
 import AppTooltip from '@/components/shared/AppTooltip.vue'
-import { getItemImage } from '@/utils/itemImages'
+import { formatNumber, formatNumberCompact } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -19,18 +20,11 @@ interface InventoryGridEntry {
 defineProps<{
   items: InventoryGridEntry[]
 }>()
-
-
-function formatAmount(amount: number): string {
-  if (amount >= 1_000_000) return `${(amount / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`
-  if (amount >= 1_000) return `${(amount / 1_000).toFixed(1).replace(/\.0$/, '')}k`
-  return String(amount)
-}
 </script>
 
 <template>
   <section>
-    <div class="rounded-2xl border border-border bg-card/50 p-5">
+    <div class="rounded-xl border border-border bg-card/50 p-5">
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="flex items-start gap-2 text-left">
           <h3 class="text-sm font-extrabold">{{ t('configs.inventoryGrid.title') }}</h3>
@@ -56,7 +50,7 @@ function formatAmount(amount: number): string {
             <AppTooltip
               v-for="item in items"
               :key="item.id"
-              :text="item.owned ? `${item.name} · ${item.amount.toLocaleString()}` : item.name"
+              :text="item.owned ? `${item.name} · ${formatNumber(item.amount)}` : item.name"
             >
               <div
                 class="relative aspect-square shrink-0 overflow-hidden rounded-md border"
@@ -79,12 +73,12 @@ function formatAmount(amount: number): string {
                 </div>
                 <template v-if="item.owned">
                   <span
-                    class="absolute right-0 top-0 rounded-bl-md bg-black/85 px-1 py-px font-mono text-[9px] font-bold tabular-nums leading-none text-white shadow"
+                    class="absolute right-0 top-0 rounded-bl-md bg-black/85 px-1 py-px font-mono text-3xs font-bold tabular-nums leading-none text-white shadow"
                   >
-                    {{ formatAmount(item.amount) }}
+                    {{ formatNumberCompact(item.amount) }}
                   </span>
                   <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-px">
-                    <p class="truncate text-center text-[9px] font-bold leading-tight text-white">
+                    <p class="truncate text-center text-3xs font-bold leading-tight text-white">
                       {{ item.name }}
                     </p>
                   </div>

--- a/src/components/configs/WorkstationQueuesSection.vue
+++ b/src/components/configs/WorkstationQueuesSection.vue
@@ -2,9 +2,9 @@
 import { ChevronRight } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
 
-import { formatDuration } from '@/utils/format'
-import { sourceIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { formatDuration, formatNumber } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
 
 interface QueuedItem {
   id: string
@@ -31,7 +31,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div class="rounded-2xl border border-border bg-card/50 p-5">
+  <div class="rounded-xl border border-border bg-card/50 p-5">
     <div class="flex flex-wrap items-start justify-between gap-3">
       <div class="flex items-start gap-2 text-left">
         <div>
@@ -61,15 +61,15 @@ const { t } = useI18n()
                 class="size-3.5 shrink-0 object-contain"
                 loading="lazy"
               />
-              <span class="text-[13px] font-extrabold">{{ group.station }}</span>
+              <span class="text-xs font-extrabold">{{ group.station }}</span>
             </div>
-            <div class="flex items-center gap-1.5 font-mono text-[10px]">
+            <div class="flex items-center gap-1.5 font-mono text-3xs">
               <span
                 v-if="queuedTimes[group.station]"
-                class="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/15 px-2 py-1 font-semibold leading-none text-amber-700 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-300"
+                class="inline-flex items-center gap-1 rounded-md border border-warning/40 bg-warning/15 px-2 py-1 font-semibold leading-none text-warning-strong dark:border-warning/25 dark:bg-warning/10 dark:text-warning-strong"
               >
                 <span
-                  class="text-[9px] font-bold uppercase leading-none tracking-[0.18em] text-amber-700/80 dark:text-amber-300/70"
+                  class="text-3xs font-bold uppercase leading-none tracking-[0.18em] text-warning-strong/80"
                 >
                   {{ t('configs.queued.eta') }}
                 </span>
@@ -97,12 +97,12 @@ const { t } = useI18n()
                 loading="lazy"
               />
               <div class="min-w-0 flex-1">
-                <div class="flex items-center gap-1 text-[11px] font-extrabold">
-                  <span class="inline-block size-1.5 animate-pulse rounded-full bg-emerald-400" />
+                <div class="flex items-center gap-1 text-2xs font-extrabold">
+                  <span class="inline-block size-1.5 animate-pulse rounded-full bg-success" />
                   <span class="truncate">{{ group.items[0].name }}</span>
                 </div>
-                <div class="font-mono text-[9px] text-muted-foreground">
-                  ×{{ group.items[0].amount.toLocaleString() }}
+                <div class="font-mono text-3xs text-muted-foreground">
+                  ×{{ formatNumber(group.items[0].amount) }}
                 </div>
               </div>
             </div>
@@ -123,8 +123,8 @@ const { t } = useI18n()
                   class="size-5 shrink-0 object-contain"
                   loading="lazy"
                 />
-                <span class="flex-1 truncate text-[10px] font-bold">{{ item.name }}</span>
-                <span class="shrink-0 font-mono text-[9px] tabular-nums text-muted-foreground">
+                <span class="flex-1 truncate text-3xs font-bold">{{ item.name }}</span>
+                <span class="shrink-0 font-mono text-3xs tabular-nums text-muted-foreground">
                   ×{{ item.amount }}
                 </span>
               </div>

--- a/src/components/skill-planner/AdvisoryRow.vue
+++ b/src/components/skill-planner/AdvisoryRow.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { Circle } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { RouterLink, useRoute } from 'vue-router'
+
+import AdvisoryDisclosureRow from '@/components/shared/AdvisoryDisclosureRow.vue'
+import { advisoryPresentation } from '@/components/skill-planner/advisoryPresentation'
+import AwakenPointSources from '@/components/skill-planner/AwakenPointSources.vue'
+import SanctuaryPartyDiff from '@/components/skill-planner/SanctuaryPartyDiff.vue'
+import type { SkillAdvisory } from '@/composables/useSkillPlanner'
+import { formatDuration } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+
+/**
+ * The Skill planner's "Ways to improve" row. Maps a `SkillAdvisory` onto the shared
+ * `AdvisoryDisclosureRow`, supplying the type-specific expanded plan (sanctuary swap,
+ * awaken funding, or the per-skill player-level checklist) via the slot. The parent
+ * owns the single-open accordion state and passes `open`.
+ */
+const props = defineProps<{
+  advisory: SkillAdvisory
+  open: boolean
+  /** Gathering job this advisory raises. When set (Summon "Ways to improve", which mixes
+   * several skills), the headline names the job and shows its icon inline. */
+  job?: string
+}>()
+
+
+defineEmits<{
+  toggle: []
+  inspect: [id: string]
+}>()
+
+
+const { t } = useI18n()
+const route = useRoute()
+
+
+const view = computed(() => advisoryPresentation(props.advisory, props.job))
+const bonus = computed(() => (props.advisory.kind === 'bonus' ? props.advisory : null))
+const playerLevel = computed(() => (props.advisory.kind === 'playerLevel' ? props.advisory : null))
+
+
+// Stable id linking the disclosure button to its expanded region for a11y.
+const bodyId = computed(
+  () => `advisory-body-${props.advisory.kind === 'bonus' ? props.advisory.lever : 'playerLevel'}`,
+)
+</script>
+
+<template>
+  <AdvisoryDisclosureRow
+    :icon-src="view.iconSrc"
+    :glyph="view.glyph"
+    :headline="view.headline"
+    :job="job"
+    :cost="view.cost"
+    :benefit="view.benefit"
+    :time-saved-seconds="advisory.timeSaved"
+    :cta-label="view.ctaLabel"
+    :cta-link="view.ctaLink"
+    :accent="playerLevel ? 'violet' : undefined"
+    :open="open"
+    :body-id="bodyId"
+    @toggle="$emit('toggle')"
+  >
+    <!-- Sanctuary: the roster swap (remove/add/keep + tier ripple). -->
+    <template v-if="bonus && bonus.partyDiff">
+      <SanctuaryPartyDiff :diff="bonus.partyDiff" @inspect="$emit('inspect', $event)" />
+    </template>
+
+    <!-- Awaken: the player's balance, or the creatures they'd awaken to earn a point. -->
+    <template v-else-if="bonus && bonus.awakenSources">
+      <AwakenPointSources
+        :sources="bonus.awakenSources"
+        :available="bonus.awakenPointsAvailable ?? 0"
+        :cost="bonus.awakenPointCost ?? 1"
+        @inspect="$emit('inspect', $event)"
+      />
+    </template>
+
+    <!-- Player level: the per-skill checklist (each row links to that skill's planner). -->
+    <template v-if="playerLevel">
+      <p class="mb-1.5 text-xs font-medium text-muted-foreground">
+        {{ t('skillPlanner.advisory.allRequired', { count: playerLevel.steps.length }) }}
+      </p>
+      <ul class="divide-y divide-border/40 overflow-hidden rounded-lg border border-border/60">
+        <li
+          v-for="step in playerLevel.steps"
+          :key="step.skillId"
+          class="flex items-center gap-2.5 px-3 py-2 text-xs"
+        >
+          <Circle class="size-3.5 shrink-0 text-muted-foreground/40" />
+          <img
+            v-if="sourceIcons[step.skillId]"
+            :src="sourceIcons[step.skillId]"
+            alt=""
+            class="size-4 shrink-0"
+            loading="lazy"
+          />
+          <RouterLink
+            :to="{
+              path: route.path,
+              query: { tab: 'skills', skill: step.skillId.toLowerCase() },
+            }"
+            class="focus-ring font-medium text-foreground transition hover:text-primary"
+          >
+            {{ step.skillId }}
+          </RouterLink>
+          <span class="tabular-nums text-muted-foreground"
+            >{{ step.fromLevel }}→{{ step.toLevel }}</span
+          >
+          <span class="ml-auto font-medium tabular-nums text-foreground">
+            ~{{ formatDuration(step.timeSeconds) }}
+          </span>
+        </li>
+      </ul>
+    </template>
+  </AdvisoryDisclosureRow>
+</template>

--- a/src/components/skill-planner/AwakenPointSources.vue
+++ b/src/components/skill-planner/AwakenPointSources.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import AwakenSummonChip from '@/components/skill-planner/AwakenSummonChip.vue'
+import CreatureDiffTile from '@/components/skill-planner/CreatureDiffTile.vue'
+import type { AwakenPointSources } from '@/composables/useSkillPlanner'
+
+/**
+ * Mini awaken-planner shown under an awaken node's "Requires 1 Awaken Point" line.
+ * If you already hold enough unspent points, it just nudges you to allocate one;
+ * otherwise it surfaces the cheapest way to *earn* a point as a prioritized cascade:
+ *   1. a creature you already own but haven't awakened,
+ *   2. otherwise the closest creature to summon then awaken.
+ */
+defineProps<{
+  sources: AwakenPointSources
+  /** Unspent Awaken Points the player is holding. */
+  available: number
+  /** Points this node costs. */
+  cost: number
+}>()
+
+
+defineEmits<{
+  inspect: [id: string]
+}>()
+
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <!-- Already banked enough points: no need to earn one, just allocate it. -->
+  <p v-if="available >= cost" class="mt-2 text-xs text-muted-foreground">
+    <i18n-t keypath="skillPlanner.awakenSources.banked" tag="span" scope="global">
+      <template #count>
+        <span class="font-medium text-success-strong">{{ available }}</span>
+      </template>
+      <template #points>{{ available > 1 ? 'Awaken Points' : 'Awaken Point' }}</template>
+    </i18n-t>
+  </p>
+
+  <div v-else-if="sources.owned.length || sources.summon.length" class="mt-2 space-y-1.5">
+    <!-- Tier 1: awaken one you already own -->
+    <template v-if="sources.owned.length">
+      <p class="text-xs text-muted-foreground">
+        {{ t('skillPlanner.awakenSources.awakenOwned', { point: 'Awaken Point' }) }}
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <!-- Same square tile the Sanctuary roster diff uses, with a ready/level badge
+             below (matches PartyCreatureTile). Inspect the tile to open the drawer. -->
+        <div
+          v-for="c in sources.owned"
+          :key="c.id"
+          class="flex flex-col items-center gap-1"
+          :title="
+            c.ready
+              ? t('skillPlanner.awakenSources.readyTitle')
+              : t('skillPlanner.awakenSources.levelFirstTitle')
+          "
+        >
+          <CreatureDiffTile
+            :id="c.id"
+            :name="c.name"
+            :contribution="c.contribution"
+            variant="neutral"
+            @inspect="$emit('inspect', $event)"
+          />
+          <span
+            class="rounded-full px-1.5 py-0.5 text-3xs font-semibold tabular-nums"
+            :class="
+              c.ready ? 'bg-success/10 text-success-strong' : 'bg-warning/10 text-warning-strong'
+            "
+          >
+            {{ c.ready ? 'LVL 70 ✓' : `LVL ${c.level}/70` }}
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <!-- Tier 2: summon then awaken (only when nothing owned to awaken) -->
+    <template v-else-if="sources.summon.length">
+      <p class="text-xs text-muted-foreground">
+        {{ t('skillPlanner.awakenSources.summonThenAwaken', { point: 'Awaken Point' }) }}
+      </p>
+      <div class="flex flex-wrap gap-1.5">
+        <AwakenSummonChip
+          v-for="c in sources.summon"
+          :key="c.id"
+          :candidate="c"
+          @inspect="$emit('inspect', $event)"
+        />
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/components/skill-planner/AwakenSummonChip.vue
+++ b/src/components/skill-planner/AwakenSummonChip.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import Badge from '@/components/shared/Badge.vue'
+import FloatingPanel from '@/components/shared/FloatingPanel.vue'
+import { usePopover } from '@/composables/core/usePopover'
+import type { AwakenSummonCandidate } from '@/composables/useSkillPlanner'
+import { formatNumber } from '@/utils/format/format'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+import { getItemImage } from '@/utils/images/itemImages'
+
+/**
+ * A "summon then awaken" suggestion chip with a hover popover that breaks down the
+ * materials you're still short on (and the skill gate, if any) — mirroring the
+ * summoning cost card. Inspect opens the creature drawer.
+ */
+defineProps<{
+  candidate: AwakenSummonCandidate
+}>()
+
+
+defineEmits<{
+  inspect: [id: string]
+}>()
+
+
+const { t } = useI18n()
+
+
+const pop = usePopover({ width: 240, gap: 8, hAlign: 'left' })
+
+
+function onEnter(event: MouseEvent) {
+  const target = event.currentTarget as HTMLElement | null
+  if (!target) return
+  pop.open(target)
+}
+
+
+function onLeave() {
+  pop.close()
+}
+
+
+const fmt = (n: number) => formatNumber(n)
+</script>
+
+<template>
+  <Badge
+    :variant="candidate.affordable ? 'success' : candidate.reachable ? 'warning' : 'danger'"
+    :pill="false"
+    size="xs"
+    class="cursor-default"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+    @contextmenu.prevent="$emit('inspect', candidate.id)"
+  >
+    <div class="size-5 shrink-0 overflow-hidden rounded-md bg-card">
+      <img
+        v-if="getCreatureImage({ id: candidate.id, image: '' })"
+        :src="getCreatureImage({ id: candidate.id, image: '' })"
+        :alt="candidate.name"
+        class="size-full object-cover"
+        loading="lazy"
+      />
+    </div>
+    <span class="font-semibold text-foreground">{{ candidate.name }}</span>
+    <span class="font-medium tabular-nums">
+      {{
+        candidate.affordable
+          ? t('skillPlanner.summonChip.canSummon')
+          : candidate.reachable
+            ? t('skillPlanner.summonChip.matsShort', { count: candidate.missingTypes })
+            : t('skillPlanner.summonChip.needsSkill', {
+                skill: candidate.blockSkill,
+                level: candidate.blockLevel,
+              })
+      }}
+    </span>
+  </Badge>
+
+  <FloatingPanel
+    :is-open="pop.isOpen"
+    :el-ref="pop.setPanelEl"
+    :style="pop.style"
+    class="pointer-events-none z-50 w-60 overflow-hidden rounded-xl border border-border/70 bg-card shadow-xl shadow-black/30"
+  >
+    <!-- Header: creature name + tier -->
+    <div class="flex items-center gap-2.5 px-3.5 pb-2 pt-3">
+      <div class="size-7 shrink-0 overflow-hidden rounded-lg bg-muted/40">
+        <img
+          v-if="getCreatureImage({ id: candidate.id, image: '' })"
+          :src="getCreatureImage({ id: candidate.id, image: '' })"
+          :alt="candidate.name"
+          class="size-full object-cover"
+          loading="lazy"
+        />
+      </div>
+      <div class="min-w-0">
+        <span class="block text-sm font-bold leading-tight text-foreground">
+          {{ candidate.name }}
+        </span>
+        <span class="block text-2xs leading-tight text-muted-foreground">
+          {{ t('skillPlanner.summonChip.tierSummonThenAwaken', { tier: candidate.tier + 1 }) }}
+        </span>
+      </div>
+    </div>
+
+    <div class="mx-3.5 border-t border-border/40" />
+
+    <!-- Missing materials -->
+    <div v-if="candidate.missing.length" class="flex flex-col gap-1 px-3.5 pb-2.5 pt-2">
+      <p class="mb-0.5 text-2xs font-medium text-muted-foreground">
+        {{ t('skillPlanner.summonChip.stillNeed') }}
+      </p>
+      <div v-for="m in candidate.missing" :key="m.id" class="flex items-center gap-1.5">
+        <img
+          v-if="getItemImage({ id: m.id })"
+          :src="getItemImage({ id: m.id })"
+          :alt="m.name"
+          class="size-4 shrink-0 object-contain"
+          loading="lazy"
+        />
+        <span class="min-w-0 flex-1 truncate text-xs text-foreground/90">{{ m.name }}</span>
+        <span class="shrink-0 text-xs font-semibold tabular-nums text-warning-strong">
+          {{ fmt(m.short) }}
+        </span>
+      </div>
+    </div>
+    <div v-else class="px-3.5 pb-2.5 pt-2">
+      <p class="text-xs font-medium text-success-strong">
+        {{ t('skillPlanner.summonChip.allInInventory') }}
+      </p>
+    </div>
+
+    <!-- Skill gate, when blocked -->
+    <div
+      v-if="!candidate.reachable"
+      class="mx-3.5 mb-2.5 rounded-md bg-danger/10 px-2 py-1 text-2xs font-medium text-danger-strong"
+    >
+      {{
+        t('skillPlanner.summonChip.blockedNeeds', {
+          skill: candidate.blockSkill,
+          level: candidate.blockLevel,
+        })
+      }}
+    </div>
+
+    <div class="border-t border-border/40 px-3.5 py-1.5">
+      <span class="text-3xs text-muted-foreground">{{ t('skillPlanner.summonChip.inspect') }}</span>
+    </div>
+  </FloatingPanel>
+</template>

--- a/src/components/skill-planner/CreatureDiffTile.vue
+++ b/src/components/skill-planner/CreatureDiffTile.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import AppTooltip from '@/components/shared/AppTooltip.vue'
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import { useCreatureStatus } from '@/composables/useCreatureStatus'
+import {
+  sanctuaryIcon,
+  helpersIcon,
+  machinesIcon,
+  expeditionsIcon,
+  dungeonsIcon,
+} from '@/utils/format/icons'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+
+/**
+ * A creature tile for the sanctuary roster diff (remove / add / keep) — the square
+ * image-with-name-overlay tile used elsewhere in the planner (cf. PartyCreatureTile),
+ * tinted by variant. An *incoming* (Add) creature that's busy/excluded gets an amber
+ * ring + its "currently doing" assignment icon (same icon + tooltip as the Sanctuary
+ * page / creature drawer). Remove/Keep are already in the sanctuary, so never flagged.
+ * Inspect to open the creature drawer. Job levels are intentionally not shown.
+ */
+const props = defineProps<{
+  id: string
+  name: string
+  /** Passed by the diff but intentionally not rendered — the tile shows no job levels. */
+  contribution: number
+  variant: 'remove' | 'add' | 'keep' | 'neutral'
+}>()
+
+
+defineEmits<{
+  inspect: [id: string]
+}>()
+
+
+const VARIANT = {
+  remove: 'border-rose-500/40',
+  add: 'border-success/40',
+  keep: 'border-border',
+  neutral: 'border-border',
+} as const
+
+
+const ROLE_BADGE = {
+  sanctuary: { icon: sanctuaryIcon, label: 'Sanctuary' },
+  helper: { icon: helpersIcon, label: 'Helper' },
+  machine: { icon: machinesIcon, label: 'Machine' },
+  expedition: { icon: expeditionsIcon, label: 'Expedition' },
+  dungeon: { icon: dungeonsIcon, label: 'Dungeon' },
+} as const
+
+
+const { t } = useI18n()
+const { statusOf } = useCreatureStatus()
+
+
+const status = computed(() => statusOf(props.id))
+
+
+/** Only incoming (Add) creatures are flagged — Remove/Keep are already slotted. */
+const flagged = computed(
+  () => props.variant === 'add' && (status.value.role !== null || status.value.excluded),
+)
+
+
+/** The "currently doing" assignment badge (icon + label), when the creature is busy. */
+const assignment = computed(() =>
+  props.variant === 'add' && status.value.role ? ROLE_BADGE[status.value.role] : null,
+)
+</script>
+
+<template>
+  <RightClickHint @contextmenu="$emit('inspect', id)">
+    <!-- Wrapper isn't clipped, so the assignment badge can sit on the bottom-right
+         corner exactly like the Sanctuary page and the creature drawer. -->
+    <div class="relative inline-flex">
+      <div
+        class="relative size-14 shrink-0 cursor-default overflow-hidden rounded-lg border bg-card/50"
+        :class="[VARIANT[variant], flagged ? 'ring-1 ring-warning/70' : '']"
+        :title="name"
+      >
+        <img
+          v-if="getCreatureImage({ id, image: '' })"
+          :src="getCreatureImage({ id, image: '' })"
+          :alt="name"
+          class="size-full object-cover"
+          loading="lazy"
+        />
+        <div class="absolute inset-x-0 bottom-0 bg-black/70 px-1 py-0.5">
+          <p class="truncate text-center text-3xs font-semibold text-white">{{ name }}</p>
+        </div>
+      </div>
+      <span v-if="assignment" class="absolute -left-1 -top-1 z-10">
+        <AppTooltip
+          :text="t('beastiary.detail.assignedTo', { label: assignment.label })"
+          position="top"
+        >
+          <img
+            :src="assignment.icon"
+            :alt="assignment.label"
+            class="size-5 rounded-full border border-background bg-background"
+            loading="lazy"
+          />
+        </AppTooltip>
+      </span>
+    </div>
+  </RightClickHint>
+</template>

--- a/src/components/skill-planner/SanctuaryPartyDiff.vue
+++ b/src/components/skill-planner/SanctuaryPartyDiff.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import AppTooltip from '@/components/shared/AppTooltip.vue'
+import CreatureDiffTile from '@/components/skill-planner/CreatureDiffTile.vue'
+import { jobIcons } from '@/utils/format/icons'
+import { getJobBenefits } from '@/utils/planner/sanctuaryConstants'
+import type { SanctuaryRosterDiff } from '@/utils/planner/skillAdvisories'
+
+/**
+ * The actionable side of a "raise this job's sanctuary tier" advisory: the exact
+ * roster change to apply as full-width tile grids (remove ▸ add ▸ keep), plus the
+ * collateral tier moves it causes on the other jobs (the sanctuary's 8 slots are
+ * shared, so optimizing one job rebalances the rest). Inspect tiles to open the drawer.
+ */
+const props = defineProps<{
+  diff: SanctuaryRosterDiff
+}>()
+
+
+defineEmits<{
+  inspect: [id: string]
+}>()
+
+
+const { t } = useI18n()
+
+
+/** One sanctuary benefit shifting across a tier move, formatted before → after.
+ * `improved` keys the arrow colour (a side-effect job can drop a tier). */
+interface BenefitDelta {
+  label: string
+  before: string
+  after: string
+  improved: boolean
+}
+
+
+const fmtXp = (v: number) => `+${v}%`
+const fmtDuration = (v: number) => (v > 0 ? `−${v}%` : '0%')
+const fmtYield = (v: number) => `+${v}`
+
+
+/** The sanctuary benefits that actually change between two tiers (benefits are
+ * cumulative, so a from≠to move always shifts at least one). */
+function benefitDeltas(from: number, to: number): BenefitDelta[] {
+  const b = getJobBenefits(from)
+  const a = getJobBenefits(to)
+  const improved = to > from
+  const rows: BenefitDelta[] = []
+  if (a.xpBonus !== b.xpBonus)
+    rows.push({ label: 'XP', before: fmtXp(b.xpBonus), after: fmtXp(a.xpBonus), improved })
+  if (a.durationReduction !== b.durationReduction)
+    rows.push({
+      label: t('skillPlanner.sanctuary.benefitGatherSpeed'),
+      before: fmtDuration(b.durationReduction),
+      after: fmtDuration(a.durationReduction),
+      improved,
+    })
+  if (a.yieldBonus !== b.yieldBonus)
+    rows.push({
+      label: t('skillPlanner.sanctuary.benefitYield'),
+      before: fmtYield(b.yieldBonus),
+      after: fmtYield(a.yieldBonus),
+      improved,
+    })
+  return rows
+}
+
+
+/** Every resulting tier move at a glance: the optimized job first (the goal, kept
+ * even though it's echoed in the title — it anchors the other jobs), then each
+ * other job the shared roster shifts. Each carries its benefit deltas for the
+ * hover popover. */
+const tierChanges = computed(() =>
+  [
+    { ...props.diff.target, primary: true },
+    ...props.diff.sideEffects.map((d) => ({ ...d, primary: false })),
+  ].map((d) => ({ ...d, benefits: benefitDeltas(d.from, d.to) })),
+)
+</script>
+
+<template>
+  <div class="mt-2.5 space-y-3">
+    <p class="text-xs text-muted-foreground">{{ t('skillPlanner.sanctuary.swapRoster') }}</p>
+
+    <!-- Remove ▸ Add, side by side and filling the full width on wider screens -->
+    <div class="grid gap-2.5 sm:grid-cols-2">
+      <div class="rounded-xl border border-rose-500/25 bg-rose-500/[0.04] p-2.5">
+        <p
+          class="mb-2 text-2xs font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400"
+        >
+          {{ t('skillPlanner.sanctuary.remove') }}
+          <span class="text-muted-foreground">({{ diff.swapOut.length }})</span>
+        </p>
+        <div v-if="diff.swapOut.length" class="flex flex-wrap gap-2">
+          <CreatureDiffTile
+            v-for="c in diff.swapOut"
+            :key="c.id"
+            :id="c.id"
+            :name="c.name"
+            :contribution="c.contribution"
+            variant="remove"
+            @inspect="$emit('inspect', $event)"
+          />
+        </div>
+        <p v-else class="text-2xs italic text-muted-foreground/80">
+          {{ t('skillPlanner.sanctuary.nothingToRemove') }}
+        </p>
+      </div>
+
+      <div class="rounded-xl border border-success/25 bg-success/[0.04] p-2.5">
+        <p class="mb-2 text-2xs font-semibold uppercase tracking-wide text-success-strong">
+          {{ t('skillPlanner.sanctuary.add') }}
+          <span class="text-muted-foreground">({{ diff.swapIn.length }})</span>
+        </p>
+        <div v-if="diff.swapIn.length" class="flex flex-wrap gap-2">
+          <CreatureDiffTile
+            v-for="c in diff.swapIn"
+            :key="c.id"
+            :id="c.id"
+            :name="c.name"
+            :contribution="c.contribution"
+            variant="add"
+            @inspect="$emit('inspect', $event)"
+          />
+        </div>
+        <p v-else class="text-2xs italic text-muted-foreground/80">
+          {{ t('skillPlanner.sanctuary.alreadySlotted') }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Members that stay put -->
+    <div v-if="diff.keep.length">
+      <p class="mb-2 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {{ t('skillPlanner.sanctuary.keepInPlace') }}
+        <span>({{ diff.keep.length }})</span>
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <CreatureDiffTile
+          v-for="c in diff.keep"
+          :key="c.id"
+          :id="c.id"
+          :name="c.name"
+          :contribution="c.contribution"
+          variant="keep"
+          @inspect="$emit('inspect', $event)"
+        />
+      </div>
+    </div>
+
+    <!-- Resulting tier moves at a glance: the target job (emphasized) plus the
+         shared-party ripple on every other job the same 8 slots feed. -->
+    <div class="rounded-xl border border-border/60 bg-muted/20 px-3 py-2.5">
+      <p class="mb-2 text-2xs font-medium text-muted-foreground">
+        {{ t('skillPlanner.sanctuary.resultingTierChanges') }}
+        <span class="text-muted-foreground/70">{{
+          t('skillPlanner.sanctuary.slotsSharedNote')
+        }}</span>
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <!-- Plain tier-move chip: which job moves from which tier to which.
+             Direction arrow keys rose (down) / emerald (up). Hover reveals the
+             sanctuary benefits that shift across the move (like the craft-card chips). -->
+        <AppTooltip v-for="d in tierChanges" :key="d.job" position="top">
+          <span
+            class="inline-flex cursor-default items-center gap-1.5 rounded-full border py-0.5 pl-1 pr-2"
+            :class="d.primary ? 'border-primary/50 bg-primary/10' : 'border-border/60 bg-card/70'"
+          >
+            <img
+              v-if="jobIcons[d.job.toLowerCase()]"
+              :src="jobIcons[d.job.toLowerCase()]"
+              :alt="d.job"
+              class="size-4 shrink-0"
+              loading="lazy"
+            />
+            <span class="text-2xs text-foreground" :class="d.primary ? 'font-bold' : 'font-medium'">
+              {{ d.job }}
+            </span>
+            <span class="text-2xs tabular-nums text-muted-foreground">{{ d.from }}</span>
+            <span
+              class="text-3xs"
+              :class="d.to < d.from ? 'text-rose-500 dark:text-rose-400' : 'text-success-strong'"
+            >
+              {{ d.to < d.from ? '▼' : '▲' }}
+            </span>
+            <span class="text-2xs font-semibold tabular-nums text-foreground">{{ d.to }}</span>
+          </span>
+
+          <!-- Benefit-shift popover: header (job + tier move) then one before→after
+               row per sanctuary benefit that changes. -->
+          <template #content>
+            <div class="flex min-w-40 flex-col gap-2">
+              <div class="flex items-center gap-2">
+                <img
+                  v-if="jobIcons[d.job.toLowerCase()]"
+                  :src="jobIcons[d.job.toLowerCase()]"
+                  :alt="d.job"
+                  class="size-4 shrink-0"
+                  loading="lazy"
+                />
+                <span class="font-semibold text-foreground">{{ d.job }}</span>
+                <span class="ml-auto text-2xs font-medium tabular-nums text-muted-foreground">
+                  {{ t('skillPlanner.sanctuary.tierMove', { from: d.from, to: d.to }) }}
+                </span>
+              </div>
+              <div class="border-t border-border/40" />
+              <div class="flex flex-col gap-1">
+                <div
+                  v-for="(b, bi) in d.benefits"
+                  :key="bi"
+                  class="flex items-center justify-between gap-4"
+                >
+                  <span class="text-2xs text-muted-foreground">{{ b.label }}</span>
+                  <span class="flex items-center gap-1 text-2xs tabular-nums">
+                    <span class="text-foreground/80">{{ b.before }}</span>
+                    <span
+                      :class="
+                        b.improved ? 'text-success-strong' : 'text-rose-500 dark:text-rose-400'
+                      "
+                      >→</span
+                    >
+                    <span class="font-semibold text-foreground">{{ b.after }}</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </template>
+        </AppTooltip>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/skill-planner/SanctuaryPlannerSuggestion.vue
+++ b/src/components/skill-planner/SanctuaryPlannerSuggestion.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { ArrowRight, Sparkles, X } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import SanctuaryPartyDiff from '@/components/skill-planner/SanctuaryPartyDiff.vue'
+import { jobIcons } from '@/utils/format/icons'
+import type { SanctuaryRosterDiff } from '@/utils/planner/skillAdvisories'
+
+/**
+ * Visible, actionable handoff from the skill planner's "Open in Sanctuary" advisory.
+ * Pure/presentational: shows the suggested target tier alongside the player's current
+ * one (so the original is never silently overwritten), then the exact roster swap via
+ * the shared `SanctuaryPartyDiff` (remove/add/keep + the collateral tier moves the
+ * shared 8-slot party causes). The parent owns store access and applies on `apply`.
+ */
+const props = defineProps<{
+  job: string
+  suggestedTier: number
+  diff: SanctuaryRosterDiff
+}>()
+
+
+defineEmits<{
+  apply: []
+  dismiss: []
+  inspect: [id: string]
+}>()
+
+
+const { t } = useI18n()
+
+
+const jobIconSrc = computed(() => jobIcons[props.job.toLowerCase() as keyof typeof jobIcons])
+</script>
+
+<template>
+  <section
+    class="surface-card border border-primary/40 bg-primary/5 p-4"
+    :aria-label="t('skillPlanner.suggestion.aria')"
+  >
+    <!-- Header: a single vertically-centered line — the suggested job + tier. -->
+    <div class="flex items-center justify-between gap-3">
+      <p class="flex items-center gap-2 text-sm font-semibold">
+        <Sparkles class="size-4 shrink-0 text-primary" />
+        <span>{{ t('skillPlanner.suggestion.suggests') }}</span>
+        <span class="inline-flex items-center gap-1 font-bold">
+          <img v-if="jobIconSrc" :src="jobIconSrc" :alt="job" class="size-4" />
+          {{ t('skillPlanner.suggestion.jobToTier', { job, tier: suggestedTier }) }}
+        </span>
+      </p>
+      <button
+        class="focus-ring shrink-0 rounded-md p-1 text-muted-foreground transition hover:bg-muted/40 hover:text-foreground"
+        :aria-label="t('skillPlanner.suggestion.dismissAria')"
+        @click="$emit('dismiss')"
+      >
+        <X class="size-4" />
+      </button>
+    </div>
+
+    <!-- The exact roster swap (remove / add / keep) + shared-slot tier ripple. -->
+    <SanctuaryPartyDiff :diff="diff" @inspect="$emit('inspect', $event)" />
+
+    <!-- Actions -->
+    <div class="mt-3 flex items-center justify-end gap-2">
+      <button
+        class="focus-ring rounded-lg border border-border bg-muted/30 px-3 py-1.5 text-xs font-semibold text-muted-foreground transition hover:text-foreground"
+        @click="$emit('dismiss')"
+      >
+        {{ t('skillPlanner.suggestion.dismiss') }}
+      </button>
+      <button
+        class="focus-ring inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground shadow-glow transition hover:bg-primary/90"
+        @click="$emit('apply')"
+      >
+        {{ t('skillPlanner.suggestion.apply') }}
+        <ArrowRight class="size-3.5" />
+      </button>
+    </div>
+  </section>
+</template>

--- a/src/components/skill-planner/SkillPlanSegments.vue
+++ b/src/components/skill-planner/SkillPlanSegments.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { Clock3, Target, Zap } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { formatDuration, formatNumber, itemName } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
+import type { SkillPlan, SkillSegment } from '@/utils/planner/skillPlanner'
+
+const props = defineProps<{ plan: SkillPlan; isWorkstation?: boolean }>()
+
+
+const { t } = useI18n()
+
+
+// Gathering repeats an activity (cycles); crafting makes an item a number of times.
+const cycleNoun = computed(() =>
+  props.isWorkstation ? t('skillPlanner.segments.times') : t('skillPlanner.segments.cycles'),
+)
+
+
+/**
+ * How far the player's current level sits through this tier, measured from the
+ * tier's unlock level to its top: 0% for tiers not unlocked yet (haven't started),
+ * 100% for tiers already cleared, partial for the tier currently in progress.
+ */
+function progressPct(seg: SkillSegment): number {
+  const span = seg.toLevel - seg.unlockLevel
+  if (span <= 0) return 0
+  const done = props.plan.currentLevel - seg.unlockLevel
+  return Math.max(0, Math.min(100, Math.round((done / span) * 100)))
+}
+
+
+/**
+ * Bar fill % per card. Workstation cards show the queued fraction of their crafts
+ * (sky-blue), so the bar only fills as far as the queue covers the total needed —
+ * empty when nothing's queued, full only when the queue covers every craft.
+ * Gathering keeps the tier-progress fill.
+ */
+function barPct(seg: SkillSegment): number {
+  if (props.isWorkstation) {
+    const queued = seg.queuedCycles ?? 0
+    return seg.cycles > 0 ? Math.round((queued / seg.cycles) * 100) : 0
+  }
+  return progressPct(seg)
+}
+
+
+/** Sky-blue = the portion already in the workstation queue (matches the cost
+ * planners); neutral for the gathering tier-progress fill. */
+function barColor(seg: SkillSegment): string {
+  return (seg.queuedCycles ?? 0) > 0 ? 'bg-info' : 'bg-muted-foreground/50'
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-3 border-b border-border/60 pb-2">
+      <p class="font-mono text-2xs uppercase tracking-[0.14em] text-muted-foreground/70">
+        {{ t('skillPlanner.segments.stepByStep') }}
+      </p>
+      <h2 class="mt-0.5 text-xl font-black tracking-tight text-foreground">
+        {{ t('skillPlanner.segments.grindPath') }}
+      </h2>
+    </div>
+
+    <div class="space-y-2">
+      <!-- Step card (topmost = do first) -->
+      <div
+        v-for="(seg, i) in plan.segments"
+        :key="`${seg.activityId}-${i}`"
+        class="overflow-hidden rounded-xl border border-border/40 bg-card/60 p-3"
+      >
+        <div class="flex items-stretch gap-3">
+          <!-- Activity icon -->
+          <div class="flex size-14 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <img
+              v-if="getItemImage({ id: seg.iconItemId })"
+              :src="getItemImage({ id: seg.iconItemId })"
+              :alt="seg.activityName"
+              class="size-8 object-contain"
+              loading="lazy"
+            />
+            <span v-else class="text-sm font-bold text-primary">
+              {{ seg.activityName.charAt(0) }}
+            </span>
+          </div>
+
+          <div class="min-w-0 flex-1">
+            <!-- Activity name + level band -->
+            <div class="mb-1 flex items-center gap-2">
+              <span class="min-w-0 truncate text-sm font-semibold text-foreground">
+                {{ seg.activityName }}
+                <span v-if="seg.variantItemId" class="font-normal text-muted-foreground">
+                  · {{ itemName(seg.variantItemId) }}
+                </span>
+              </span>
+              <span
+                v-if="(seg.queuedCycles ?? 0) > 0"
+                class="shrink-0 rounded-md bg-info/15 px-1.5 py-0.5 text-3xs font-bold uppercase tracking-wide text-info-strong"
+              >
+                {{
+                  t('skillPlanner.segments.inQueue', {
+                    count: formatNumber(Math.round(seg.queuedCycles ?? 0)),
+                  })
+                }}
+              </span>
+              <span
+                class="ml-auto shrink-0 rounded-md bg-muted/50 px-2 py-0.5 font-mono text-2xs font-bold text-foreground"
+              >
+                LVL {{ seg.fromLevel }} → {{ seg.toLevel }}
+              </span>
+            </div>
+
+            <!-- Progress bar: sky = in workstation queue, neutral = tier progress -->
+            <div class="mt-2 h-1.5 overflow-hidden rounded-full bg-border/30">
+              <div
+                class="h-full rounded-full transition-all"
+                :class="barColor(seg)"
+                :style="{ width: `${barPct(seg)}%` }"
+              />
+            </div>
+
+            <!-- Metrics -->
+            <div
+              class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-2xs font-semibold text-muted-foreground"
+            >
+              <span class="inline-flex items-center gap-1">
+                <Zap class="size-3 text-primary" />
+                {{ seg.xpPerSec.toFixed(2)
+                }}<span class="font-normal text-muted-foreground/50"> XP/s</span>
+              </span>
+              <span class="inline-flex items-center gap-1">
+                <Target class="size-3" />
+                {{ formatNumber(Math.round(seg.cycles))
+                }}<span class="font-normal text-muted-foreground/50"> {{ cycleNoun }}</span>
+              </span>
+              <span class="ml-auto inline-flex items-center gap-1 text-foreground">
+                <Clock3 class="size-3" />
+                {{ formatDuration(seg.timeSeconds) }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/skill-planner/__tests__/AdvisoryRow.test.ts
+++ b/src/components/skill-planner/__tests__/AdvisoryRow.test.ts
@@ -1,0 +1,177 @@
+import { mount } from '@vue/test-utils'
+
+import AdvisoryRow from '@/components/skill-planner/AdvisoryRow.vue'
+import type { SkillAdvisory } from '@/composables/useSkillPlanner'
+
+vi.mock('@/utils/format/format', () => ({
+  formatNumber: (n: number) => n.toLocaleString('en-US'),
+  formatDuration: (s: number) => `${s}s`,
+}))
+
+vi.mock('@/utils/format/icons', () => ({
+  sourceIcons: {} as Record<string, string>,
+}))
+
+vi.mock('@/utils/images/itemImages', () => ({
+  getItemImage: () => undefined,
+}))
+
+vi.mock('@/components/skill-planner/SanctuaryPartyDiff.vue', () => ({
+  default: { name: 'SanctuaryPartyDiff', template: '<div class="sanctuary-diff" />' },
+}))
+
+vi.mock('@/components/skill-planner/AwakenPointSources.vue', () => ({
+  default: { name: 'AwakenPointSources', template: '<div class="awaken-sources" />' },
+}))
+
+const stubs = {
+  RouterLink: { name: 'RouterLink', props: ['to'], template: '<a><slot /></a>' },
+}
+
+vi.mock('vue-router', async (orig) => {
+  const actual = await (orig as () => Promise<Record<string, unknown>>)()
+  return { ...actual, useRoute: () => ({ path: '/tools' }) }
+})
+
+function sanctuaryAdv(): SkillAdvisory {
+  return {
+    kind: 'bonus',
+    lever: 'sanctuary:mining',
+    label: 'Sanctuary - Mining Tier 3',
+    benefits: [
+      { kind: 'xp', before: 0, after: 40 },
+      { kind: 'duration', before: 0, after: 10 },
+    ],
+    timeSaved: 3600,
+    routeName: 'sanctuary',
+    partyDiff: {
+      target: { job: 'Mining', from: 0, to: 3 },
+      sideEffects: [],
+      swapIn: [],
+      swapOut: [],
+      keep: [],
+    } as never,
+  }
+}
+
+function awakenAdv(): SkillAdvisory {
+  return {
+    kind: 'bonus',
+    lever: 'awaken:mining:0',
+    label: 'Mining XP III',
+    benefits: [{ kind: 'xp', before: 0, after: 10 }],
+    timeSaved: 1800,
+    routeName: 'awaken',
+    awakenPointCost: 1,
+    awakenPointsAvailable: 0,
+    awakenTreeId: 'mining',
+    awakenNodeId: '0',
+    awakenSources: { owned: [], summon: [] },
+  }
+}
+
+function toolAdv(): SkillAdvisory {
+  return {
+    kind: 'bonus',
+    lever: 'tools:mining',
+    label: 'Mining Pickaxe Level 1 → 2',
+    benefits: [{ kind: 'xp', before: 0, after: 5 }],
+    timeSaved: 900,
+    routeName: 'tools',
+    toolId: 'mining-pickaxe',
+    toolCost: { itemId: 'bar', itemName: 'Copper Bar', amount: 50 },
+  }
+}
+
+function playerLevelAdv(): SkillAdvisory {
+  return {
+    kind: 'playerLevel',
+    timeSaved: 7200,
+    steps: [
+      { skillId: 'Fishing', fromLevel: 5, toLevel: 8, levelsAdded: 3, timeSeconds: 600 },
+      { skillId: 'Farming', fromLevel: 2, toLevel: 4, levelsAdded: 2, timeSeconds: 300 },
+    ],
+    totalXpCost: 1000,
+    levelUpTimeSeconds: 3600,
+    playerLevelFrom: 10,
+    playerLevelTo: 12,
+    xpBonusGain: 2,
+  }
+}
+
+function mountRow(advisory: SkillAdvisory, open = false) {
+  return mount(AdvisoryRow, { props: { advisory, open }, global: { stubs } })
+}
+
+describe('AdvisoryRow', () => {
+  test('renders sanctuary headline + time saved; benefit only once open', () => {
+    const w = mountRow(sanctuaryAdv())
+    expect(w.text()).toContain('Sanctuary → Tier 3')
+    expect(w.text()).toContain('−3600s')
+    // The benefit phrase moved to the expanded body, off the collapsed row.
+    expect(w.text()).not.toContain('+40% XP')
+    expect(mountRow(sanctuaryAdv(), true).text()).toContain('+40% XP · 10% faster gathering')
+  })
+
+  test('renders awaken node-name headline (skill word stripped) and point-cost line', () => {
+    const w = mountRow(awakenAdv())
+    expect(w.text()).toContain('XP III')
+    expect(w.text()).not.toContain('Mining XP III')
+    expect(w.text()).toContain('1 Awaken Point')
+  })
+
+  test('renders tool label headline and item cost', () => {
+    const w = mountRow(toolAdv())
+    expect(w.text()).toContain('Mining Pickaxe Level 1 → 2')
+    expect(w.text()).toContain('50 Copper Bar')
+  })
+
+  test('renders playerLevel headline; on-every-skill benefit when open', () => {
+    const w = mountRow(playerLevelAdv(), true)
+    expect(w.text()).toContain('Raise low skills → +2 player levels')
+    expect(w.text()).toContain('+2% XP on every skill')
+  })
+
+  test('emits toggle on click', async () => {
+    const w = mountRow(sanctuaryAdv())
+    await w.find('button').trigger('click')
+    expect(w.emitted('toggle')).toHaveLength(1)
+  })
+
+  test('emits toggle on Enter and Space', async () => {
+    const w = mountRow(sanctuaryAdv())
+    await w.find('button').trigger('keydown.enter')
+    await w.find('button').trigger('keydown.space')
+    expect(w.emitted('toggle')).toHaveLength(2)
+  })
+
+  test('aria-expanded tracks the open prop', async () => {
+    const w = mountRow(sanctuaryAdv(), false)
+    expect(w.find('button').attributes('aria-expanded')).toBe('false')
+    await w.setProps({ open: true })
+    expect(w.find('button').attributes('aria-expanded')).toBe('true')
+  })
+
+  test('body is hidden when collapsed, shown when open', async () => {
+    const w = mountRow(sanctuaryAdv(), false)
+    expect(w.find('.sanctuary-diff').exists()).toBe(false)
+    await w.setProps({ open: true })
+    expect(w.find('.sanctuary-diff').exists()).toBe(true)
+  })
+
+  test('bonus rows render exactly one CTA when open', () => {
+    const w = mountRow(toolAdv(), true)
+    const links = w.findAllComponents({ name: 'RouterLink' })
+    const ctas = links.filter((l) => l.text().includes('Open in'))
+    expect(ctas).toHaveLength(1)
+    expect(ctas[0].text()).toContain('Open in Tools')
+  })
+
+  test('playerLevel row has NO single CTA — only per-skill links', () => {
+    const w = mountRow(playerLevelAdv(), true)
+    const links = w.findAllComponents({ name: 'RouterLink' })
+    expect(links.some((l) => l.text().includes('Open in'))).toBe(false)
+    // One link per skill step instead.
+    expect(links).toHaveLength(2)
+  })
+})

--- a/src/components/skill-planner/__tests__/CreatureDiffTile.test.ts
+++ b/src/components/skill-planner/__tests__/CreatureDiffTile.test.ts
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils'
+
+import CreatureDiffTile from '@/components/skill-planner/CreatureDiffTile.vue'
+
+vi.mock('@/utils/images/creatureImages', () => ({ getCreatureImage: () => undefined }))
+
+vi.mock('@/utils/format/icons', () => ({
+  sanctuaryIcon: 'sanctuary.webp',
+  helpersIcon: 'helper.webp',
+  machinesIcon: 'machine.webp',
+  expeditionsIcon: 'expedition.webp',
+  dungeonsIcon: 'dungeon.webp',
+}))
+
+vi.mock('@/components/shared/AppTooltip.vue', () => ({
+  default: { name: 'AppTooltip', props: ['text', 'position'], template: '<span><slot /></span>' },
+}))
+
+vi.mock('@/components/shared/RightClickHint.vue', () => ({
+  default: {
+    name: 'RightClickHint',
+    emits: ['contextmenu'],
+    template: `<div class="rch" @contextmenu="$emit('contextmenu')"><slot /></div>`,
+  },
+}))
+
+// id 'busy' → assigned as a helper; id 'excl' → excluded; anything else → available.
+vi.mock('@/composables/useCreatureStatus', () => ({
+  useCreatureStatus: () => ({
+    statusOf: (id: string) => ({
+      role: id === 'busy' ? 'helper' : null,
+      excluded: id === 'excl',
+    }),
+  }),
+}))
+
+function mountTile(id: string, variant: 'remove' | 'add' | 'keep' = 'add') {
+  return mount(CreatureDiffTile, {
+    props: { id, name: 'Cuddles', contribution: 5, variant },
+  })
+}
+
+describe('CreatureDiffTile', () => {
+  test('available creature: no ring, no assignment icon', () => {
+    const w = mountTile('ok')
+    expect(w.html()).not.toContain('ring-warning')
+    expect(w.find('img[alt="Helper"]').exists()).toBe(false)
+  })
+
+  test('excluded incoming creature: warning ring, no assignment icon', () => {
+    const w = mountTile('excl')
+    expect(w.html()).toContain('ring-warning')
+    expect(w.find('img[alt="Helper"]').exists()).toBe(false)
+  })
+
+  test('busy incoming creature: warning ring + assignment icon', () => {
+    const w = mountTile('busy')
+    expect(w.html()).toContain('ring-warning')
+    expect(w.find('img[alt="Helper"]').exists()).toBe(true)
+  })
+
+  test('does not flag creatures already in the sanctuary (remove/keep)', () => {
+    expect(mountTile('excl', 'remove').html()).not.toContain('ring-warning')
+    expect(mountTile('busy', 'keep').html()).not.toContain('ring-warning')
+    expect(mountTile('busy', 'keep').find('img[alt="Helper"]').exists()).toBe(false)
+  })
+
+  test('emits inspect with the id on inspect', async () => {
+    const w = mountTile('ok')
+    await w.find('.rch').trigger('contextmenu')
+    expect(w.emitted('inspect')?.[0]).toEqual(['ok'])
+  })
+})

--- a/src/components/skill-planner/__tests__/SanctuaryPartyDiff.test.ts
+++ b/src/components/skill-planner/__tests__/SanctuaryPartyDiff.test.ts
@@ -1,0 +1,62 @@
+import { mount } from '@vue/test-utils'
+
+import SanctuaryPartyDiff from '@/components/skill-planner/SanctuaryPartyDiff.vue'
+import type { SanctuaryRosterDiff } from '@/utils/planner/skillAdvisories'
+
+vi.mock('@/utils/format/icons', () => ({
+  jobIcons: {} as Record<string, string>,
+}))
+
+// Stub the creature tile; assert on the names/ids the diff passes through.
+vi.mock('@/components/skill-planner/CreatureDiffTile.vue', () => ({
+  default: {
+    name: 'CreatureDiffTile',
+    props: ['id', 'name', 'contribution', 'variant'],
+    emits: ['inspect'],
+    template: `<button class="tile" :data-variant="variant" @click="$emit('inspect', id)">{{ name }}</button>`,
+  },
+}))
+
+function diff(overrides: Partial<SanctuaryRosterDiff> = {}): SanctuaryRosterDiff {
+  return {
+    target: { job: 'Mining', from: 1, to: 3 },
+    keep: [{ id: 'a', name: 'Keeper', contribution: 5 }],
+    swapOut: [{ id: 'b', name: 'Bench Me', contribution: 0 }],
+    swapIn: [{ id: 'c', name: 'New Star', contribution: 8 }],
+    sideEffects: [],
+    ...overrides,
+  }
+}
+
+function mountDiff(overrides: Partial<SanctuaryRosterDiff> = {}) {
+  return mount(SanctuaryPartyDiff, { props: { diff: diff(overrides) } })
+}
+
+describe('SanctuaryPartyDiff', () => {
+  test('renders remove / add / keep creatures by variant', () => {
+    const w = mountDiff()
+    const byVariant = (v: string) => w.findAll(`.tile[data-variant="${v}"]`).map((t) => t.text())
+    expect(byVariant('remove')).toContain('Bench Me')
+    expect(byVariant('add')).toContain('New Star')
+    expect(byVariant('keep')).toContain('Keeper')
+  })
+
+  test('renders the resulting tier change for the target job (rising)', () => {
+    const w = mountDiff()
+    expect(w.text()).toContain('Resulting tier changes')
+    expect(w.text()).toContain('Mining')
+    expect(w.text()).toContain('▲')
+  })
+
+  test('shows shared-slot side-effect tier moves (falling)', () => {
+    const w = mountDiff({ sideEffects: [{ job: 'Fishing', from: 2, to: 1 }] })
+    expect(w.text()).toContain('Fishing')
+    expect(w.text()).toContain('▼')
+  })
+
+  test('forwards inspect with the creature id from a tile', async () => {
+    const w = mountDiff()
+    await w.find('.tile[data-variant="remove"]').trigger('click')
+    expect(w.emitted('inspect')?.[0]).toEqual(['b'])
+  })
+})

--- a/src/components/skill-planner/__tests__/SanctuaryPlannerSuggestion.test.ts
+++ b/src/components/skill-planner/__tests__/SanctuaryPlannerSuggestion.test.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils'
+
+import SanctuaryPlannerSuggestion from '@/components/skill-planner/SanctuaryPlannerSuggestion.vue'
+import type { SanctuaryRosterDiff } from '@/utils/planner/skillAdvisories'
+
+vi.mock('@/utils/format/icons', () => ({
+  jobIcons: {} as Record<string, string>,
+}))
+
+// The roster swap rendering is covered by SanctuaryPartyDiff's own test; stub it here
+// and just verify the panel wires it up (passes the diff, forwards inspect).
+vi.mock('@/components/skill-planner/SanctuaryPartyDiff.vue', () => ({
+  default: {
+    name: 'SanctuaryPartyDiff',
+    props: ['diff'],
+    emits: ['inspect'],
+    template: `<button class="diff-stub" @click="$emit('inspect', 'a')">diff</button>`,
+  },
+}))
+
+function diff(overrides: Partial<SanctuaryRosterDiff> = {}): SanctuaryRosterDiff {
+  return {
+    target: { job: 'Mining', from: 1, to: 3 },
+    keep: [{ id: 'a', name: 'Keeper', contribution: 5 }],
+    swapOut: [{ id: 'b', name: 'Bench Me', contribution: 0 }],
+    swapIn: [{ id: 'c', name: 'New Star', contribution: 8 }],
+    sideEffects: [],
+    ...overrides,
+  }
+}
+
+function mountPanel(overrides: Record<string, unknown> = {}) {
+  return mount(SanctuaryPlannerSuggestion, {
+    props: {
+      job: 'Mining',
+      suggestedTier: 3,
+      diff: diff(),
+      ...overrides,
+    },
+  })
+}
+
+describe('SanctuaryPlannerSuggestion', () => {
+  test('renders the suggested job and tier', () => {
+    const w = mountPanel()
+    expect(w.text()).toContain('Skill Planner suggests')
+    expect(w.text()).toContain('Mining → Tier 3')
+  })
+
+  test('renders the roster-swap diff child', () => {
+    const w = mountPanel()
+    expect(w.findComponent({ name: 'SanctuaryPartyDiff' }).exists()).toBe(true)
+  })
+
+  test('forwards inspect from the diff child', async () => {
+    const w = mountPanel()
+    await w.find('.diff-stub').trigger('click')
+    expect(w.emitted('inspect')?.[0]).toEqual(['a'])
+  })
+
+  test('emits apply when the Apply button is clicked', async () => {
+    const w = mountPanel()
+    const apply = w.findAll('button').find((b) => b.text().includes('Apply'))
+    await apply?.trigger('click')
+    expect(w.emitted('apply')).toHaveLength(1)
+  })
+
+  test('emits dismiss when the Dismiss button is clicked', async () => {
+    const w = mountPanel()
+    const dismiss = w.findAll('button').find((b) => b.text().trim() === 'Dismiss')
+    await dismiss?.trigger('click')
+    expect(w.emitted('dismiss')).toHaveLength(1)
+  })
+})

--- a/src/components/skill-planner/__tests__/advisoryPresentation.test.ts
+++ b/src/components/skill-planner/__tests__/advisoryPresentation.test.ts
@@ -1,0 +1,123 @@
+import { Sparkles, TrendingUp, Users, Wrench } from 'lucide-vue-next'
+
+import { advisoryPresentation } from '@/components/skill-planner/advisoryPresentation'
+import type { SkillAdvisory } from '@/composables/useSkillPlanner'
+
+function sanctuaryAdv(
+  over: Partial<Extract<SkillAdvisory, { kind: 'bonus' }>> = {},
+): SkillAdvisory {
+  return {
+    kind: 'bonus',
+    lever: 'sanctuary:mining',
+    label: 'Sanctuary - Mining Tier 3',
+    benefits: [
+      { kind: 'xp', before: 0, after: 40 },
+      { kind: 'duration', before: 0, after: 10 },
+    ],
+    timeSaved: 3600,
+    routeName: 'sanctuary',
+    partyDiff: {
+      target: { job: 'Mining', from: 0, to: 3 },
+      sideEffects: [],
+      swapIn: [],
+      swapOut: [],
+      keep: [],
+    } as never,
+    ...over,
+  }
+}
+
+function awakenAdv(over: Partial<Extract<SkillAdvisory, { kind: 'bonus' }>> = {}): SkillAdvisory {
+  return {
+    kind: 'bonus',
+    lever: 'awaken:mining:0',
+    label: 'Mining XP III',
+    benefits: [{ kind: 'xp', before: 0, after: 10 }],
+    timeSaved: 1800,
+    routeName: 'awaken',
+    awakenPointCost: 1,
+    awakenPointsAvailable: 0,
+    awakenTreeId: 'mining',
+    awakenNodeId: '0',
+    ...over,
+  }
+}
+
+function toolAdv(over: Partial<Extract<SkillAdvisory, { kind: 'bonus' }>> = {}): SkillAdvisory {
+  return {
+    kind: 'bonus',
+    lever: 'tools:mining',
+    label: 'Mining Pickaxe Level 1 → 2',
+    benefits: [{ kind: 'xp', before: 0, after: 5 }],
+    timeSaved: 900,
+    routeName: 'tools',
+    toolId: 'mining-pickaxe',
+    toolCost: { itemId: 'bar', itemName: 'Copper Bar', amount: 50 },
+    ...over,
+  }
+}
+
+function playerLevelAdv(): SkillAdvisory {
+  return {
+    kind: 'playerLevel',
+    timeSaved: 7200,
+    steps: [],
+    totalXpCost: 1000,
+    levelUpTimeSeconds: 3600,
+    playerLevelFrom: 10,
+    playerLevelTo: 12,
+    xpBonusGain: 2,
+  }
+}
+
+describe('advisoryPresentation', () => {
+  test('sanctuary: target-state headline, no cost, benefit phrase, CTA to Sanctuary', () => {
+    const p = advisoryPresentation(sanctuaryAdv())
+    expect(p.glyph).toBe(Users)
+    expect(p.headline).toBe('Sanctuary → Tier 3')
+    expect(p.cost).toBe('')
+    expect(p.benefit).toBe('+40% XP · 10% faster gathering')
+    expect(p.ctaLabel).toBe('Open in Sanctuary')
+    expect(p.ctaLink).toEqual({ name: 'sanctuary', query: { job: 'Mining', target: 3 } })
+  })
+
+  test('awaken: scoped Skill planner drops the redundant skill word from the node name', () => {
+    const p = advisoryPresentation(awakenAdv())
+    expect(p.glyph).toBe(Sparkles)
+    expect(p.headline).toBe('XP III')
+    expect(p.cost).toBe('1 Awaken Point')
+    expect(p.benefit).toBe('+10% XP')
+    expect(p.ctaLabel).toBe('Open in Awaken tree')
+    expect(p.ctaLink).toEqual({ name: 'awaken', query: { tree: 'mining', node: '0' } })
+  })
+
+  test('awaken: Summon context (job set) keeps the full node name', () => {
+    // Summon "Ways to improve" mixes skills, so the skill word stays for disambiguation.
+    expect(advisoryPresentation(awakenAdv(), 'Mining').headline).toBe('Mining XP III')
+  })
+
+  test('awaken: plural Awaken Points cost', () => {
+    const p = advisoryPresentation(awakenAdv({ awakenPointCost: 2 }))
+    expect(p.cost).toBe('2 Awaken Points')
+  })
+
+  test('tool: reuses the tool label as headline, item cost, benefit, CTA to Tools', () => {
+    const p = advisoryPresentation(toolAdv())
+    expect(p.glyph).toBe(Wrench)
+    expect(p.headline).toBe('Mining Pickaxe Level 1 → 2')
+    expect(p.cost).toBe('50 Copper Bar')
+    expect(p.benefit).toBe('+5% XP')
+    expect(p.ctaLabel).toBe('Open in Tools')
+    expect(p.ctaLink).toEqual({ name: 'tools', query: { tool: 'mining-pickaxe' } })
+  })
+
+  test('playerLevel: no cost, on-every-skill benefit, singular/plural levels, NO CTA', () => {
+    const p = advisoryPresentation(playerLevelAdv())
+    expect(p.glyph).toBe(TrendingUp)
+    expect(p.headline).toBe('Raise low skills → +2 player levels')
+    expect(p.cost).toBe('')
+    expect(p.benefit).toBe('+2% XP on every skill')
+    expect(p.ctaLabel).toBeUndefined()
+    expect(p.ctaLink).toBeUndefined()
+  })
+})

--- a/src/components/skill-planner/advisoryPresentation.ts
+++ b/src/components/skill-planner/advisoryPresentation.ts
@@ -1,0 +1,146 @@
+import { Sparkles, TrendingUp, Users, Wrench } from 'lucide-vue-next'
+import type { FunctionalComponent } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+
+import type { SkillAdvisory, SkillBoost } from '@/composables/useSkillPlanner'
+import { t } from '@/i18n'
+import { formatNumber } from '@/utils/format/format'
+
+type BonusAdvisory = Extract<SkillAdvisory, { kind: 'bonus' }>
+type PlayerLevelAdvisory = Extract<SkillAdvisory, { kind: 'playerLevel' }>
+
+/** Where the advisory's link goes, so the CTA reads "Open in Sanctuary" rather than
+ * a bare "Open" (which page it lands on is otherwise ambiguous). Sanctuary, the
+ * Awaken Tree, and Tools are frozen feature names kept in English in every locale. */
+const ADVISORY_DESTINATIONS: Record<BonusAdvisory['routeName'], () => string> = {
+  sanctuary: () => 'Sanctuary',
+  awaken: () => 'Awaken tree',
+  tools: () => 'Tools',
+} as const
+
+export function advisoryDestination(adv: BonusAdvisory): string {
+  return ADVISORY_DESTINATIONS[adv.routeName]()
+}
+
+/** Deep-links a bonus advisory to its destination, highlighting the node/tool. */
+export function advisoryLink(adv: BonusAdvisory): RouteLocationRaw {
+  if (adv.routeName === 'awaken')
+    return { name: 'awaken', query: { tree: adv.awakenTreeId, node: adv.awakenNodeId } }
+  if (adv.routeName === 'tools') return { name: 'tools', query: { tool: adv.toolId } }
+  if (adv.routeName === 'sanctuary')
+    return {
+      name: 'sanctuary',
+      query: { job: adv.partyDiff?.target.job, target: adv.partyDiff?.target.to },
+    }
+  return { name: adv.routeName }
+}
+
+/** The presentational shape every advisory row renders from. */
+export interface AdvisoryPresentation {
+  /** Real in-game asset image for the lever (sanctuary / awaken tree / the specific
+   * tool). Preferred over `glyph` when present. */
+  iconSrc?: string
+  /** Fallback icon when there's no asset image — and the player-level row, which
+   * reuses the Summary's Player Level chart icon. */
+  glyph: FunctionalComponent
+  headline: string
+  /** The price to act, shown as the collapsed row's single muted subline. Empty when
+   * the lever has no resource cost (e.g. a Sanctuary roster swap, or player level). */
+  cost: string
+  /** The gain this lever grants (e.g. "+40% XP · faster gathering"). Shown at the top
+   * of the expanded body — not in the collapsed row, where the time-saved badge
+   * already quantifies the payoff. */
+  benefit: string
+  /** Bonus levers carry one specific navigation CTA; playerLevel has none (it has
+   * many per-skill destinations instead). */
+  ctaLabel?: string
+  ctaLink?: RouteLocationRaw
+}
+
+/** One benefit's gain phrase — the delta this lever grants, e.g. "+40% XP",
+ * "10% faster gathering", "+2 yield". Mirrors the in-planner bonus wording. */
+function benefitGain(b: SkillBoost): string {
+  const diff = b.after - b.before
+  if (b.kind === 'duration') return t('advisories.benefit.fasterGathering', { pct: Math.abs(diff) })
+  if (b.kind === 'yield') return t('advisories.benefit.yield', { amount: diff })
+  return t('advisories.benefit.xp', { pct: diff })
+}
+
+/** Up to two benefit gains, joined by " · " — the primary payoff for the subline. */
+function benefitsPhrase(benefits: SkillBoost[]): string {
+  return benefits.slice(0, 2).map(benefitGain).join(' · ')
+}
+
+/** The price to act on a bonus lever — the resource it spends. Empty for Sanctuary,
+ * whose only "cost" is a free roster rearrange. */
+function costHint(adv: BonusAdvisory): string {
+  if (adv.toolCost)
+    return t('advisories.cost.tool', {
+      amount: formatNumber(adv.toolCost.amount),
+      itemName: adv.toolCost.itemName,
+    })
+  if (adv.awakenPointCost)
+    return t('advisories.cost.awakenPoints', { n: adv.awakenPointCost }, adv.awakenPointCost)
+  return ''
+}
+
+/** In the Skill planner we're already scoped to one skill, so an awaken node's leading
+ * skill word is redundant ("Fishing Yield I" → "Yield I"). Stripped only there; the
+ * Summon "Ways to improve" mixes skills (job set), so it keeps the full node name. */
+function stripSkillPrefix(label: string, treeId?: string): string {
+  if (!treeId) return label
+  const prefix = `${treeId} ` // treeId is the lowercase skill id, e.g. "fishing"
+  return label.toLowerCase().startsWith(prefix) ? label.slice(prefix.length) : label
+}
+
+function bonusPresentation(adv: BonusAdvisory, job?: string): AdvisoryPresentation {
+  let glyph: FunctionalComponent
+  let headline: string
+  if (adv.routeName === 'sanctuary') {
+    glyph = Users
+    // Name the gathering job being raised when known (Summon "Ways to improve" mixes
+    // advisories from several skills); the Skill planner omits it (already scoped).
+    // "Sanctuary" and the job name are frozen, passed through as params.
+    const tier = adv.partyDiff?.target.to ?? ''
+    headline = job
+      ? t('advisories.sanctuary.headlineWithJob', { job, tier })
+      : t('advisories.sanctuary.headline', { tier })
+  } else if (adv.routeName === 'awaken') {
+    glyph = Sparkles
+    // The node name (e.g. "Fishing Yield I") is self-describing; the awaken icon + cost
+    // line carry the rest, so we drop the old "Allocate Awaken node · " jargon prefix.
+    // Scoped Skill planner also drops the redundant leading skill word.
+    headline = job ? adv.label : stripSkillPrefix(adv.label, adv.awakenTreeId)
+  } else {
+    glyph = Wrench
+    // The tool label already names the tool + target level clearly, so reuse it.
+    headline = adv.label
+  }
+
+  return {
+    iconSrc: adv.iconSrc,
+    glyph,
+    headline,
+    cost: costHint(adv),
+    benefit: benefitsPhrase(adv.benefits),
+    ctaLabel: t('advisories.openIn', { destination: advisoryDestination(adv) }),
+    ctaLink: advisoryLink(adv),
+  }
+}
+
+function playerLevelPresentation(adv: PlayerLevelAdvisory): AdvisoryPresentation {
+  const levels = adv.playerLevelTo - adv.playerLevelFrom
+  return {
+    glyph: TrendingUp,
+    headline: t('advisories.playerLevel.headline', { levels }, levels),
+    cost: '',
+    benefit: t('advisories.playerLevel.benefit', { pct: adv.xpBonusGain }),
+    // playerLevel has many per-skill destinations, so no single CTA.
+  }
+}
+
+/** Maps a `SkillAdvisory` to its row presentation, keeping headline/subline grammar
+ * in one place. Pure — no side effects. */
+export function advisoryPresentation(adv: SkillAdvisory, job?: string): AdvisoryPresentation {
+  return adv.kind === 'bonus' ? bonusPresentation(adv, job) : playerLevelPresentation(adv)
+}

--- a/src/composables/__tests__/useSanctuary.test.ts
+++ b/src/composables/__tests__/useSanctuary.test.ts
@@ -2,7 +2,7 @@ import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useSanctuary } from '@/composables/useSanctuary'
-import { MAX_SANCTUARY_SLOTS, SANCTUARY_JOBS } from '@/utils/sanctuaryConstants'
+import { MAX_SANCTUARY_SLOTS, SANCTUARY_JOBS } from '@/utils/planner/sanctuaryConstants'
 
 describe('useSanctuary', () => {
   beforeEach(() => {
@@ -81,6 +81,43 @@ describe('useSanctuary', () => {
     test('does nothing when removing from an empty slot', () => {
       const { sanctuaryCreatureIds, removeCreatureFromSlot } = useSanctuary()
       removeCreatureFromSlot(0)
+      expect(sanctuaryCreatureIds.value).toHaveLength(0)
+    })
+  })
+
+  describe('setParty', () => {
+    test('replaces the party with the given creatures', () => {
+      const { creatures } = useCreatures()
+      const { sanctuaryCreatureIds, setParty } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      const [c1, c2, c3] = creatures.value
+      setSanctuaryCreatures([c1.id])
+
+      setParty([c2, c3])
+      expect(sanctuaryCreatureIds.value).toEqual([c2.id, c3.id])
+    })
+
+    test('caps the party at MAX_SANCTUARY_SLOTS', () => {
+      const { creatures } = useCreatures()
+      const { sanctuaryCreatureIds, setParty } = useSanctuary()
+
+      const tooMany = creatures.value.slice(0, MAX_SANCTUARY_SLOTS + 3)
+      setParty(tooMany)
+
+      expect(sanctuaryCreatureIds.value).toHaveLength(MAX_SANCTUARY_SLOTS)
+      expect(sanctuaryCreatureIds.value).toEqual(
+        tooMany.slice(0, MAX_SANCTUARY_SLOTS).map((c) => c.id),
+      )
+    })
+
+    test('clears the party when given an empty list', () => {
+      const { creatures } = useCreatures()
+      const { sanctuaryCreatureIds, setParty } = useSanctuary()
+      const { setSanctuaryCreatures } = useGameConfig()
+
+      setSanctuaryCreatures([creatures.value[0].id, creatures.value[1].id])
+      setParty([])
       expect(sanctuaryCreatureIds.value).toHaveLength(0)
     })
   })

--- a/src/composables/__tests__/useSkillPlanner.test.ts
+++ b/src/composables/__tests__/useSkillPlanner.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ref } from 'vue'
+
+import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatures } from '@/composables/useCreatures'
+import { useGameConfig } from '@/composables/useGameConfig'
+import { useSkillPlanner } from '@/composables/useSkillPlanner'
+import { items } from '@/data/indexes'
+
+/** Stock a huge amount of every item so inventory never constrains a workstation plan. */
+function stockEverything(amount = 1e9) {
+  const cfg = useGameConfig()
+  for (const item of items) cfg.setInventory(item.id, amount)
+}
+
+describe('useSkillPlanner', () => {
+  beforeEach(() => {
+    useGameConfig().resetGameConfig()
+    useCreatureCollection().resetCollection()
+  })
+
+  it('derives current level from config and starts the plan there', () => {
+    useGameConfig().setSkillLevels({ Mining: 40 })
+    const skillId = ref('Mining')
+    const target = ref(70)
+    const { plan, currentLevel } = useSkillPlanner(skillId, target)
+
+    expect(currentLevel.value).toBe(40)
+    expect(plan.value?.currentLevel).toBe(40)
+    expect(plan.value?.segments[0].fromLevel).toBe(40)
+  })
+
+  it('lets a what-if override beat the live config value', () => {
+    useGameConfig().setSkillLevels({ Mining: 40 })
+    const { plan, currentLevel, setOverride, hasOverrides } = useSkillPlanner(
+      ref('Mining'),
+      ref(70),
+    )
+
+    expect(hasOverrides.value).toBe(false)
+    setOverride('currentLevel', 10)
+    expect(hasOverrides.value).toBe(true)
+    expect(currentLevel.value).toBe(10)
+    expect(plan.value?.currentLevel).toBe(10)
+  })
+
+  it('restores the config value after resetOverrides', () => {
+    useGameConfig().setSkillLevels({ Mining: 40 })
+    const { currentLevel, setOverride, resetOverrides, hasOverrides } = useSkillPlanner(
+      ref('Mining'),
+      ref(70),
+    )
+
+    setOverride('currentLevel', 10)
+    resetOverrides()
+    expect(hasOverrides.value).toBe(false)
+    expect(currentLevel.value).toBe(40)
+  })
+
+  it('recomputes the plan when the selected skill changes', () => {
+    const skillId = ref('Mining')
+    const { plan } = useSkillPlanner(skillId, ref(50))
+    expect(plan.value?.skillId).toBe('Mining')
+    skillId.value = 'Chopping'
+    expect(plan.value?.skillId).toBe('Chopping')
+  })
+
+  it('applies awaken-XP overrides to the bonus breakdown and multiplier', () => {
+    const { bonusBreakdown, multipliers, setOverride } = useSkillPlanner(ref('Mining'), ref(50))
+    const baseXpMult = multipliers.value.xpMultiplier
+
+    setOverride('awakenXpTier', 6) // 6 nodes × +10%
+    expect(bonusBreakdown.value.awakenXp).toBe(60)
+    expect(multipliers.value.xpMultiplier).toBeCloseTo(baseXpMult + 0.6, 6)
+  })
+
+  it('exposes every gathering tier above the current level, tagged with its resource', () => {
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    const { targetPresets } = useSkillPlanner(ref('Mining'), ref(70))
+    // All Mining tiers (1 excluded, not > current 1) plus the trailing max preset.
+    expect(targetPresets.value.map((p) => p.level)).toEqual([
+      5, 10, 15, 20, 30, 40, 50, 60, 70, 80, 90, 99,
+    ])
+    // Each preset names the resource the tier unlocks (L5 Mining → copper ore).
+    expect(targetPresets.value[0]).toMatchObject({ level: 5, itemId: 'copper-ore' })
+  })
+
+  it('always offers a max-level (99) preset with no resource tag', () => {
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    const { targetPresets } = useSkillPlanner(ref('Mining'), ref(70))
+    const max = targetPresets.value.at(-1)
+    expect(max).toMatchObject({ level: 99, isMax: true })
+    expect(max?.itemId).toBeUndefined()
+  })
+
+  it('hides preset tiers at or below the current level', () => {
+    useGameConfig().setSkillLevels({ Mining: 60 })
+    const { targetPresets } = useSkillPlanner(ref('Mining'), ref(90))
+    expect(targetPresets.value.map((p) => p.level)).toEqual([70, 80, 90, 99])
+  })
+
+  it('omits the max preset once the skill is already at the cap', () => {
+    useGameConfig().setSkillLevels({ Mining: 99 })
+    const { targetPresets } = useSkillPlanner(ref('Mining'), ref(99))
+    expect(targetPresets.value).toEqual([])
+  })
+
+  it('shows all workstation recipe tiers, tagged with the best-XP recipe item', () => {
+    // Furnace bars/armor feed tool & machine upgrades, so every tier is shown.
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    const { targetPresets } = useSkillPlanner(ref('Furnace'), ref(60))
+    expect(targetPresets.value.map((p) => p.level)).toEqual([5, 10, 15, 20, 25, 30, 40, 50, 60, 99])
+    expect(targetPresets.value.filter((p) => !p.isMax).every((p) => p.itemId && p.itemName)).toBe(
+      true,
+    )
+
+    useGameConfig().setSkillLevels({ Workbench: 1 })
+    const wb = useSkillPlanner(ref('Workbench'), ref(80))
+    expect(wb.targetPresets.value.map((p) => p.level)).toEqual([
+      5, 10, 15, 20, 25, 30, 35, 60, 65, 80, 99,
+    ])
+  })
+
+  it('ranks bonus-lever advisories by time saved on a gathering grind', () => {
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    const { advisories } = useSkillPlanner(ref('Mining'), ref(70))
+    const levers = advisories.value.flatMap((a) => (a.kind === 'bonus' ? [a.lever] : []))
+    // From a default config (no nodes/tool) the awaken + tool levers help. The
+    // sanctuary lever is collection-dependent (needs owned+awakened creatures),
+    // so it's absent here — covered separately below.
+    expect(levers).toContain('awakenXp')
+    expect(levers).toContain('toolLevel')
+    expect(levers).not.toContain('sanctuaryTier')
+    // Ranked by time saved, descending, and all positive.
+    const times = advisories.value.map((a) => a.timeSaved)
+    expect(times).toEqual([...times].toSorted((x, y) => y - x))
+    expect(advisories.value.every((a) => a.timeSaved > 0)).toBe(true)
+  })
+
+  it('prices an awaken node by its full prerequisite chain, not a flat 1 point', () => {
+    // Default config: no awaken nodes allocated. mining-xp-i has no prerequisites,
+    // but mining-duration-i is gated behind mining-xp-ii → mining-xp-i, so unlocking
+    // it really costs 3 points (the node + both XP prerequisites).
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    const { advisories } = useSkillPlanner(ref('Mining'), ref(70))
+    const xp = advisories.value.find((a) => a.kind === 'bonus' && a.lever === 'awakenXp')
+    const duration = advisories.value.find(
+      (a) => a.kind === 'bonus' && a.lever === 'awakenDuration',
+    )
+    if (xp?.kind !== 'bonus' || duration?.kind !== 'bonus') throw new Error('no awaken advisories')
+    expect(xp.awakenPointCost).toBe(1)
+    expect(duration.awakenPointCost).toBe(3)
+  })
+
+  it('targets the sanctuary tier the recommended party reaches, with cumulative effects', () => {
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    // Own + awaken three Mining-10 creatures → score 30 → reaches tier 3.
+    const col = useCreatureCollection()
+    for (const id of ['ivan', 'clad', 'kragg']) {
+      col.setOwned(id, true)
+      col.setAwakened(id, true)
+    }
+    const { advisories } = useSkillPlanner(ref('Mining'), ref(70))
+    const sanctuary = advisories.value.find(
+      (a) => a.kind === 'bonus' && a.lever === 'sanctuaryTier',
+    )
+    expect(sanctuary).toBeDefined()
+    if (sanctuary?.kind !== 'bonus') throw new Error('expected bonus advisory')
+    // Headline names the job and shows the final tier the party reaches (3, not 1).
+    expect(sanctuary.label).toBe('Sanctuary - Mining Tier 3')
+    // The before→after progression still rides along in the diff's target delta.
+    expect(sanctuary.partyDiff?.target).toMatchObject({ job: 'Mining', from: 0, to: 3 })
+    // Tier 0→3 grants cumulative XP and duration boosts (before/after for tile + popover).
+    expect(sanctuary.benefits.map((b) => b.kind).toSorted()).toEqual(['duration', 'xp'])
+    expect(sanctuary.benefits.find((b) => b.kind === 'xp')).toMatchObject({ before: 0, after: 120 })
+    expect(sanctuary.benefits.find((b) => b.kind === 'duration')).toMatchObject({
+      before: 0,
+      after: 10,
+    })
+    expect(sanctuary.party?.length).toBe(3)
+  })
+
+  it('offers workstation levers (not sanctuary) for a workstation grind', () => {
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    stockEverything() // levers need a non-empty (unblocked) plan to measure against
+    const { advisories } = useSkillPlanner(ref('Furnace'), ref(50))
+    const levers = advisories.value.flatMap((a) => (a.kind === 'bonus' ? [a.lever] : []))
+    expect(levers).toContain('workstationXp')
+    expect(levers).toContain('workstationSpeed')
+    expect(levers).not.toContain('sanctuaryTier')
+  })
+
+  it('prices a workstation speed node by its unowned XP prerequisite chain', () => {
+    // One XP node owned (furnace-xp-i). Furnace Speed I is gated behind furnace-xp-ii,
+    // so unlocking it costs 2 points (the missing XP prereq + the Speed node), and
+    // the already-owned furnace-xp-i must not be re-charged.
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    useGameConfig().setAwakenWorkstationXpTier('Furnace', 1)
+    stockEverything()
+    const { advisories } = useSkillPlanner(ref('Furnace'), ref(50))
+    const speed = advisories.value.find((a) => a.kind === 'bonus' && a.lever === 'workstationSpeed')
+    const xp = advisories.value.find((a) => a.kind === 'bonus' && a.lever === 'workstationXp')
+    if (speed?.kind !== 'bonus' || xp?.kind !== 'bonus')
+      throw new Error('no workstation advisories')
+    expect(speed.awakenNodeId).toBe('furnace-speed-i')
+    expect(speed.awakenPointCost).toBe(2)
+    // The next XP node (furnace-xp-ii) has its only prereq already owned → 1 point.
+    expect(xp.awakenNodeId).toBe('furnace-xp-ii')
+    expect(xp.awakenPointCost).toBe(1)
+  })
+
+  it('stops a workstation plan short when inventory cannot afford any recipe', () => {
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    // Default inventory is empty → nothing affordable at level 1.
+    const { plan, reachedLevel } = useSkillPlanner(ref('Furnace'), ref(50))
+    expect(plan.value?.segments).toEqual([])
+    expect(reachedLevel.value).toBe(1)
+  })
+
+  it('recomputes the workstation plan reactively when inventory changes', () => {
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    const { plan } = useSkillPlanner(ref('Furnace'), ref(50))
+    expect(plan.value?.segments.length).toBe(0) // empty inventory → no affordable craft
+
+    stockEverything()
+    expect(plan.value?.segments.length).toBeGreaterThan(0)
+  })
+
+  it('leaves gathering plans and reachedLevel untouched by inventory', () => {
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    const { plan, reachedLevel } = useSkillPlanner(ref('Mining'), ref(50))
+    const cyclesBefore = plan.value?.totalCycles
+    expect(reachedLevel.value).toBeNull()
+
+    stockEverything()
+    expect(plan.value?.totalCycles).toBe(cyclesBefore) // inventory is irrelevant to gathering
+  })
+
+  it('credits the workstation queue (queued crafts) toward the plan', () => {
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    // Empty inventory would normally stall at level 1; a big coal queue clears the
+    // target on its own because queued crafts already paid their ingredients.
+    useGameConfig().setQueuedAmounts({ Furnace: { coal: 5000 } })
+    const { plan, reachedLevel } = useSkillPlanner(ref('Furnace'), ref(10))
+    expect(plan.value?.segments.some((s) => (s.queuedCycles ?? 0) > 0)).toBe(true)
+    expect(reachedLevel.value).toBe(10)
+  })
+
+  it('recomputes the workstation plan reactively when the queue changes', () => {
+    useGameConfig().setSkillLevels({ Furnace: 1 })
+    const { plan } = useSkillPlanner(ref('Furnace'), ref(10))
+    expect(plan.value?.segments.length).toBe(0) // empty inventory + no queue → no progress
+
+    useGameConfig().setQueuedAmounts({ Furnace: { coal: 5000 } })
+    expect(plan.value?.segments.some((s) => (s.queuedCycles ?? 0) > 0)).toBe(true)
+  })
+
+  it('includes the player-level boost when lagging skills make the levels cheap', () => {
+    // Mining → 99 while every other skill sits at 1: the source levels are dirt cheap
+    // relative to the huge grind they speed up, so the boost passes the ROI gate.
+    useGameConfig().setSkillLevels({ Mining: 1 })
+    const { advisories } = useSkillPlanner(ref('Mining'), ref(99))
+    expect(advisories.value.some((a) => a.kind === 'playerLevel')).toBe(true)
+  })
+
+  it('suppresses the player-level boost when the detour costs more than it saves', () => {
+    // One high skill (Fishing 70) with everything else at 5: chasing +8 player levels
+    // means raising seven skills 5→15, which takes longer (~6.5h) than it shaves off
+    // the Digging 5→70 grind (~3h). Net-negative right now → the ROI gate drops it.
+    useGameConfig().setSkillLevels({
+      Chopping: 5,
+      Mining: 5,
+      Digging: 5,
+      Exploring: 5,
+      Fishing: 70,
+      Farming: 5,
+      Furnace: 5,
+      Stove: 5,
+      Workbench: 5,
+    })
+    const { advisories } = useSkillPlanner(ref('Digging'), ref(70))
+    expect(advisories.value.some((a) => a.kind === 'playerLevel')).toBe(false)
+  })
+
+  it('suppresses the player-level boost at skill parity (poor ROI)', () => {
+    // All nine skills at 35: there are no cheap "low" skills, so gaining a player
+    // level costs ~30 grinds' worth of time to save a few minutes — the ROI gate
+    // should drop the suggestion entirely.
+    useGameConfig().setSkillLevels({
+      Chopping: 35,
+      Mining: 35,
+      Digging: 35,
+      Exploring: 35,
+      Fishing: 35,
+      Farming: 35,
+      Furnace: 35,
+      Stove: 35,
+      Workbench: 35,
+    })
+    const { advisories } = useSkillPlanner(ref('Mining'), ref(60))
+    expect(advisories.value.some((a) => a.kind === 'playerLevel')).toBe(false)
+  })
+
+  it('reports the player-level delta from raising only this skill', () => {
+    // all skills default to 1 → player level 1; Mining → 99 raises the average
+    const { playerLevelDelta, setOverride } = useSkillPlanner(ref('Mining'), ref(99))
+    setOverride('currentLevel', 1)
+    // floor((8×1 + 99) / 9) = 11, minus baseline 1 = 10
+    expect(playerLevelDelta.value).toBe(10)
+  })
+
+  // The awaken-point sourcing attached to every awaken advisory. Awakening one
+  // creature grants exactly 1 point, so these suggest the cheapest path to it.
+  function awakenSources(skill: string) {
+    useGameConfig().setSkillLevels({ [skill]: 1 })
+    const { advisories } = useSkillPlanner(ref(skill), ref(70))
+    const adv = advisories.value.find((a) => a.kind === 'bonus' && a.lever === 'awakenXp')
+    if (adv?.kind !== 'bonus' || !adv.awakenSources) throw new Error('no awaken advisory')
+    return adv.awakenSources
+  }
+
+  it('suggests owned-but-unawakened creatures, awaken-ready first', () => {
+    const col = useCreatureCollection()
+    // Two Mining creatures owned, not awakened: one at the awaken level, one below.
+    col.setOwned('scoots', true)
+    col.setLevel('scoots', 70) // ready to awaken
+    col.setOwned('slick', true)
+    col.setLevel('slick', 40) // needs leveling first
+
+    const { owned } = awakenSources('Mining')
+    const ids = owned.map((c) => c.id)
+    expect(ids).toContain('scoots')
+    expect(ids).toContain('slick')
+    // Ready creatures rank ahead of ones that still need leveling.
+    expect(ids.indexOf('scoots')).toBeLessThan(ids.indexOf('slick'))
+    expect(owned.find((c) => c.id === 'scoots')).toMatchObject({ ready: true, level: 70 })
+    expect(owned.find((c) => c.id === 'slick')).toMatchObject({ ready: false, level: 40 })
+  })
+
+  it('omits already-awakened creatures from the owned suggestions', () => {
+    const col = useCreatureCollection()
+    col.setOwned('scoots', true)
+    col.setAwakened('scoots', true)
+    expect(awakenSources('Mining').owned.map((c) => c.id)).not.toContain('scoots')
+  })
+
+  it('ranks summon candidates by how close they are to affordable', () => {
+    // Fully stock scoots' summon cost; slick is left one ingredient short.
+    const cfg = useGameConfig()
+    cfg.setInventory('mining-charm', 5)
+    cfg.setInventory('stone', 100)
+
+    const { summon } = awakenSources('Mining')
+    expect(summon[0]).toMatchObject({ id: 'scoots', affordable: true, missingTypes: 0 })
+    const slick = summon.find((c) => c.id === 'slick')
+    expect(slick).toMatchObject({ affordable: false })
+    expect(slick!.missingTypes).toBeGreaterThan(0)
+  })
+
+  // Reachability gate: a summon candidate is only "close" if every missing material
+  // is obtainable at the player's current skill levels.
+  function summonCandidates(skill: string) {
+    const { advisories } = useSkillPlanner(ref(skill), ref(99))
+    const adv = advisories.value.find((a) => a.kind === 'bonus' && a.lever === 'awakenXp')
+    if (adv?.kind !== 'bonus' || !adv.awakenSources) throw new Error('no awaken advisory')
+    return adv.awakenSources.summon
+  }
+
+  // Every skill maxed except Digging, so Scruff's only unreached gate is Volcanic
+  // Rock (Digging 80). Other skills cover its charms/cakes/runes chain.
+  const allMaxExceptDigging = (digging: number) => ({
+    Chopping: 99,
+    Mining: 99,
+    Digging: digging,
+    Exploring: 99,
+    Fishing: 99,
+    Farming: 99,
+    Furnace: 99,
+    Stove: 99,
+    Workbench: 99,
+  })
+
+  it('flags a summon candidate blocked behind a skill level it cannot reach', () => {
+    const col = useCreatureCollection()
+    const { creatures } = useCreatures()
+    // Leave only Scruff un-owned among Digging creatures so it surfaces in the list.
+    for (const c of creatures.value) {
+      if ((c.jobs?.digging ?? 0) > 0 && c.id !== 'scruff') {
+        col.setOwned(c.id, true)
+        col.setAwakened(c.id, true)
+      }
+    }
+
+    // Digging 70 < the Volcanic Rock gate of 80 → blocked, reported as the binding gate.
+    useGameConfig().setSkillLevels(allMaxExceptDigging(70))
+    expect(summonCandidates('Digging').find((c) => c.id === 'scruff')).toMatchObject({
+      reachable: false,
+      blockSkill: 'Digging',
+      blockLevel: 80,
+    })
+
+    // At Digging 80 the gate is met → reachable, no blocker.
+    useGameConfig().setSkillLevels(allMaxExceptDigging(80))
+    const reachable = summonCandidates('Digging').find((c) => c.id === 'scruff')
+    expect(reachable?.reachable).toBe(true)
+    expect(reachable?.blockSkill).toBeUndefined()
+  })
+
+  it('ranks reachable summon candidates ahead of level-gated ones', () => {
+    useGameConfig().setSkillLevels(allMaxExceptDigging(70))
+    const summon = summonCandidates('Digging')
+    // No blocked candidate appears before a reachable one.
+    const firstBlocked = summon.findIndex((c) => !c.reachable)
+    const lastReachable = summon.map((c) => c.reachable).lastIndexOf(true)
+    if (firstBlocked !== -1 && lastReachable !== -1) {
+      expect(firstBlocked).toBeGreaterThan(lastReachable)
+    }
+  })
+})

--- a/src/composables/useExpeditionAllocation.ts
+++ b/src/composables/useExpeditionAllocation.ts
@@ -1,0 +1,346 @@
+import { computed, ref, type Ref } from 'vue'
+
+import type SummoningMaterialTree from '@/components/summoning-planner/SummoningMaterialTree.vue'
+import { biomeMap } from '@/data/entityMaps'
+import { expeditionSourceIndex } from '@/data/indexes'
+import type { Biome, Creature, Expedition } from '@/types'
+import {
+  calculateDuration,
+  calculatePartyScore,
+  getLootAmount,
+  getRecommendedCreatures,
+} from '@/utils/formulas'
+import { getSourceGroup } from '@/utils/planner/plannerSourceGroups'
+
+type TreeRef = InstanceType<typeof SummoningMaterialTree>
+
+export interface ExpeditionPartyVariant {
+  party: { creature: Creature; rating: number }[]
+  durationPerRun: number
+  totalTime: number
+  runsNeeded: number
+}
+
+export interface ExpeditionAllocation {
+  expeditionName: string
+  rewardItemId: string
+  tier: number
+  lootPerRun: number
+  primary: ExpeditionPartyVariant
+  alternatives: ExpeditionPartyVariant[]
+}
+
+export interface CreatureExpeditionEntry {
+  name: string
+  rewardItemId: string
+}
+
+export interface UseExpeditionAllocationOptions {
+  sortedCosts: Ref<{ itemId: string; itemName: string; amount: number }[]>
+  treeRefs: Ref<TreeRef[]>
+  ownedCreaturesList: Ref<Creature[]>
+  collectionLevels: Ref<Record<string, number>>
+}
+
+/**
+ * Expedition party recommendations with deconfliction. For every Expedition-group material
+ * it picks a minimal party (diminishing-returns sized) against a greedily-reserved creature
+ * pool — hardest bottleneck first — exposes per-item variant selection, and detects
+ * creatures double-booked across active parties (the conflict popover).
+ */
+export function useExpeditionAllocation(opts: UseExpeditionAllocationOptions) {
+  const { sortedCosts, treeRefs, ownedCreaturesList, collectionLevels } = opts
+
+  function buildPartyVariant(
+    recommended: { creature: Creature; rating: number; level: number }[],
+    expedition: Expedition,
+    tier: number,
+    targetAmount: number,
+    sourceAmount: number,
+    biome: Biome | undefined,
+  ): ExpeditionPartyVariant | null {
+    if (recommended.length === 0) return null
+
+    // Find minimal party with diminishing returns threshold
+    let bestPartySize = 1
+    let bestTime = Infinity
+
+    for (let size = 1; size <= Math.min(expedition.maxPartySize, recommended.length); size++) {
+      const party = recommended.slice(0, size).map((p) => p.creature)
+      const score = calculatePartyScore(party, expedition, collectionLevels.value, biome)
+      const duration = calculateDuration(score, expedition, tier)
+      const loot = getLootAmount(sourceAmount, tier)
+      const runs = Math.ceil(targetAmount / loot)
+      const totalTime = runs * duration
+
+      if (size === 1) {
+        bestTime = totalTime
+        bestPartySize = 1
+      } else {
+        const improvement = (bestTime - totalTime) / bestTime
+        if (improvement > 0.1) {
+          bestTime = totalTime
+          bestPartySize = size
+        } else {
+          break
+        }
+      }
+    }
+
+    const minimalParty = recommended.slice(0, bestPartySize)
+    const partyCreatures = minimalParty.map((p) => p.creature)
+    const score = calculatePartyScore(partyCreatures, expedition, collectionLevels.value, biome)
+    const loot = getLootAmount(sourceAmount, tier)
+
+    return {
+      party: minimalParty.map((p) => ({ creature: p.creature, rating: p.rating })),
+      durationPerRun: calculateDuration(score, expedition, tier),
+      totalTime: bestTime,
+      runsNeeded: Math.ceil(targetAmount / loot),
+    }
+  }
+
+  // Track user-selected party variant per item
+  const selectedVariantByItem = ref<Record<string, number>>({}) // itemId → variant index (0 = primary)
+
+  const expeditionAllocations = computed(() => {
+    const allocations = new Map<number, ExpeditionAllocation>()
+
+    // 1. Collect all expedition-group items with their best expedition
+    interface ExpeditionEntry {
+      sortedIndex: number
+      itemId: string
+      targetAmount: number
+      expedition: Expedition
+      tier: number
+      sourceAmount: number
+    }
+
+    const entries: ExpeditionEntry[] = []
+    for (let i = 0; i < sortedCosts.value.length; i++) {
+      const cost = sortedCosts.value[i]
+      if (getSourceGroup(cost.itemId) !== 'Expedition') continue
+      const tree = treeRefs.value[i]
+      if (!tree?.expeditionResult?.best) continue
+
+      const best = tree.expeditionResult.best
+      const sources = expeditionSourceIndex.get(cost.itemId)
+      const source = sources?.find((s) => s.expeditionId === best.expedition.id)
+      if (!source) continue
+
+      const targetAmount = tree.rootNode?.requiredAmount ?? cost.amount
+      if (targetAmount <= 0) continue // Fully stocked, no expedition needed
+
+      entries.push({
+        sortedIndex: i,
+        itemId: cost.itemId,
+        targetAmount,
+        expedition: best.expedition,
+        tier: best.tier,
+        sourceAmount: source.amount,
+      })
+    }
+
+    // 2. Sort by total time desc (hardest bottleneck gets first pick of creatures)
+    entries.sort((a, b) => {
+      const timeA = treeRefs.value[a.sortedIndex]?.expeditionResult?.best?.totalTime ?? 0
+      const timeB = treeRefs.value[b.sortedIndex]?.expeditionResult?.best?.totalTime ?? 0
+      return timeB - timeA
+    })
+
+    // 3. Greedily allocate creatures
+    const reservedCreatureIds = new Set<string>()
+
+    for (const entry of entries) {
+      const biome = biomeMap.get(entry.expedition.biome)
+
+      // Primary: best available creatures (excluding reserved)
+      const availableForPrimary = getRecommendedCreatures(
+        ownedCreaturesList.value,
+        entry.expedition,
+        collectionLevels.value,
+        biome,
+        reservedCreatureIds,
+      )
+      const primary = buildPartyVariant(
+        availableForPrimary,
+        entry.expedition,
+        entry.tier,
+        entry.targetAmount,
+        entry.sourceAmount,
+        biome,
+      )
+
+      // Generate alternatives
+      const alternatives: ExpeditionPartyVariant[] = []
+
+      if (primary) {
+        // Alt 1: Use all creatures (ignoring reservations) — shows what's optimal if no conflicts
+        const allCreatures = getRecommendedCreatures(
+          ownedCreaturesList.value,
+          entry.expedition,
+          collectionLevels.value,
+          biome,
+        )
+        const unrestricted = buildPartyVariant(
+          allCreatures,
+          entry.expedition,
+          entry.tier,
+          entry.targetAmount,
+          entry.sourceAmount,
+          biome,
+        )
+        // Only add if different from primary
+        if (unrestricted && unrestricted.totalTime < primary.totalTime * 0.95) {
+          alternatives.push(unrestricted)
+        }
+
+        // Alt 2: Smaller party (1 fewer creature from primary)
+        if (primary.party.length > 1) {
+          const smallerRecommended = availableForPrimary.slice(0, primary.party.length - 1)
+          const smaller = buildPartyVariant(
+            smallerRecommended,
+            entry.expedition,
+            entry.tier,
+            entry.targetAmount,
+            entry.sourceAmount,
+            biome,
+          )
+          if (smaller) {
+            alternatives.push(smaller)
+          }
+        }
+
+        // Reserve creatures from primary party
+        for (const member of primary.party) {
+          reservedCreatureIds.add(member.creature.id)
+        }
+      }
+
+      if (primary) {
+        allocations.set(entry.sortedIndex, {
+          expeditionName: entry.expedition.name,
+          rewardItemId: entry.expedition.rewards[0]?.itemId ?? '',
+          tier: entry.tier,
+          lootPerRun: getLootAmount(entry.sourceAmount, entry.tier),
+          primary,
+          alternatives,
+        })
+      }
+    }
+
+    return allocations
+  })
+
+  function getActiveExpeditionParty(
+    sortedIndex: number,
+  ): (ExpeditionAllocation & { activeVariant: ExpeditionPartyVariant }) | null {
+    const allocation = expeditionAllocations.value.get(sortedIndex)
+    if (!allocation) return null
+    const itemId = sortedCosts.value[sortedIndex]?.itemId
+    const variantIndex = itemId ? (selectedVariantByItem.value[itemId] ?? 0) : 0
+    const activeVariant =
+      variantIndex === 0
+        ? allocation.primary
+        : (allocation.alternatives[variantIndex - 1] ?? allocation.primary)
+    return { ...allocation, activeVariant }
+  }
+
+  function selectExpeditionVariant(itemId: string, variantIndex: number) {
+    selectedVariantByItem.value = { ...selectedVariantByItem.value, [itemId]: variantIndex }
+  }
+
+  /** Get the alternatives to show — swaps active selection back into the list and removes it from alts */
+  function getDisplayedAlternatives(
+    sortedIndex: number,
+  ): { variant: ExpeditionPartyVariant; targetIndex: number }[] {
+    const allocation = expeditionAllocations.value.get(sortedIndex)
+    if (!allocation) return []
+    const itemId = sortedCosts.value[sortedIndex]?.itemId
+    const activeIndex = itemId ? (selectedVariantByItem.value[itemId] ?? 0) : 0
+
+    const result: { variant: ExpeditionPartyVariant; targetIndex: number }[] = []
+
+    // If an alt is active, show the original primary as a swappable option
+    if (activeIndex > 0) {
+      result.push({ variant: allocation.primary, targetIndex: 0 })
+    }
+
+    // Show non-active alternatives
+    for (let i = 0; i < allocation.alternatives.length; i++) {
+      if (i + 1 !== activeIndex) {
+        result.push({ variant: allocation.alternatives[i], targetIndex: i + 1 })
+      }
+    }
+
+    return result
+  }
+
+  // Detect creatures used in multiple active parties
+  const creatureExpeditionMap = computed(() => {
+    const map = new Map<string, CreatureExpeditionEntry[]>()
+    for (const [sortedIndex] of expeditionAllocations.value) {
+      const active = getActiveExpeditionParty(sortedIndex)
+      if (!active) continue
+      const entry: CreatureExpeditionEntry = {
+        name: active.expeditionName,
+        rewardItemId: active.rewardItemId,
+      }
+      for (const member of active.activeVariant.party) {
+        const list = map.get(member.creature.id)
+        if (list) list.push(entry)
+        else map.set(member.creature.id, [entry])
+      }
+    }
+    return map
+  })
+
+  const conflictedCreatureIds = computed(() => {
+    const conflicts = new Set<string>()
+    for (const [id, entries] of creatureExpeditionMap.value) {
+      if (entries.length > 1) conflicts.add(id)
+    }
+    return conflicts
+  })
+
+  // Conflict popover state
+  const conflictPopover = ref<{
+    creatureId: string
+    otherExpeditions: CreatureExpeditionEntry[]
+    style: Record<string, string>
+  } | null>(null)
+
+  function onConflictEnter(creatureId: string, currentExpedition: string, event: MouseEvent) {
+    if (!conflictedCreatureIds.value.has(creatureId)) return
+    const target = event.currentTarget as HTMLElement
+    if (!target) return
+    const rect = target.getBoundingClientRect()
+    const GAP = 8
+    const POPOVER_WIDTH = 288
+    const viewportWidth = document.documentElement.clientWidth
+    let left = rect.left + rect.width / 2 - POPOVER_WIDTH / 2
+    left = Math.max(GAP, Math.min(left, viewportWidth - POPOVER_WIDTH - GAP))
+    const allExpeditions = creatureExpeditionMap.value.get(creatureId) ?? []
+    const otherExpeditions = allExpeditions.filter((e) => e.name !== currentExpedition)
+    conflictPopover.value = {
+      creatureId,
+      otherExpeditions,
+      style: { position: 'fixed', top: `${rect.top - GAP}px`, left: `${left}px` },
+    }
+  }
+
+  function onConflictLeave() {
+    conflictPopover.value = null
+  }
+
+  return {
+    expeditionAllocations,
+    getActiveExpeditionParty,
+    selectExpeditionVariant,
+    getDisplayedAlternatives,
+    conflictedCreatureIds,
+    conflictPopover,
+    onConflictEnter,
+    onConflictLeave,
+  }
+}

--- a/src/composables/useExpeditionLadder.ts
+++ b/src/composables/useExpeditionLadder.ts
@@ -1,0 +1,256 @@
+import { computed, type Ref } from 'vue'
+
+import { useCreatures } from '@/composables/useCreatures'
+import { useGameConfig } from '@/composables/useGameConfig'
+import expeditionsData from '@/data/expeditions.json'
+import type { Expedition } from '@/types'
+import {
+  getTotalCompletedExpeditions,
+  getMaxUnlockedTier,
+  TIER_UNLOCK_REQUIREMENTS,
+} from '@/utils/planner/expeditionUnlocks'
+import type { SaveConfig } from '@/utils/save/parseSave'
+
+const allExpeditions = (expeditionsData as Expedition[]).toSorted((a, b) => {
+  const diff = a.requiredExpeditionCompletions - b.requiredExpeditionCompletions
+  if (diff !== 0) return diff
+  return a.baseRating - b.baseRating
+})
+
+// --- Expedition ladder: compact per-row data for the mockup-faithful list ---
+interface ExpeditionLadderRow {
+  id: string
+  name: string
+  rewardItemId: string | undefined
+  requiredExpeditionCompletions: number
+  tiers: { tier: number; cleared: boolean; unlocked: boolean; completions: number }[]
+  maxTier: number
+  nextTier: number
+  pct: number
+  have: number
+  need: number
+  remaining: number
+  runs: number
+  locked: boolean
+  maxed: boolean
+}
+
+// Expeditions × creatures-on-party — for the Assignments card row.
+// Mirrors /expeditions' resolution pattern (creatures.find by id) so the same
+// localStorage state renders identically here.
+interface AssignmentExpeditionSlot {
+  id: string
+  name: string
+  image: string
+  tier: number
+}
+
+export function useExpeditionLadder(saveConfig: Ref<SaveConfig | null>) {
+  const { creatures } = useCreatures()
+  const { expeditionCompletions, expeditionParties } = useGameConfig()
+
+  // Single source-selection: when a save is loaded, the ladder/frontier/display
+  // computeds read the save's completions; otherwise the persisted config.
+  const completionsSource = computed(() =>
+    saveConfig.value ? saveConfig.value.expeditionCompletions : expeditionCompletions.value,
+  )
+
+  // --- Expedition frontiers: what to unlock next ---
+  const expeditionFrontiers = computed(() => {
+    const items = expeditionDisplay.value.items
+
+    // Next expedition to unlock (first locked one in the sorted list)
+    const nextExpItem = items.find((it) => !it.unlocked)
+    const completions = completionsSource.value
+    const totalRunsCompleted = getTotalCompletedExpeditions(completions)
+    const nextExp = nextExpItem
+      ? {
+          name: nextExpItem.expedition.name,
+          rewardItemId: nextExpItem.expedition.rewards[0]?.itemId,
+          have: totalRunsCompleted,
+          need: nextExpItem.expedition.requiredExpeditionCompletions,
+          remaining: Math.max(
+            0,
+            nextExpItem.expedition.requiredExpeditionCompletions - totalRunsCompleted,
+          ),
+          pct: Math.min(
+            100,
+            Math.round(
+              (totalRunsCompleted / nextExpItem.expedition.requiredExpeditionCompletions) * 100,
+            ),
+          ),
+        }
+      : null
+
+    // Tier-up frontiers: unlocked expeditions with a locked next tier, closest to ready
+    const tierUps = items
+      .filter((it) => it.unlocked)
+      .map((it) => {
+        const lockedTier = it.tiers.find((t) => !t.unlocked)
+        if (!lockedTier) return null
+        const required = TIER_UNLOCK_REQUIREMENTS[lockedTier.tier] ?? 0
+        const prevTierCompletions = completions[it.expedition.id]?.[lockedTier.tier - 1] ?? 0
+        const have = prevTierCompletions
+        const need = required
+        const remaining = lockedTier.remaining
+        const pct = need ? Math.min(100, Math.round((have / need) * 100)) : 0
+        return {
+          name: it.expedition.name,
+          rewardItemId: it.expedition.rewards[0]?.itemId,
+          fromTier: lockedTier.tier - 1,
+          toTier: lockedTier.tier,
+          have,
+          need,
+          remaining,
+          pct,
+        }
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null)
+      .toSorted((a, b) => b.pct - a.pct)
+      .slice(0, 2)
+
+    return { nextExp, tierUps }
+  })
+
+  const expeditionLadder = computed<ExpeditionLadderRow[]>(() => {
+    const completions = completionsSource.value
+    const totalRuns = getTotalCompletedExpeditions(completions)
+    return allExpeditions.map((e) => {
+      const unlocked = totalRuns >= e.requiredExpeditionCompletions
+      const expCompletions = completions[e.id] ?? {}
+      const tierEntries = [1, 2, 3, 4, 5].map((t) => {
+        const cleared = (expCompletions[t] ?? 0) > 0
+        const prevCompletions = expCompletions[t - 1] ?? 0
+        const tierUnlocked =
+          unlocked && (t === 1 || prevCompletions >= (TIER_UNLOCK_REQUIREMENTS[t] ?? 0))
+        return {
+          tier: t,
+          completions: expCompletions[t] ?? 0,
+          cleared,
+          unlocked: tierUnlocked,
+        }
+      })
+      // maxTier is the highest *unlocked* tier (not necessarily run yet) — once
+      // the threshold for the next tier is met, we conceptually move to it even
+      // before the player has done a single run there.
+      const maxTier = unlocked
+        ? Math.max(0, ...tierEntries.filter((t) => t.unlocked).map((t) => t.tier))
+        : 0
+      const nextTier = Math.min(5, maxTier + 1)
+      const need = maxTier > 0 && maxTier < 5 ? (TIER_UNLOCK_REQUIREMENTS[nextTier] ?? 0) : 0
+      const have = maxTier > 0 ? (expCompletions[maxTier] ?? 0) : 0
+      const remaining = Math.max(0, need - have)
+      const pct = need ? Math.min(100, Math.round((have / need) * 100)) : 0
+      const runs = tierEntries.reduce((s, t) => s + t.completions, 0)
+      const locked = !unlocked
+      const maxed = maxTier === 5
+      return {
+        id: e.id,
+        name: e.name,
+        rewardItemId: e.rewards[0]?.itemId,
+        requiredExpeditionCompletions: e.requiredExpeditionCompletions,
+        tiers: tierEntries,
+        maxTier,
+        nextTier,
+        pct,
+        have,
+        need,
+        remaining,
+        runs,
+        locked,
+        maxed,
+      }
+    })
+  })
+
+  const expeditionLadderColumns = computed(() => {
+    const rows = expeditionLadder.value
+    const mid = Math.ceil(rows.length / 2)
+    return [rows.slice(0, mid), rows.slice(mid)]
+  })
+
+  const expeditionPartiesList = computed(() => {
+    // Mirror the Sanctuary/Helpers/Machines swap: when a save is loaded and the
+    // expedition setup hasn't been applied yet, preview the save's party data so
+    // the user can see what `Apply` would set. Otherwise show the persisted ids.
+    const saveParties = saveConfig.value?.currentExpedition?.parties
+    const showSavePreview =
+      !!saveConfig.value && !!saveParties && Object.keys(saveParties).length > 0
+    const parties = showSavePreview ? saveParties : (expeditionParties.value ?? {})
+    return allExpeditions.map((e) => {
+      const partyIds = (parties[e.id] ?? []) as string[]
+      const maxSlots = Math.max(3, e.maxPartySize ?? 3)
+      const slots: (AssignmentExpeditionSlot | null)[] = []
+      for (let i = 0; i < maxSlots; i++) {
+        const id = partyIds[i]
+        if (!id) {
+          slots.push(null)
+          continue
+        }
+        const meta = creatures.value.find((c) => c.id === id)
+        slots.push(
+          meta
+            ? { id: meta.id, name: meta.name, image: meta.image, tier: meta.tier }
+            : { id, name: id, image: '', tier: 0 },
+        )
+      }
+      return {
+        id: e.id,
+        name: e.name,
+        rewardItemId: e.rewards[0]?.itemId,
+        slots,
+      }
+    })
+  })
+
+  const expeditionPartiesAssigned = computed(() => {
+    // Match the source used by expeditionPartiesList so the slot counter stays
+    // in sync with the preview-vs-persisted behaviour.
+    let count = 0
+    for (const exp of expeditionPartiesList.value) {
+      for (const slot of exp.slots) {
+        if (slot) count += 1
+      }
+    }
+    return count
+  })
+
+  const expeditionDisplay = computed(() => {
+    const completions = completionsSource.value
+    const totalCompletions = getTotalCompletedExpeditions(completions)
+    const unlockedCount = allExpeditions.filter(
+      (e) => totalCompletions >= e.requiredExpeditionCompletions,
+    ).length
+
+    const items = allExpeditions.map((expedition) => {
+      const unlocked = totalCompletions >= expedition.requiredExpeditionCompletions
+      const maxTier = unlocked ? getMaxUnlockedTier(expedition.id, completions) : 0
+      const expCompletions = completions[expedition.id]
+      const tiers = [1, 2, 3, 4, 5].map((t) => {
+        const isUnlocked = t <= maxTier
+        const prevTierCount = expCompletions?.[t - 1] ?? 0
+        const required = TIER_UNLOCK_REQUIREMENTS[t] ?? 0
+        const remaining = isUnlocked || t === 1 ? 0 : Math.max(0, required - prevTierCount)
+        return { tier: t, unlocked: isUnlocked || t === 1, remaining }
+      })
+      return { expedition, unlocked, tiers }
+    })
+
+    const totalTiersUnlocked = items.reduce(
+      (sum, item) => sum + (item.unlocked ? item.tiers.filter((t) => t.unlocked).length : 0),
+      0,
+    )
+
+    return { items, unlockedCount, totalTiersUnlocked }
+  })
+
+  return {
+    allExpeditions,
+    expeditionFrontiers,
+    expeditionLadder,
+    expeditionLadderColumns,
+    expeditionDisplay,
+    expeditionPartiesList,
+    expeditionPartiesAssigned,
+  }
+}

--- a/src/composables/useSanctuary.ts
+++ b/src/composables/useSanctuary.ts
@@ -12,7 +12,7 @@ import {
   TIER_THRESHOLDS,
   TIER_THRESHOLDS_RAW,
   MAX_TIER,
-} from '@/utils/sanctuaryConstants'
+} from '@/utils/planner/sanctuaryConstants'
 
 interface JobProgress {
   job: string
@@ -43,12 +43,14 @@ export function useSanctuary() {
   const showExcludedCreatures = ref(false)
   const ownedOnly = ref(true)
 
+  // Rebuilds only when the creature roster changes — not on every party reshuffle.
+  const creatureMap = computed(() => new Map(creatures.value.map((c) => [c.id, c])))
+
   // Party slots (8 fixed slots)
   const partySlots = computed<(Creature | null)[]>(() => {
-    const creatureMap = new Map(creatures.value.map((c) => [c.id, c]))
     const slots: (Creature | null)[] = Array(MAX_SANCTUARY_SLOTS).fill(null)
     for (let i = 0; i < sanctuaryCreatureIds.value.length && i < MAX_SANCTUARY_SLOTS; i++) {
-      slots[i] = creatureMap.get(sanctuaryCreatureIds.value[i]) ?? null
+      slots[i] = creatureMap.value.get(sanctuaryCreatureIds.value[i]) ?? null
     }
     return slots
   })
@@ -56,7 +58,7 @@ export function useSanctuary() {
   const partyCreatureIds = computed(() => new Set(sanctuaryCreatureIds.value))
 
   const isFull = computed(() => sanctuaryCreatureIds.value.length >= MAX_SANCTUARY_SLOTS)
-  const hasEmptySlot = computed(() => sanctuaryCreatureIds.value.length < MAX_SANCTUARY_SLOTS)
+  const hasEmptySlot = computed(() => !isFull.value)
 
   // Raw job scores from sanctuary creatures
   const jobScores = computed(() => {
@@ -310,6 +312,14 @@ export function useSanctuary() {
     setSanctuaryCreatures([])
   }
 
+  // Replace the whole sanctuary party with the given creatures, capped at the slot
+  // limit. `assignCreatureToSlot` is active-slot-based and awkward for bulk swaps, so
+  // this clears the prior roster and fills the first N slots in the given order.
+  // Accepts anything carrying an `id` (full Creature or a recommendation pick).
+  function setParty(party: { id: string }[]) {
+    setSanctuaryCreatures(party.slice(0, MAX_SANCTUARY_SLOTS).map((c) => c.id))
+  }
+
   function getCreatureStatus(id: string): 'helper' | 'machine' | 'expedition' | 'dungeon' | null {
     if (helperCreatureIds.value.includes(id)) return 'helper'
     if (machineCreatureIds.value.includes(id)) return 'machine'
@@ -342,6 +352,7 @@ export function useSanctuary() {
     setTargetTier,
     setAllTargets,
     clearSanctuary,
+    setParty,
 
     // Helpers
     isOwned,

--- a/src/composables/useSkillAdvisories.ts
+++ b/src/composables/useSkillAdvisories.ts
@@ -1,0 +1,480 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+
+import type { AwakenPointSources } from '@/composables/useAwakenPointSources'
+import { itemById } from '@/data/indexes'
+import { awakenNodeNames, awakenPrerequisiteClosure, awakenUnlockCost } from '@/data/upgrades'
+import { t } from '@/i18n'
+import type { Creature } from '@/types'
+import { sanctuaryIcon, toolIcons, upgradesIcon } from '@/utils/format/icons'
+import {
+  getJobBenefits,
+  MAX_SANCTUARY_SLOTS,
+  MAX_TIER,
+  TIER_THRESHOLDS_RAW,
+} from '@/utils/planner/sanctuaryConstants'
+import {
+  buildSanctuaryDiff,
+  recommendPartyForJob,
+  type JobPartyPick,
+  type PlayerLevelBoostStep,
+  type SanctuaryRosterDiff,
+} from '@/utils/planner/skillAdvisories'
+import {
+  AWAKEN_DURATION_PER_TIER,
+  AWAKEN_XP_PER_TIER,
+  buildGatheringPlan,
+  buildWorkstationPlan,
+  getSkillMultipliers,
+  getWorkstationMultipliers,
+  TOOL_XP_PER_LEVEL,
+  WORKSTATION_SPEED_PER_TIER,
+  WORKSTATION_TOOL_SPEED_PER_LEVEL,
+  WORKSTATION_XP_PER_TIER,
+  type SkillActivity,
+  type SkillBonusInputs,
+  type SkillPlan,
+  type WorkstationBonusInputs,
+  type WorkstationPlan,
+  type WorkstationRecipe,
+} from '@/utils/planner/skillPlanner'
+import { calculateJobTiersFromSanctuary } from '@/utils/save/parseSave'
+
+/** Upgrade caps for the bonus-lever advisories (mirrors the awaken/tool config). */
+const AWAKEN_XP_CAP = 6
+const AWAKEN_DURATION_CAP = 4
+const WORKSTATION_XP_CAP = 5
+const WORKSTATION_SPEED_CAP = 4
+const TOOL_LEVEL_CAP = 10
+/** Awaken node ids use roman numerals: index 0 = tier I, …, 5 = tier VI. */
+const AWAKEN_ROMAN = ['i', 'ii', 'iii', 'iv', 'v', 'vi']
+const TOOL_SPEED_DURATION_PER_LEVEL = WORKSTATION_TOOL_SPEED_PER_LEVEL
+
+/**
+ * One benefit dimension changed by an upgrade: the cumulative total from that
+ * source before and after. The tile shows `after`; the popover shows the diff.
+ */
+export interface SkillBoost {
+  kind: 'xp' | 'duration' | 'yield'
+  before: number
+  after: number
+}
+
+/** A single "worth a look" suggestion, ranked by the time it shaves off this grind. */
+export type SkillAdvisory =
+  | {
+      kind: 'bonus'
+      lever: string
+      label: string
+      /** Cumulative source benefit(s) before/after this upgrade (a multi-tier jump may move several). */
+      benefits: SkillBoost[]
+      timeSaved: number
+      routeName: 'sanctuary' | 'awaken' | 'tools'
+      /** In-game icon prefixing the suggestion (sanctuary / awaken / tool). */
+      iconSrc?: string
+      /** Awaken levers: points the node costs and how many are unallocated. */
+      awakenPointCost?: number
+      awakenPointsAvailable?: number
+      /** Awaken levers: the tree (skill) and node to highlight when opened. */
+      awakenTreeId?: string
+      awakenNodeId?: string
+      /** Tool lever: the bar cost of the next upgrade level + tool to highlight. */
+      toolCost?: { itemId: string; itemName: string; amount: number }
+      toolId?: string
+      /** Sanctuary lever: full party that reaches the headline tier. */
+      party?: JobPartyPick[]
+      /** Sanctuary lever: how to turn the live roster into that party, with the
+       * collateral tier moves on other jobs (the shared-party trade-off). */
+      partyDiff?: SanctuaryRosterDiff
+      /** Awaken levers: how to earn the point this node needs. */
+      awakenSources?: AwakenPointSources
+    }
+  | {
+      kind: 'playerLevel'
+      timeSaved: number
+      steps: PlayerLevelStepTime[]
+      totalXpCost: number
+      /** Estimated total time to grind the cheap source levels (≈ time to gain the player level). */
+      levelUpTimeSeconds: number
+      playerLevelFrom: number
+      playerLevelTo: number
+      xpBonusGain: number
+    }
+
+/** A boost step plus the estimated time to raise that one skill at its live bonuses. */
+export type PlayerLevelStepTime = PlayerLevelBoostStep & { timeSeconds: number }
+
+type BonusAdvisory = Extract<SkillAdvisory, { kind: 'bonus' }>
+
+// ----- Pure helper factories (hoisted to module scope) -----
+
+/** A one-dimension boost from `count` tiers/levels to the next, `per` units each. */
+const step = (kind: SkillBoost['kind'], count: number, per: number): SkillBoost[] => [
+  { kind, before: count * per, after: (count + 1) * per },
+]
+
+/** Tag the exact tree/node so "Open" can highlight it. Node ids are
+ * `{skill}-{type}-{roman}` (upgrades.ts). */
+const awakenNodeId = (skill: string, type: 'xp' | 'duration' | 'speed', curTier: number) =>
+  `${skill.toLowerCase()}-${type}-${AWAKEN_ROMAN[curTier]}`
+
+/** The set of awaken nodes already allocated for this skill, derived from the
+ * tracked per-type tier counts (tier N ⇒ the first N nodes of that type). Used
+ * to price a suggestion by its true point cost — node + unowned prerequisites. */
+const allocatedAwakenNodes = (
+  skill: string,
+  tiers: Partial<Record<'xp' | 'duration' | 'speed', number>>,
+) => {
+  const lower = skill.toLowerCase()
+  const set = new Set<string>()
+  for (const type of ['xp', 'duration', 'speed'] as const) {
+    for (let k = 0; k < (tiers[type] ?? 0); k++) set.add(`${lower}-${type}-${AWAKEN_ROMAN[k]}`)
+  }
+  // Owning a node implies owning its prerequisites, so close over them — a
+  // branch node (e.g. Speed) already covers the XP spine gating it, and that
+  // spine must not be re-charged when pricing the next node to buy.
+  return awakenPrerequisiteClosure(set)
+}
+
+/** Reuse the awaken tree's real node name (e.g. "Chopping XP III") for the
+ * advisory headline; fall back to a generic tier label if the id is unknown. */
+const awakenNodeLabel = (skill: string, type: 'xp' | 'duration' | 'speed', curTier: number) =>
+  awakenNodeNames.get(awakenNodeId(skill, type, curTier)) ??
+  t('advisories.skill.awakenNodeFallback', { type, from: curTier, to: curTier + 1 })
+
+const awakenExtra = (
+  skill: string,
+  type: 'xp' | 'duration' | 'speed',
+  curTier: number,
+  allocated: ReadonlySet<string>,
+  awakenPointsAvailable: number,
+  awakenSources: AwakenPointSources,
+): Partial<BonusAdvisory> => ({
+  iconSrc: upgradesIcon,
+  // Unlocking this node may require buying its prerequisite chain too (e.g.
+  // Duration I needs XP II → XP I), so the cost is the full unowned closure.
+  awakenPointCost: awakenUnlockCost(awakenNodeId(skill, type, curTier), allocated),
+  awakenPointsAvailable,
+  awakenTreeId: skill.toLowerCase(),
+  awakenNodeId: awakenNodeId(skill, type, curTier),
+  awakenSources,
+})
+
+/** Next tool level's bar cost: `getUpgradeCost(currentLevel)` → cost to reach level+1. */
+const toolExtra = (
+  tool: { id: string; name: string } | undefined,
+  cost: { barId: string; amount: number } | null | undefined,
+): Partial<BonusAdvisory> => ({
+  iconSrc: tool ? toolIcons[tool.id] : undefined,
+  toolId: tool?.id,
+  toolCost: cost
+    ? {
+        itemId: cost.barId,
+        itemName: itemById.get(cost.barId)?.name ?? cost.barId,
+        amount: cost.amount,
+      }
+    : undefined,
+})
+
+/** Push a bonus advisory onto `out`, deriving `timeSaved` from the `base` time. */
+const pushBonus = (
+  out: SkillAdvisory[],
+  base: number,
+  lever: string,
+  label: string,
+  benefits: SkillBoost[],
+  newTime: number,
+  routeName: 'sanctuary' | 'awaken' | 'tools',
+  extra: Partial<BonusAdvisory> = {},
+) =>
+  out.push({
+    kind: 'bonus',
+    lever,
+    label,
+    benefits,
+    timeSaved: base - newTime,
+    routeName,
+    ...extra,
+  })
+
+// ----- Per-route builders -----
+
+interface AdvisoryContext {
+  skillId: string
+  currentLevel: number
+  targetLevel: number
+  inventoryAmounts: Record<string, number>
+  queuedAmounts: Record<string, Record<string, number>>
+  awakenPointsAvailable: number
+  awakenSources: AwakenPointSources
+  tool: { id: string; name: string } | undefined
+  toolDisplayName: string
+  upgradeCost: (level: number) => { barId: string; amount: number } | null | undefined
+  // Gathering-only:
+  activities: SkillActivity[]
+  creatures: Creature[]
+  sanctuaryCreatureIds: string[]
+  isOwned: (id: string) => boolean
+  isAwakened: (id: string) => boolean
+  // Workstation-only:
+  workstationRecipes: WorkstationRecipe[]
+}
+
+function workstationAdvisories(
+  out: SkillAdvisory[],
+  base: number,
+  inputs: WorkstationBonusInputs,
+  ctx: AdvisoryContext,
+) {
+  const allocated = allocatedAwakenNodes(ctx.skillId, {
+    xp: inputs.awakenXpTier,
+    speed: inputs.awakenSpeedTier,
+  })
+  const timeAt = (mods: WorkstationBonusInputs) =>
+    buildWorkstationPlan(
+      ctx.skillId,
+      ctx.workstationRecipes,
+      ctx.currentLevel,
+      ctx.targetLevel,
+      getWorkstationMultipliers(mods),
+      ctx.inventoryAmounts,
+      ctx.queuedAmounts[ctx.skillId] ?? {},
+    ).totalTimeSeconds
+  if (inputs.awakenXpTier < WORKSTATION_XP_CAP)
+    pushBonus(
+      out,
+      base,
+      'workstationXp',
+      awakenNodeLabel(ctx.skillId, 'xp', inputs.awakenXpTier),
+      step('xp', inputs.awakenXpTier, WORKSTATION_XP_PER_TIER),
+      timeAt({ ...inputs, awakenXpTier: inputs.awakenXpTier + 1 }),
+      'awaken',
+      awakenExtra(
+        ctx.skillId,
+        'xp',
+        inputs.awakenXpTier,
+        allocated,
+        ctx.awakenPointsAvailable,
+        ctx.awakenSources,
+      ),
+    )
+  if (inputs.awakenSpeedTier < WORKSTATION_SPEED_CAP)
+    pushBonus(
+      out,
+      base,
+      'workstationSpeed',
+      awakenNodeLabel(ctx.skillId, 'speed', inputs.awakenSpeedTier),
+      step('duration', inputs.awakenSpeedTier, WORKSTATION_SPEED_PER_TIER),
+      timeAt({ ...inputs, awakenSpeedTier: inputs.awakenSpeedTier + 1 }),
+      'awaken',
+      awakenExtra(
+        ctx.skillId,
+        'speed',
+        inputs.awakenSpeedTier,
+        allocated,
+        ctx.awakenPointsAvailable,
+        ctx.awakenSources,
+      ),
+    )
+  if (inputs.toolLevel < TOOL_LEVEL_CAP)
+    pushBonus(
+      out,
+      base,
+      'toolLevel',
+      t('advisories.skill.toolLevel', {
+        tool: ctx.toolDisplayName,
+        from: inputs.toolLevel,
+        to: inputs.toolLevel + 1,
+      }),
+      inputs.speedMode
+        ? step('duration', inputs.toolLevel, TOOL_SPEED_DURATION_PER_LEVEL)
+        : step('xp', inputs.toolLevel, TOOL_XP_PER_LEVEL),
+      timeAt({ ...inputs, toolLevel: inputs.toolLevel + 1 }),
+      'tools',
+      toolExtra(ctx.tool, ctx.upgradeCost(inputs.toolLevel)),
+    )
+}
+
+function gatheringAdvisories(
+  out: SkillAdvisory[],
+  base: number,
+  inputs: SkillBonusInputs,
+  ctx: AdvisoryContext,
+) {
+  const allocated = allocatedAwakenNodes(ctx.skillId, {
+    xp: inputs.awakenXpTier,
+    duration: inputs.awakenDurationTier,
+  })
+  const timeAt = (mods: SkillBonusInputs) =>
+    buildGatheringPlan(
+      ctx.skillId,
+      ctx.activities,
+      ctx.currentLevel,
+      ctx.targetLevel,
+      getSkillMultipliers(mods),
+    ).totalTimeSeconds
+  // Sanctuary advice targets the tier the recommended (full, owned+awakened)
+  // party actually reaches — so the headline tier, effects, and time saved all
+  // reflect the same setup the chips below show.
+  if (inputs.jobTier < MAX_TIER) {
+    const rec = recommendPartyForJob(
+      ctx.creatures,
+      ctx.skillId.toLowerCase(),
+      TIER_THRESHOLDS_RAW,
+      MAX_SANCTUARY_SLOTS,
+      (id) => ctx.isOwned(id) && ctx.isAwakened(id),
+    )
+    const targetTier = rec.reachedTier
+    if (targetTier > inputs.jobTier) {
+      const before = getJobBenefits(inputs.jobTier)
+      const after = getJobBenefits(targetTier)
+      const benefits: SkillBoost[] = []
+      if (after.xpBonus !== before.xpBonus)
+        benefits.push({ kind: 'xp', before: before.xpBonus, after: after.xpBonus })
+      if (after.durationReduction !== before.durationReduction)
+        benefits.push({
+          kind: 'duration',
+          before: before.durationReduction,
+          after: after.durationReduction,
+        })
+      if (after.yieldBonus !== before.yieldBonus)
+        benefits.push({ kind: 'yield', before: before.yieldBonus, after: after.yieldBonus })
+      const partyDiff = buildSanctuaryDiff(
+        ctx.creatures,
+        ctx.sanctuaryCreatureIds,
+        rec.party,
+        ctx.skillId.toLowerCase(),
+        ctx.skillId,
+        calculateJobTiersFromSanctuary,
+      )
+      pushBonus(
+        out,
+        base,
+        'sanctuaryTier',
+        t('advisories.skill.sanctuaryLabel', { skill: ctx.skillId, tier: targetTier }),
+        benefits,
+        timeAt({ ...inputs, jobTier: targetTier }),
+        'sanctuary',
+        { iconSrc: sanctuaryIcon, party: rec.party, partyDiff },
+      )
+    }
+  }
+  if (inputs.awakenXpTier < AWAKEN_XP_CAP)
+    pushBonus(
+      out,
+      base,
+      'awakenXp',
+      awakenNodeLabel(ctx.skillId, 'xp', inputs.awakenXpTier),
+      step('xp', inputs.awakenXpTier, AWAKEN_XP_PER_TIER),
+      timeAt({ ...inputs, awakenXpTier: inputs.awakenXpTier + 1 }),
+      'awaken',
+      awakenExtra(
+        ctx.skillId,
+        'xp',
+        inputs.awakenXpTier,
+        allocated,
+        ctx.awakenPointsAvailable,
+        ctx.awakenSources,
+      ),
+    )
+  if (inputs.awakenDurationTier < AWAKEN_DURATION_CAP)
+    pushBonus(
+      out,
+      base,
+      'awakenDuration',
+      awakenNodeLabel(ctx.skillId, 'duration', inputs.awakenDurationTier),
+      step('duration', inputs.awakenDurationTier, AWAKEN_DURATION_PER_TIER),
+      timeAt({ ...inputs, awakenDurationTier: inputs.awakenDurationTier + 1 }),
+      'awaken',
+      awakenExtra(
+        ctx.skillId,
+        'duration',
+        inputs.awakenDurationTier,
+        allocated,
+        ctx.awakenPointsAvailable,
+        ctx.awakenSources,
+      ),
+    )
+  if (inputs.toolLevel < TOOL_LEVEL_CAP)
+    pushBonus(
+      out,
+      base,
+      'toolLevel',
+      t('advisories.skill.toolLevel', {
+        tool: ctx.toolDisplayName,
+        from: inputs.toolLevel,
+        to: inputs.toolLevel + 1,
+      }),
+      step('xp', inputs.toolLevel, TOOL_XP_PER_LEVEL),
+      timeAt({ ...inputs, toolLevel: inputs.toolLevel + 1 }),
+      'tools',
+      toolExtra(ctx.tool, ctx.upgradeCost(inputs.toolLevel)),
+    )
+}
+
+interface SkillAdvisoriesDeps {
+  skillId: Ref<string>
+  isWorkstation: Ref<boolean>
+  plan: Ref<SkillPlan | WorkstationPlan | null>
+  currentLevel: Ref<number>
+  targetLevel: Ref<number>
+  gatheringInputs: Ref<SkillBonusInputs>
+  workstationInputs: Ref<WorkstationBonusInputs>
+  activities: Ref<SkillActivity[]>
+  workstationRecipesFor: (skillId: string) => WorkstationRecipe[]
+  awakenPointSources: ComputedRef<AwakenPointSources>
+  inventoryAmounts: Ref<Record<string, number>>
+  queuedAmounts: Ref<Record<string, Record<string, number>>>
+  creatures: Ref<Creature[]>
+  sanctuaryCreatureIds: Ref<string[]>
+  isOwned: (id: string) => boolean
+  isAwakened: (id: string) => boolean
+  getToolBySkillId: (skillId: string) => { id: string; name: string } | undefined
+  getUpgradeCost: (level: number) => { barId: string; amount: number } | null | undefined
+}
+
+/**
+ * Bonus-lever advisories: bump one upgradeable input (sanctuary tier, awaken node,
+ * tool level) by one step, recompute the plan, and report the time it saves. Pure
+ * sensitivity analysis on the same `build*Plan` the planner already uses — no new
+ * math. Ranked by time saved; entries that save nothing (e.g. a yield-only tier)
+ * drop out. Acquisition cost is not modelled here — this answers "which lever helps
+ * most," not "is it worth the materials."
+ */
+export function useSkillAdvisories(deps: SkillAdvisoriesDeps) {
+  const bonusAdvisories = computed<SkillAdvisory[]>(() => {
+    const p = deps.plan.value
+    if (!p || p.segments.length === 0) return []
+    const base = p.totalTimeSeconds
+    const out: SkillAdvisory[] = []
+    const skillId = deps.skillId.value
+    const tool = deps.getToolBySkillId(skillId)
+    const ctx: AdvisoryContext = {
+      skillId,
+      currentLevel: deps.currentLevel.value,
+      targetLevel: deps.targetLevel.value,
+      inventoryAmounts: deps.inventoryAmounts.value,
+      queuedAmounts: deps.queuedAmounts.value,
+      awakenPointsAvailable: deps.inventoryAmounts.value['awaken-points'] ?? 0,
+      awakenSources: deps.awakenPointSources.value,
+      tool,
+      // Name the skill's actual tool (e.g. "Pickaxe"); fall back to a generic label.
+      toolDisplayName: tool?.name ?? t('advisories.skill.toolFallback'),
+      upgradeCost: deps.getUpgradeCost,
+      activities: deps.activities.value,
+      creatures: deps.creatures.value,
+      sanctuaryCreatureIds: deps.sanctuaryCreatureIds.value,
+      isOwned: deps.isOwned,
+      isAwakened: deps.isAwakened,
+      workstationRecipes: deps.workstationRecipesFor(skillId),
+    }
+
+    if (deps.isWorkstation.value) {
+      workstationAdvisories(out, base, deps.workstationInputs.value, ctx)
+    } else {
+      gatheringAdvisories(out, base, deps.gatheringInputs.value, ctx)
+    }
+    return out
+  })
+
+  return { bonusAdvisories }
+}

--- a/src/composables/useSkillOverrides.ts
+++ b/src/composables/useSkillOverrides.ts
@@ -1,0 +1,57 @@
+import { computed, reactive, readonly } from 'vue'
+
+/** Session-only what-if overrides; null means "use the live config value". */
+export interface SkillBonusOverrides {
+  currentLevel: number | null
+  jobTier: number | null
+  awakenXpTier: number | null
+  awakenDurationTier: number | null
+  toolLevel: number | null
+  playerLevel: number | null
+}
+
+function emptyOverrides(): SkillBonusOverrides {
+  return {
+    currentLevel: null,
+    jobTier: null,
+    awakenXpTier: null,
+    awakenDurationTier: null,
+    toolLevel: null,
+    playerLevel: null,
+  }
+}
+
+/** Override value wins unless null (0 is a valid override, so check === null). */
+export function pick<T>(override: T | null, live: T): T {
+  return override === null ? live : override
+}
+
+/**
+ * Session-only what-if overrides for the skill planner: the raw reactive store plus
+ * the mutators and the `hasOverrides` flag. Reads of override values inside the
+ * planner go through the raw `overrides` reactive (so `pick` sees individual keys);
+ * consumers outside get the `readonly` view.
+ */
+export function useSkillOverrides() {
+  const overrides = reactive<SkillBonusOverrides>(emptyOverrides())
+
+  function setOverride<K extends keyof SkillBonusOverrides>(key: K, value: SkillBonusOverrides[K]) {
+    overrides[key] = value
+  }
+
+  function resetOverrides() {
+    Object.assign(overrides, emptyOverrides())
+  }
+
+  const hasOverrides = computed(() =>
+    (Object.keys(overrides) as (keyof SkillBonusOverrides)[]).some((k) => overrides[k] !== null),
+  )
+
+  return {
+    overrides,
+    readonlyOverrides: readonly(overrides),
+    setOverride,
+    resetOverrides,
+    hasOverrides,
+  }
+}

--- a/src/composables/useSkillPlanner.ts
+++ b/src/composables/useSkillPlanner.ts
@@ -1,0 +1,514 @@
+import { computed, type Ref } from 'vue'
+
+import { useAwakenPointSources } from '@/composables/useAwakenPointSources'
+import { useCreatureCollection } from '@/composables/useCreatureCollection'
+import { useCreatures } from '@/composables/useCreatures'
+import { useGameConfig } from '@/composables/useGameConfig'
+import { useSkillAdvisories, type SkillAdvisory } from '@/composables/useSkillAdvisories'
+import { useSkillOverrides } from '@/composables/useSkillOverrides'
+import { pick } from '@/composables/useSkillOverrides'
+import { useTools } from '@/composables/useTools'
+import { items, itemById } from '@/data/indexes'
+import jobsData from '@/data/jobs.json'
+import { getPlayerLevel, getPlayerLevelXpBonus } from '@/utils/formulas'
+import { getJobBenefits } from '@/utils/planner/sanctuaryConstants'
+import { planPlayerLevelBoost, valueBoostOnGrind } from '@/utils/planner/skillAdvisories'
+import {
+  AWAKEN_DURATION_PER_TIER,
+  AWAKEN_XP_PER_TIER,
+  buildGatheringPlan,
+  buildWorkstationPlan,
+  getSkillMultipliers,
+  getWorkstationMultipliers,
+  TOOL_XP_PER_LEVEL,
+  WORKSTATION_SPEED_PER_TIER,
+  WORKSTATION_TOOL_SPEED_PER_LEVEL,
+  WORKSTATION_XP_PER_TIER,
+  type SkillActivity,
+  type SkillBonusInputs,
+  type SkillMultipliers,
+  type SkillPlan,
+  type WorkstationBonusInputs,
+  type WorkstationPlan,
+  type WorkstationRecipe,
+} from '@/utils/planner/skillPlanner'
+
+// Re-export the public types/values consumers import from this module so the
+// decomposition stays invisible to callers (SkillPlanner, components, tests).
+export type {
+  AwakenOwnedCandidate,
+  AwakenPointSources,
+  AwakenSummonCandidate,
+  SummonShortfall,
+} from '@/composables/useAwakenPointSources'
+export type {
+  PlayerLevelStepTime,
+  SkillAdvisory,
+  SkillBoost,
+} from '@/composables/useSkillAdvisories'
+export type { SkillBonusOverrides } from '@/composables/useSkillOverrides'
+
+export const WORKSTATION_IDS = ['Furnace', 'Stove', 'Workbench']
+
+/** Player-level booster advisory: how many levels to chase, and the "cheap" budget
+ * (fraction of the active grind's XP) the source levels must stay within to qualify. */
+const PLAYER_BOOST_MAX_DELTA = 8
+const PLAYER_BOOST_COST_FRACTION = 0.05
+/** ROI gate for the player-level boost: only suggest it if the time to grind the
+ * cheap source levels pays back within this many grinds of the current size. We hold
+ * it to 1 — the detour must save at least as much time on the grind in front of you
+ * as it costs. The permanent +XP also helps future grinds, but that value is
+ * speculative, so we never recommend a detour that's net-negative right now. */
+const PLAYER_BOOST_MAX_PAYBACK_GRINDS = 1
+
+/** Gathering activities by skill id (canonical ids: Chopping, Mining, …). */
+const gatheringActivities = new Map<string, SkillActivity[]>()
+for (const job of jobsData) {
+  if (job.type !== 'skilling' || !Array.isArray(job.activities)) continue
+  gatheringActivities.set(
+    job.id,
+    job.activities.map((a) => ({
+      id: a.id,
+      name: a.name,
+      // Primary output (first drop, chance 1) is the resource this node yields — use its icon.
+      iconItemId: a.output?.[0]?.id ?? a.id,
+      levelRequirement: a.levelRequirement,
+      xpRate: a.xpRate,
+      duration: a.duration,
+    })),
+  )
+}
+
+/** Crafting recipes by workstation (Furnace / Stove / Workbench). */
+const workstationRecipes = new Map<string, WorkstationRecipe[]>()
+for (const item of items) {
+  for (const recipe of item.recipes ?? []) {
+    const ws = recipe.workstation
+    if (!ws) continue
+    const list = workstationRecipes.get(ws) ?? []
+    list.push({
+      itemId: item.id,
+      itemName: item.name,
+      levelRequirement: recipe.levelRequirement,
+      experience: recipe.experience,
+      craftTime: recipe.craftTime,
+      ingredients: recipe.ingredients.map((ing) => ({ id: ing.id, amount: ing.amount })),
+    })
+    workstationRecipes.set(ws, list)
+  }
+}
+
+/** Skill level cap — always offered as a "max out" target preset. */
+export const MAX_SKILL_LEVEL = 99
+
+/** A target preset: a tier-unlock level plus the resource it unlocks (none for max). */
+export interface SkillTierPreset {
+  level: number
+  itemId?: string
+  itemName?: string
+  isMax?: boolean
+}
+
+/**
+ * Per-skill target presets: every level that unlocks a new tier, tagged with the
+ * resource it yields. Gathering tiers use the activity's primary output; for
+ * workstations each level uses the highest-XP/sec recipe unlocked there (what the
+ * planner actually crafts). Each item feeds summons, tool/machine upgrades, or
+ * both — so all major tiers are shown, not just the ones that directly summon.
+ */
+const skillTierPresets = new Map<string, SkillTierPreset[]>()
+for (const [skill, list] of gatheringActivities) {
+  const byLevel = new Map<number, SkillTierPreset>()
+  for (const a of list) {
+    if (byLevel.has(a.levelRequirement)) continue
+    const itemId = a.iconItemId ?? a.id
+    byLevel.set(a.levelRequirement, {
+      level: a.levelRequirement,
+      itemId,
+      itemName: itemById.get(itemId)?.name ?? a.name,
+    })
+  }
+  skillTierPresets.set(
+    skill,
+    [...byLevel.values()].toSorted((x, y) => x.level - y.level),
+  )
+}
+for (const [ws, recipes] of workstationRecipes) {
+  const best = new Map<number, { preset: SkillTierPreset; rate: number }>()
+  for (const r of recipes) {
+    if (r.craftTime <= 0) continue
+    const rate = r.experience / r.craftTime
+    const cur = best.get(r.levelRequirement)
+    if (!cur || rate > cur.rate) {
+      best.set(r.levelRequirement, {
+        rate,
+        preset: { level: r.levelRequirement, itemId: r.itemId, itemName: r.itemName },
+      })
+    }
+  }
+  skillTierPresets.set(
+    ws,
+    [...best.values()].map((b) => b.preset).toSorted((x, y) => x.level - y.level),
+  )
+}
+
+export interface SkillBonusBreakdown {
+  sanctuaryXp: number
+  awakenXp: number
+  playerLevelXp: number
+  toolXp: number
+  sanctuaryDuration: number
+  awakenDuration: number
+}
+
+/**
+ * Reactive planner for a single gathering skill. Reads live state from
+ * `useGameConfig` / `useTools`, applies session-only what-if overrides, and
+ * recomputes the plan when the skill, target, or any override changes.
+ */
+export function useSkillPlanner(skillId: Ref<string>, targetLevel: Ref<number>) {
+  const {
+    skillLevels,
+    jobTiers,
+    awakenGatherUpgrades,
+    awakenSpeedTiers,
+    awakenWorkstationXpTiers,
+    toolLevels,
+    toolSpeedModes,
+    playerLevel,
+    inventoryAmounts,
+    queuedAmounts,
+    sanctuaryCreatureIds,
+  } = useGameConfig()
+  const { getToolBySkillId, getUpgradeCost, xpBonusPerLevel } = useTools()
+  const { creatures } = useCreatures()
+  const { isOwned, isAwakened, getLevel } = useCreatureCollection()
+
+  const { overrides, readonlyOverrides, setOverride, resetOverrides, hasOverrides } =
+    useSkillOverrides()
+
+  const isWorkstation = computed(() => WORKSTATION_IDS.includes(skillId.value))
+
+  const liveCurrentLevel = computed(() => skillLevels.value[skillId.value] ?? 1)
+  const currentLevel = computed(() => pick(overrides.currentLevel, liveCurrentLevel.value))
+
+  const liveToolLevel = computed(() => {
+    const tool = getToolBySkillId(skillId.value)
+    return tool ? (toolLevels.value[tool.id] ?? 0) : 0
+  })
+  const toolLevel = computed(() => pick(overrides.toolLevel, liveToolLevel.value))
+  const effPlayerLevel = computed(() => pick(overrides.playerLevel, playerLevel.value))
+
+  const gatheringInputs = computed<SkillBonusInputs>(() => {
+    const awaken = awakenGatherUpgrades.value[skillId.value]
+    return {
+      jobTier: pick(overrides.jobTier, jobTiers.value[skillId.value] ?? 0),
+      awakenXpTier: pick(overrides.awakenXpTier, awaken?.xpTier ?? 0),
+      awakenDurationTier: pick(overrides.awakenDurationTier, awaken?.durationTier ?? 0),
+      toolLevel: toolLevel.value,
+      playerLevel: effPlayerLevel.value,
+    }
+  })
+
+  const workstationInputs = computed<WorkstationBonusInputs>(() => ({
+    awakenXpTier: pick(overrides.awakenXpTier, awakenWorkstationXpTiers.value[skillId.value] ?? 0),
+    awakenSpeedTier: pick(overrides.awakenDurationTier, awakenSpeedTiers.value[skillId.value] ?? 0),
+    toolLevel: toolLevel.value,
+    speedMode: toolSpeedModes.value[skillId.value] ?? false,
+    playerLevel: effPlayerLevel.value,
+  }))
+
+  const multipliers = computed<SkillMultipliers>(() =>
+    isWorkstation.value
+      ? getWorkstationMultipliers(workstationInputs.value)
+      : getSkillMultipliers(gatheringInputs.value),
+  )
+
+  const bonusBreakdown = computed<SkillBonusBreakdown>(() => {
+    if (isWorkstation.value) {
+      const i = workstationInputs.value
+      return {
+        sanctuaryXp: 0,
+        awakenXp: i.awakenXpTier * WORKSTATION_XP_PER_TIER,
+        playerLevelXp: getPlayerLevelXpBonus(i.playerLevel),
+        toolXp: i.speedMode ? 0 : i.toolLevel * TOOL_XP_PER_LEVEL,
+        sanctuaryDuration: 0,
+        awakenDuration:
+          i.awakenSpeedTier * WORKSTATION_SPEED_PER_TIER +
+          (i.speedMode ? i.toolLevel * WORKSTATION_TOOL_SPEED_PER_LEVEL : 0),
+      }
+    }
+    const i = gatheringInputs.value
+    const benefits = getJobBenefits(i.jobTier)
+    return {
+      sanctuaryXp: benefits.xpBonus,
+      awakenXp: i.awakenXpTier * AWAKEN_XP_PER_TIER,
+      playerLevelXp: getPlayerLevelXpBonus(i.playerLevel),
+      toolXp: i.toolLevel * xpBonusPerLevel,
+      sanctuaryDuration: benefits.durationReduction,
+      awakenDuration: i.awakenDurationTier * AWAKEN_DURATION_PER_TIER,
+    }
+  })
+
+  const activities = computed<SkillActivity[]>(() =>
+    isWorkstation.value ? [] : (gatheringActivities.get(skillId.value) ?? []),
+  )
+
+  const isMaxLevel = computed(
+    () => currentLevel.value >= MAX_SKILL_LEVEL || targetLevel.value <= currentLevel.value,
+  )
+
+  /**
+   * Tier-unlock target presets for this skill, above the current level, plus a
+   * trailing max-level (99) preset so players can always target a full grind.
+   */
+  const targetPresets = computed<SkillTierPreset[]>(() => {
+    const tiers = (skillTierPresets.get(skillId.value) ?? []).filter(
+      (p) => p.level > currentLevel.value,
+    )
+    if (MAX_SKILL_LEVEL > currentLevel.value) {
+      tiers.push({ level: MAX_SKILL_LEVEL, isMax: true })
+    }
+    return tiers
+  })
+
+  /**
+   * Estimated time to raise one skill from `fromLevel` → `toLevel` using the same
+   * plan builders the headline planner uses. Shared by the reactive `plan` (active
+   * skill, its overridden multipliers) and `estimateSkillTime` (other skills, their
+   * live multipliers). Returns 0 if the skill has no plannable data.
+   */
+  function planTimeFor(
+    id: string,
+    fromLevel: number,
+    toLevel: number,
+    mults: SkillMultipliers,
+  ): number {
+    if (toLevel <= fromLevel) return 0
+    if (WORKSTATION_IDS.includes(id)) {
+      const recipes = workstationRecipes.get(id) ?? []
+      if (recipes.length === 0) return 0
+      return buildWorkstationPlan(
+        id,
+        recipes,
+        fromLevel,
+        toLevel,
+        mults,
+        inventoryAmounts.value,
+        queuedAmounts.value[id] ?? {},
+      ).totalTimeSeconds
+    }
+    const acts = gatheringActivities.get(id) ?? []
+    if (acts.length === 0) return 0
+    return buildGatheringPlan(id, acts, fromLevel, toLevel, mults).totalTimeSeconds
+  }
+
+  const plan = computed<SkillPlan | WorkstationPlan | null>(() => {
+    if (isWorkstation.value) {
+      const recipes = workstationRecipes.get(skillId.value) ?? []
+      if (recipes.length === 0) return null
+      return buildWorkstationPlan(
+        skillId.value,
+        recipes,
+        currentLevel.value,
+        targetLevel.value,
+        multipliers.value,
+        inventoryAmounts.value,
+        queuedAmounts.value[skillId.value] ?? {},
+      )
+    }
+    if (activities.value.length === 0) return null
+    return buildGatheringPlan(
+      skillId.value,
+      activities.value,
+      currentLevel.value,
+      targetLevel.value,
+      multipliers.value,
+    )
+  })
+
+  /** Flat aggregated ingredient cost (workstation plans only; empty otherwise). */
+  const ingredientCost = computed<Record<string, number>>(() => {
+    const p = plan.value
+    return p && 'ingredientCost' in p ? p.ingredientCost : {}
+  })
+
+  /** Level the affordable workstation plan reaches (null for gathering plans). */
+  const reachedLevel = computed<number | null>(() => {
+    const p = plan.value
+    return p && 'reachedLevel' in p ? p.reachedLevel : null
+  })
+
+  /** Player-level change from raising only this skill current → target, plus the
+   * global XP bonus that level change grants (applies to every skill, not just this one). */
+  const playerLevelGain = computed(() => {
+    const id = skillId.value
+    const base = skillLevels.value
+    const cur = currentLevel.value
+    const tgt = Math.max(cur, Math.min(99, Math.floor(targetLevel.value)))
+    const before = getPlayerLevel({ ...base, [id]: cur })
+    const after = getPlayerLevel({ ...base, [id]: tgt })
+    return {
+      delta: after - before,
+      levelFrom: before,
+      levelTo: after,
+      xpBonusGain: getPlayerLevelXpBonus(after) - getPlayerLevelXpBonus(before),
+      xpBonusFrom: getPlayerLevelXpBonus(before),
+      xpBonusTo: getPlayerLevelXpBonus(after),
+    }
+  })
+  const playerLevelDelta = computed(() => playerLevelGain.value.delta)
+  const playerLevelXpBonusGain = computed(() => playerLevelGain.value.xpBonusGain)
+
+  /**
+   * Estimated time to raise one (other) skill from `fromLevel` → `toLevel` at that
+   * skill's *live* bonuses (overrides apply only to the active skill, which is never
+   * a boost step). Reuses the same plan builders the planner uses, so the estimate is
+   * consistent with the headline numbers. Returns 0 if the skill has no plannable data.
+   */
+  function estimateSkillTime(id: string, fromLevel: number, toLevel: number): number {
+    if (toLevel <= fromLevel) return 0
+    const tool = getToolBySkillId(id)
+    const toolLvl = tool ? (toolLevels.value[tool.id] ?? 0) : 0
+    if (WORKSTATION_IDS.includes(id)) {
+      return planTimeFor(
+        id,
+        fromLevel,
+        toLevel,
+        getWorkstationMultipliers({
+          awakenXpTier: awakenWorkstationXpTiers.value[id] ?? 0,
+          awakenSpeedTier: awakenSpeedTiers.value[id] ?? 0,
+          toolLevel: toolLvl,
+          speedMode: toolSpeedModes.value[id] ?? false,
+          playerLevel: playerLevel.value,
+        }),
+      )
+    }
+    const awaken = awakenGatherUpgrades.value[id]
+    return planTimeFor(
+      id,
+      fromLevel,
+      toLevel,
+      getSkillMultipliers({
+        jobTier: jobTiers.value[id] ?? 0,
+        awakenXpTier: awaken?.xpTier ?? 0,
+        awakenDurationTier: awaken?.durationTier ?? 0,
+        toolLevel: toolLvl,
+        playerLevel: playerLevel.value,
+      }),
+    )
+  }
+
+  /**
+   * "Worth a look" player-level booster: the largest set of cheap low-skill raises
+   * (other than the one being grinded) whose XP cost stays within a small fraction
+   * of the active grind, valued by the time it shaves off that grind. Null when the
+   * player level is capped or no cheap levels exist. See [[skillAdvisories]].
+   */
+  const playerLevelBoost = computed(() => {
+    const p = plan.value
+    if (!p || p.segments.length === 0) return null
+    const budget = p.totalXp * PLAYER_BOOST_COST_FRACTION
+
+    // Harvest the largest boost whose source XP stays within the cheap budget.
+    let best = null
+    for (let delta = 1; delta <= PLAYER_BOOST_MAX_DELTA; delta++) {
+      const boost = planPlayerLevelBoost(skillLevels.value, delta, skillId.value)
+      if (!boost || boost.totalXpCost > budget) break
+      best = boost
+    }
+    if (!best) return null
+
+    // Estimate the grind time of each cheap source raise; the total ≈ time to gain the level.
+    const steps = best.steps.map((s) => ({
+      ...s,
+      timeSeconds: estimateSkillTime(s.skillId, s.fromLevel, s.toLevel),
+    }))
+    const levelUpTimeSeconds = steps.reduce((sum, s) => sum + s.timeSeconds, 0)
+
+    return {
+      ...best,
+      steps,
+      levelUpTimeSeconds,
+      ...valueBoostOnGrind(best, multipliers.value.xpMultiplier, p.totalTimeSeconds),
+    }
+  })
+
+  const { awakenPointSources } = useAwakenPointSources({
+    skillId,
+    creatures,
+    skillLevels,
+    inventoryAmounts,
+    isOwned,
+    isAwakened,
+    getLevel,
+  })
+
+  const { bonusAdvisories } = useSkillAdvisories({
+    skillId,
+    isWorkstation,
+    plan,
+    currentLevel,
+    targetLevel,
+    gatheringInputs,
+    workstationInputs,
+    activities,
+    workstationRecipesFor: (id) => workstationRecipes.get(id) ?? [],
+    awakenPointSources,
+    inventoryAmounts,
+    queuedAmounts,
+    creatures,
+    sanctuaryCreatureIds,
+    isOwned,
+    isAwakened,
+    getToolBySkillId,
+    getUpgradeCost,
+  })
+
+  /** Unified, ranked "worth a look" list: bonus levers + the player-level boost. */
+  const advisories = computed<SkillAdvisory[]>(() => {
+    const list = [...bonusAdvisories.value]
+    const boost = playerLevelBoost.value
+    // ROI gate: the boost helps this grind and every future one, but at skill parity
+    // its grind cost dwarfs the per-grind saving (~30 grinds to break even). Only
+    // surface it when the cheap source levels pay back within a few grinds — i.e. when
+    // a genuinely lagging skill makes the levels cheap relative to the time they save.
+    if (
+      boost &&
+      boost.timeSaved > 0 &&
+      boost.levelUpTimeSeconds <= boost.timeSaved * PLAYER_BOOST_MAX_PAYBACK_GRINDS
+    ) {
+      list.push({
+        kind: 'playerLevel',
+        timeSaved: boost.timeSaved,
+        steps: boost.steps,
+        totalXpCost: boost.totalXpCost,
+        levelUpTimeSeconds: boost.levelUpTimeSeconds,
+        playerLevelFrom: boost.playerLevelFrom,
+        playerLevelTo: boost.playerLevelTo,
+        xpBonusGain: boost.xpBonusGain,
+      })
+    }
+    return list.filter((a) => a.timeSaved > 0.5).toSorted((a, b) => b.timeSaved - a.timeSaved)
+  })
+
+  return {
+    plan,
+    currentLevel,
+    isWorkstation,
+    isMaxLevel,
+    targetPresets,
+    multipliers,
+    bonusBreakdown,
+    ingredientCost,
+    reachedLevel,
+    playerLevelDelta,
+    playerLevelXpBonusGain,
+    playerLevelGain,
+    advisories,
+    overrides: readonlyOverrides,
+    hasOverrides,
+    setOverride,
+    resetOverrides,
+  }
+}

--- a/src/utils/__tests__/advisoryCheck.test.ts
+++ b/src/utils/__tests__/advisoryCheck.test.ts
@@ -1,0 +1,187 @@
+/** THROWAWAY — end-to-end check that yield-aware gather advisories surface the big lever. */
+import { readFileSync } from 'node:fs'
+
+import { test, expect } from 'vitest'
+
+import { buildPlannerGraph, type PlannerModifiers } from '@/composables/useCraftPlanner'
+import creaturesData from '@/data/creatures.json'
+import { jobActivityIndex } from '@/data/indexes'
+import { computeGatherAdvisories, type GatherLeverSaving } from '@/utils/planner/gatherAdvisories'
+import { computeGoldPerMinute } from '@/utils/planner/goldIncome'
+import { JOB_TIER_BENEFITS } from '@/utils/planner/sanctuaryConstants'
+import { decryptSave } from '@/utils/save/decrypt'
+import { extractSaveConfig } from '@/utils/save/parseSave'
+
+interface Cr {
+  id: string
+  name: string
+  tier: number
+  summoningCost?: { id: string; amount: number }[]
+}
+const CREATURES = creaturesData as Cr[]
+async function loadSave(p: string) {
+  const t = readFileSync(p, 'utf-8')
+  try {
+    return JSON.parse(t) as Record<string, unknown>
+  } catch {
+    return (await decryptSave(t)) as Record<string, unknown>
+  }
+}
+type Graph = ReturnType<typeof buildPlannerGraph>
+type Node = NonNullable<Graph['root']>
+const effective = (n: Node, g: Graph) => {
+  let m = n.defaultMethodId ? g.methodsById[n.defaultMethodId] : null
+  if (m?.kind === 'container')
+    m = n.methods.find((x) => x.kind === 'gather') ?? n.methods.find((x) => x.kind === 'craft') ?? m
+  return m
+}
+const perUnitGather = (n: Node) => {
+  const x = n.methods.find((m) => m.kind === 'gather')
+  return x?.localTimeSeconds != null && n.grossAmount > 0 ? x.localTimeSeconds / n.grossAmount : 0
+}
+
+test('yield-aware advisories', async () => {
+  const raw = await loadSave(process.env.KOLTERA_SAVE ?? 'e2e/fixtures/save.json')
+  const cfg = extractSaveConfig(raw)
+  const mods: PlannerModifiers = {
+    gardenFlowers: {},
+    awakenGatherUpgrades: cfg.awakenGatherUpgrades,
+    awakenSpeedTiers: cfg.awakenSpeedTiers,
+    toolSpeedBonuses: {},
+    jobTiers: cfg.jobTiers,
+    goldPerMinute: computeGoldPerMinute(
+      cfg.creatures.filter((c) => c.awakened).length,
+      cfg.awakenGoldLevel,
+      [],
+    ),
+    machineLevels: cfg.machineLevels,
+    machineRecipes: cfg.machineRecipes,
+    fabricationAllocations: cfg.fabricationAllocations,
+    expeditionTier: 5,
+  }
+  const inv = cfg.inventory
+  const t5 = CREATURES.filter((c) => c.tier === 4 && (c.summoningCost?.length ?? 0) > 0)
+
+  // collect gatherable items (active + passive-direct with a gather alternative) per job
+  const itemJob = new Map<string, string>()
+  const gross = new Map<string, number>()
+  for (const c of t5)
+    for (const ing of c.summoningCost ?? []) {
+      let g: Graph
+      try {
+        g = buildPlannerGraph(ing.id, ing.amount, {}, mods)
+      } catch {
+        continue
+      }
+      if (!g.root) continue
+      const rootEff = effective(g.root, g)
+      if (
+        rootEff &&
+        ['fabrication', 'machine', 'garden'].includes(rootEff.kind) &&
+        perUnitGather(g.root) > 0
+      ) {
+        gross.set(ing.id, (gross.get(ing.id) ?? 0) + g.root.grossAmount)
+        const j = jobActivityIndex.get(ing.id)?.[0]?.jobId
+        if (j) itemJob.set(ing.id, j)
+      }
+      const seen = new Set<string>()
+      const st = [g.root.id]
+      while (st.length) {
+        const id = st.pop()!
+        if (seen.has(id)) continue
+        seen.add(id)
+        const n = g.nodesById[id]
+        if (!n) continue
+        const eff = effective(n, g)
+        if (eff?.kind === 'gather') {
+          gross.set(n.itemId, (gross.get(n.itemId) ?? 0) + n.grossAmount)
+          const j = jobActivityIndex.get(n.itemId)?.[0]?.jobId
+          if (j) itemJob.set(n.itemId, j)
+        }
+        for (const ch of eff?.children ?? []) st.push(ch.nodeId)
+      }
+    }
+
+  const perUnitAt = (itemId: string, m: PlannerModifiers) => {
+    const g = buildPlannerGraph(itemId, 1000, {}, m)
+    const gm = g.root?.methods.find((x) => x.kind === 'gather')
+    return gm?.localTimeSeconds != null ? gm.localTimeSeconds / 1000 : 0
+  }
+  const itemsByJob = new Map<string, { itemId: string; need: number }[]>()
+  for (const [itemId, j] of itemJob) {
+    const need = Math.max(0, (gross.get(itemId) ?? 0) - (inv[itemId] ?? 0))
+    if (need > 0) (itemsByJob.get(j) ?? itemsByJob.set(j, []).get(j)!).push({ itemId, need })
+  }
+  const nextTier = (cur: number) => {
+    const c = JOB_TIER_BENEFITS[cur]
+    for (let t = cur + 1; t < JOB_TIER_BENEFITS.length; t++)
+      if (
+        JOB_TIER_BENEFITS[t].durationReduction > c.durationReduction ||
+        JOB_TIER_BENEFITS[t].yieldBonus > c.yieldBonus
+      )
+        return t
+    return null
+  }
+
+  const savings: GatherLeverSaving[] = []
+  for (const [job, items] of itemsByJob) {
+    const aw = mods.awakenGatherUpgrades[job] ?? { durationTier: 0, yieldBonus: 0, xpTier: 0 }
+    const sumAt = (m: PlannerModifiers) =>
+      items.reduce((s, it) => s + it.need * perUnitAt(it.itemId, m), 0)
+    const cur = sumAt(mods)
+    const tt = nextTier(mods.jobTiers[job] ?? 0)
+    if (tt != null)
+      savings.push({
+        job,
+        lever: 'sanctuary',
+        targetTier: tt,
+        currentSeconds: cur,
+        boostedSeconds: sumAt({ ...mods, jobTiers: { ...mods.jobTiers, [job]: tt } }),
+      })
+    if ((aw.yieldBonus ?? 0) < 2)
+      savings.push({
+        job,
+        lever: 'awakenYield',
+        currentSeconds: cur,
+        boostedSeconds: sumAt({
+          ...mods,
+          awakenGatherUpgrades: {
+            ...mods.awakenGatherUpgrades,
+            [job]: { ...aw, yieldBonus: (aw.yieldBonus ?? 0) + 1 },
+          },
+        }),
+      })
+    if ((aw.durationTier ?? 0) < 4)
+      savings.push({
+        job,
+        lever: 'awakenDuration',
+        currentSeconds: cur,
+        boostedSeconds: sumAt({
+          ...mods,
+          awakenGatherUpgrades: {
+            ...mods.awakenGatherUpgrades,
+            [job]: { ...aw, durationTier: (aw.durationTier ?? 0) + 1 },
+          },
+        }),
+      })
+  }
+
+  const advisories = computeGatherAdvisories(savings).map((a) => ({
+    ...a,
+    savedHours: +(a.timeSavedSeconds / 3600).toFixed(1),
+  }))
+  // eslint-disable-next-line no-console
+  console.log(
+    '\n===== YIELD-AWARE ADVISORIES =====\n' +
+      JSON.stringify(
+        advisories.map((a) => ({
+          headline: a.headline,
+          detail: a.detail,
+          savedHours: a.savedHours,
+        })),
+        null,
+        2,
+      ),
+  )
+  expect(advisories.length).toBeGreaterThan(0)
+})

--- a/src/utils/__tests__/sanctuaryConstants.test.ts
+++ b/src/utils/__tests__/sanctuaryConstants.test.ts
@@ -8,7 +8,7 @@ import {
   JOB_TIER_BENEFITS,
   JOB_COLORS,
   jobTierLabel,
-} from '@/utils/sanctuaryConstants'
+} from '@/utils/planner/sanctuaryConstants'
 
 describe('sanctuaryConstants', () => {
   test('MAX_SANCTUARY_SLOTS is 8', () => {

--- a/src/utils/__tests__/sanctuaryHelpers.test.ts
+++ b/src/utils/__tests__/sanctuaryHelpers.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_TIER,
   MAX_SCORE,
   SCORE_DIVISOR,
-} from '@/utils/sanctuaryConstants'
+} from '@/utils/planner/sanctuaryConstants'
 
 describe('MAX_SCORE', () => {
   test('equals the last tier threshold', () => {

--- a/src/utils/__tests__/skillAdvisories.test.ts
+++ b/src/utils/__tests__/skillAdvisories.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+
+import { getPlayerLevel } from '@/utils/formulas'
+import {
+  buildSanctuaryDiff,
+  planPlayerLevelBoost,
+  recommendPartyForJob,
+  valueBoostOnGrind,
+  PLAYER_XP_PP_PER_LEVEL,
+} from '@/utils/planner/skillAdvisories'
+
+describe('planPlayerLevelBoost', () => {
+  it('raises the cheapest (lowest) skills to gain player levels', () => {
+    // Eight skills already high, one dead skill dragging the average down.
+    const levels: Record<string, number> = {
+      Chopping: 90,
+      Mining: 90,
+      Digging: 90,
+      Exploring: 90,
+      Fishing: 90,
+      Farming: 90,
+      Furnace: 90,
+      Stove: 90,
+      Workbench: 1, // the laggard
+    }
+    const boost = planPlayerLevelBoost(levels, 2)
+    expect(boost).not.toBeNull()
+    // Only the laggard is cheap enough to touch.
+    expect(boost!.steps.map((s) => s.skillId)).toEqual(['Workbench'])
+    expect(boost!.playerLevelTo).toBe(boost!.playerLevelFrom + 2)
+    expect(boost!.xpBonusGain).toBeCloseTo(2 * PLAYER_XP_PP_PER_LEVEL, 6)
+    expect(boost!.totalXpCost).toBeGreaterThan(0)
+    // Cross-check the player-level math against the live formula.
+    const after = { ...levels, Workbench: boost!.steps[0].toLevel }
+    expect(getPlayerLevel(after)).toBe(boost!.playerLevelTo)
+  })
+
+  it('skips the skill you are already planning to grind', () => {
+    const levels: Record<string, number> = {
+      Chopping: 1,
+      Mining: 1,
+      Digging: 1,
+      Exploring: 1,
+      Fishing: 1,
+      Farming: 1,
+      Furnace: 1,
+      Stove: 1,
+      Workbench: 1,
+    }
+    const boost = planPlayerLevelBoost(levels, 1, 'Mining')
+    expect(boost).not.toBeNull()
+    expect(boost!.steps.some((s) => s.skillId === 'Mining')).toBe(false)
+  })
+
+  it('returns null when the player level is already capped', () => {
+    const maxed = Object.fromEntries(
+      [
+        'Chopping',
+        'Mining',
+        'Digging',
+        'Exploring',
+        'Fishing',
+        'Farming',
+        'Furnace',
+        'Stove',
+        'Workbench',
+      ].map((id) => [id, 99]),
+    )
+    expect(planPlayerLevelBoost(maxed, 3)).toBeNull()
+  })
+
+  it('prefers the cheap laggard over an already-high skill (cost asymmetry)', () => {
+    const levels: Record<string, number> = {
+      Chopping: 50,
+      Mining: 50,
+      Digging: 50,
+      Exploring: 50,
+      Fishing: 50,
+      Farming: 50,
+      Furnace: 50,
+      Stove: 50,
+      Workbench: 5,
+    }
+    const boost = planPlayerLevelBoost(levels, 1)!
+    // It should only raise Workbench (far cheaper per level than the L50 skills).
+    expect(boost.steps.map((s) => s.skillId)).toEqual(['Workbench'])
+  })
+})
+
+describe('recommendPartyForJob', () => {
+  const THRESHOLDS = [6, 18, 30, 42, 54]
+  const creatures = [
+    { id: 'a', name: 'A', jobs: { mining: 12 } },
+    { id: 'b', name: 'B', jobs: { mining: 9 } },
+    { id: 'c', name: 'C', jobs: { mining: 7 } },
+    { id: 'd', name: 'D', jobs: { mining: 5 } },
+    { id: 'e', name: 'E', jobs: { mining: 0, chopping: 8 } }, // no mining contribution
+  ]
+
+  it('fills the full party with the top owned+awakened contributors', () => {
+    const eligible = new Set(['a', 'b', 'c']) // only these are summoned & awakened
+    const rec = recommendPartyForJob(creatures, 'mining', THRESHOLDS, 6, (id) => eligible.has(id))
+    // Only eligible mining contributors, sorted by contribution descending.
+    expect(rec.party.map((p) => p.id)).toEqual(['a', 'b', 'c'])
+    expect(rec.score).toBe(28) // 12 + 9 + 7
+    expect(rec.reachedTier).toBe(2) // >= 18 but < 30
+  })
+
+  it('caps the party at the slot count', () => {
+    const rec = recommendPartyForJob(creatures, 'mining', THRESHOLDS, 2, () => true)
+    expect(rec.party.map((p) => p.id)).toEqual(['a', 'b'])
+    expect(rec.score).toBe(21)
+  })
+
+  it('returns an empty party when nothing is eligible', () => {
+    const rec = recommendPartyForJob(creatures, 'mining', THRESHOLDS, 6, () => false)
+    expect(rec.party).toEqual([])
+    expect(rec.reachedTier).toBe(0)
+  })
+})
+
+describe('buildSanctuaryDiff', () => {
+  const creatures = [
+    { id: 'a', name: 'A', jobs: { mining: 12, chopping: 5 } },
+    { id: 'b', name: 'B', jobs: { mining: 9 } },
+    { id: 'c', name: 'C', jobs: { mining: 7, chopping: 10 } },
+    { id: 'd', name: 'D', jobs: { chopping: 20 } }, // dead weight for mining
+    { id: 'e', name: 'E', jobs: { mining: 0, farming: 18 } },
+    { id: 'f', name: 'F', jobs: { mining: 3 } }, // some mining, but not recommended
+  ]
+
+  // Stub for the game's calculateJobTiersFromSanctuary: 10 points = 1 tier.
+  const tiersFor = (ids: string[]): Record<string, number> => {
+    const sums: Record<string, number> = { Mining: 0, Chopping: 0, Farming: 0 }
+    for (const id of ids) {
+      const c = creatures.find((x) => x.id === id)
+      if (!c) continue
+      for (const [job, score] of Object.entries(c.jobs)) {
+        const cap = job.charAt(0).toUpperCase() + job.slice(1)
+        if (cap in sums) sums[cap] += score
+      }
+    }
+    return Object.fromEntries(Object.entries(sums).map(([j, s]) => [j, Math.floor(s / 10)]))
+  }
+
+  it('splits the roster into keep / swap-out / swap-in and reports other-job fallout', () => {
+    const current = ['d', 'e', 'a', 'f']
+    const recommended = [
+      { id: 'a', name: 'A', contribution: 12 },
+      { id: 'b', name: 'B', contribution: 9 },
+      { id: 'c', name: 'C', contribution: 7 },
+    ]
+    const diff = buildSanctuaryDiff(creatures, current, recommended, 'mining', 'Mining', tiersFor)
+
+    // The headline target: current ['d','e','a','f'] mining = 15 (t1) → ['a','b','c'] = 28 (t2).
+    expect(diff.target).toEqual({ job: 'Mining', from: 1, to: 2 })
+    expect(diff.keep.map((c) => c.id)).toEqual(['a'])
+    expect(diff.swapIn.map((c) => c.id)).toEqual(['b', 'c'])
+    // Removed creatures, least useful for this job first (0-contributors lead, f's 3 last).
+    expect(diff.swapOut.map((c) => c.id)).toEqual(['d', 'e', 'f'])
+    expect(diff.swapOut.map((c) => c.contribution)).toEqual([0, 0, 3])
+
+    // Mining (the job being optimized) is excluded; only changed jobs appear.
+    // Chopping: a5+d20=25 (t2) → a5+c10=15 (t1). Farming: e18 (t1) → 0 (t0).
+    expect(diff.sideEffects).toEqual([
+      { job: 'Chopping', from: 2, to: 1 },
+      { job: 'Farming', from: 1, to: 0 },
+    ])
+  })
+
+  it('reports no swaps and no fallout when the roster already is the recommended party', () => {
+    const current = ['a', 'b']
+    const recommended = [
+      { id: 'a', name: 'A', contribution: 12 },
+      { id: 'b', name: 'B', contribution: 9 },
+    ]
+    const diff = buildSanctuaryDiff(creatures, current, recommended, 'mining', 'Mining', tiersFor)
+
+    expect(diff.target).toEqual({ job: 'Mining', from: 2, to: 2 })
+    expect(diff.keep.map((c) => c.id)).toEqual(['a', 'b'])
+    expect(diff.swapIn).toEqual([])
+    expect(diff.swapOut).toEqual([])
+    expect(diff.sideEffects).toEqual([])
+  })
+})
+
+describe('valueBoostOnGrind', () => {
+  it('reduces grind time in proportion to the XP multiplier increase', () => {
+    const boost = {
+      steps: [],
+      totalXpCost: 0,
+      playerLevelFrom: 80,
+      playerLevelTo: 82,
+      xpBonusGain: 0.5, // +0.5 percentage points
+    }
+    // Current stack ×2.0 → new ×2.005; time 1000s → 1000 × 2.0/2.005 ≈ 997.51s.
+    const v = valueBoostOnGrind(boost, 2.0, 1000)
+    expect(v.timeAfter).toBeCloseTo(997.51, 1)
+    expect(v.timeSaved).toBeCloseTo(2.49, 1)
+  })
+})

--- a/src/utils/__tests__/skillPlanner.test.ts
+++ b/src/utils/__tests__/skillPlanner.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect } from 'vitest'
+
+import { xpForSkillLevel } from '@/utils/formulas'
+import { getJobBenefits } from '@/utils/planner/sanctuaryConstants'
+import {
+  buildGatheringPlan,
+  buildWorkstationPlan,
+  getActivityXpPerSec,
+  getSkillMultipliers,
+  getWorkstationMultipliers,
+  type SkillActivity,
+  type SkillMultipliers,
+  type WorkstationRecipe,
+} from '@/utils/planner/skillPlanner'
+
+// The 12-tier gathering progression shared by all 6 gathering skills.
+const PROGRESSION: SkillActivity[] = [
+  { id: 't1', name: 'T1', levelRequirement: 1, xpRate: 2, duration: 8 },
+  { id: 't2', name: 'T2', levelRequirement: 5, xpRate: 3, duration: 9 },
+  { id: 't3', name: 'T3', levelRequirement: 10, xpRate: 4, duration: 10 },
+  { id: 't4', name: 'T4', levelRequirement: 15, xpRate: 6, duration: 11 },
+  { id: 't5', name: 'T5', levelRequirement: 20, xpRate: 8, duration: 12 },
+  { id: 't6', name: 'T6', levelRequirement: 30, xpRate: 10, duration: 13 },
+  { id: 't7', name: 'T7', levelRequirement: 40, xpRate: 14, duration: 14 },
+  { id: 't8', name: 'T8', levelRequirement: 50, xpRate: 20, duration: 16 },
+  { id: 't9', name: 'T9', levelRequirement: 60, xpRate: 26, duration: 20 },
+  { id: 't10', name: 'T10', levelRequirement: 70, xpRate: 36, duration: 25 },
+  { id: 't11', name: 'T11', levelRequirement: 80, xpRate: 60, duration: 35 },
+  { id: 't12', name: 'T12', levelRequirement: 90, xpRate: 120, duration: 45 },
+]
+
+const NEUTRAL: SkillMultipliers = { xpMultiplier: 1, durationMultiplier: 1 }
+
+const zeroInputs = {
+  jobTier: 0,
+  awakenXpTier: 0,
+  awakenDurationTier: 0,
+  toolLevel: 0,
+  playerLevel: 0,
+}
+
+describe('getJobBenefits', () => {
+  it('tier 0 grants nothing', () => {
+    expect(getJobBenefits(0)).toEqual({ xpBonus: 0, durationReduction: 0, yieldBonus: 0 })
+  })
+
+  it('is cumulative across tiers', () => {
+    expect(getJobBenefits(3)).toEqual({ xpBonus: 120, durationReduction: 10, yieldBonus: 0 })
+    expect(getJobBenefits(5)).toEqual({ xpBonus: 120, durationReduction: 20, yieldBonus: 1 })
+  })
+
+  it('clamps tiers beyond the table to the max', () => {
+    expect(getJobBenefits(99)).toEqual(getJobBenefits(5))
+  })
+})
+
+describe('getSkillMultipliers', () => {
+  it('applies only the player-level bonus when everything else is zero', () => {
+    // getPlayerLevelXpBonus(0) = 0.25 percentage points
+    const m = getSkillMultipliers(zeroInputs)
+    expect(m.xpMultiplier).toBeCloseTo(1.0025, 6)
+    expect(m.durationMultiplier).toBe(1)
+  })
+
+  it('player level 99 contributes +25% XP', () => {
+    const m = getSkillMultipliers({ ...zeroInputs, playerLevel: 99 })
+    expect(m.xpMultiplier).toBeCloseTo(1.25, 6)
+  })
+
+  it('tool level adds +5% XP per level', () => {
+    const m = getSkillMultipliers({ ...zeroInputs, toolLevel: 10 })
+    expect(m.xpMultiplier).toBeCloseTo(1 + (0.25 + 50) / 100, 6)
+  })
+
+  it('awaken XP nodes add +10% each', () => {
+    const m = getSkillMultipliers({ ...zeroInputs, awakenXpTier: 2 })
+    expect(m.xpMultiplier).toBeCloseTo(1 + (0.25 + 20) / 100, 6)
+  })
+
+  it('job tier contributes both XP and duration', () => {
+    const m = getSkillMultipliers({ ...zeroInputs, jobTier: 3 })
+    expect(m.xpMultiplier).toBeCloseTo(1 + (0.25 + 120) / 100, 6) // +120% sanctuary XP
+    expect(m.durationMultiplier).toBeCloseTo(0.9, 6) // -10% duration
+  })
+
+  it('awaken duration nodes reduce duration by 5% each', () => {
+    const m = getSkillMultipliers({ ...zeroInputs, awakenDurationTier: 4 })
+    expect(m.durationMultiplier).toBeCloseTo(0.8, 6)
+  })
+
+  it('stacks all XP components additively', () => {
+    const m = getSkillMultipliers({
+      jobTier: 3, // +120 xp, -10 dur
+      awakenXpTier: 2, // +20 xp
+      awakenDurationTier: 4, // -20 dur
+      toolLevel: 10, // +50 xp
+      playerLevel: 99, // +25 xp
+    })
+    expect(m.xpMultiplier).toBeCloseTo(1 + (120 + 20 + 25 + 50) / 100, 6) // ×3.15
+    expect(m.durationMultiplier).toBeCloseTo(1 - (10 + 20) / 100, 6) // ×0.70
+  })
+
+  it('clamps the duration multiplier at 0.01', () => {
+    const m = getSkillMultipliers({ ...zeroInputs, awakenDurationTier: 30 }) // 150% reduction
+    expect(m.durationMultiplier).toBe(0.01)
+  })
+})
+
+describe('getActivityXpPerSec', () => {
+  it('is xpRate / duration with neutral multipliers', () => {
+    expect(getActivityXpPerSec(120, 45, NEUTRAL)).toBeCloseTo(120 / 45, 6) // ≈2.667
+    expect(getActivityXpPerSec(2, 8, NEUTRAL)).toBeCloseTo(0.25, 6)
+  })
+
+  it('scales with multipliers', () => {
+    const m: SkillMultipliers = { xpMultiplier: 2, durationMultiplier: 0.5 }
+    expect(getActivityXpPerSec(120, 45, m)).toBeCloseTo((120 * 2) / (45 * 0.5), 6)
+  })
+
+  it('is monotonic across the progression', () => {
+    const rates = PROGRESSION.map((a) => getActivityXpPerSec(a.xpRate, a.duration, NEUTRAL))
+    for (let i = 1; i < rates.length; i++) {
+      expect(rates[i]).toBeGreaterThan(rates[i - 1])
+    }
+  })
+})
+
+describe('buildGatheringPlan', () => {
+  it('returns an empty plan when target <= current', () => {
+    const plan = buildGatheringPlan('Mining', PROGRESSION, 50, 50, NEUTRAL)
+    expect(plan.segments).toEqual([])
+    expect(plan.totalXp).toBe(0)
+    expect(plan.totalCycles).toBe(0)
+  })
+
+  it('crosses every unlock threshold from 1 to 99', () => {
+    const plan = buildGatheringPlan('Mining', PROGRESSION, 1, 99, NEUTRAL)
+    // boundaries: 1,5,10,15,20,30,40,50,60,70,80,90,99 -> 12 segments
+    expect(plan.segments).toHaveLength(12)
+    expect(plan.segments[0].unlockLevel).toBe(1)
+    expect(plan.segments.at(-1)?.unlockLevel).toBe(90)
+  })
+
+  it('total XP equals the curve delta and band XP sums to it', () => {
+    const plan = buildGatheringPlan('Mining', PROGRESSION, 1, 99, NEUTRAL)
+    const expected = xpForSkillLevel(99) - xpForSkillLevel(1)
+    expect(plan.totalXp).toBe(expected)
+    const summed = plan.segments.reduce((s, seg) => s + seg.bandXp, 0)
+    expect(summed).toBe(expected)
+  })
+
+  it('starts a mid-range plan on the correct unlocked activity', () => {
+    const plan = buildGatheringPlan('Mining', PROGRESSION, 42, 70, NEUTRAL)
+    // active at 42 = highest req <= 42 = the level-40 activity (t7)
+    expect(plan.segments[0].fromLevel).toBe(42)
+    expect(plan.segments[0].unlockLevel).toBe(40)
+    expect(plan.segments[0].activityId).toBe('t7')
+    // unlocks inside (42,70): 50, 60 -> boundaries 42,50,60,70 -> 3 segments
+    expect(plan.segments.map((s) => s.fromLevel)).toEqual([42, 50, 60])
+    expect(plan.segments.map((s) => s.toLevel)).toEqual([50, 60, 70])
+  })
+
+  it('reports whole-number cycle counts and consistent totals', () => {
+    const plan = buildGatheringPlan('Mining', PROGRESSION, 1, 90, NEUTRAL)
+    for (const seg of plan.segments) {
+      expect(Number.isInteger(seg.cycles)).toBe(true)
+      expect(seg.cycles).toBeGreaterThan(0)
+      expect(seg.timeSeconds).toBeCloseTo(seg.cycles * seg.effectiveDuration, 6)
+    }
+    expect(plan.totalCycles).toBe(plan.segments.reduce((s, seg) => s + seg.cycles, 0))
+  })
+
+  it('clamps out-of-range levels into [1, 99]', () => {
+    const plan = buildGatheringPlan('Mining', PROGRESSION, -5, 200, NEUTRAL)
+    expect(plan.currentLevel).toBe(1)
+    expect(plan.targetLevel).toBe(99)
+  })
+})
+
+describe('getWorkstationMultipliers', () => {
+  const base = {
+    awakenXpTier: 0,
+    awakenSpeedTier: 0,
+    toolLevel: 0,
+    speedMode: false,
+    playerLevel: 0,
+  }
+
+  it('applies only the player-level bonus at the zero state', () => {
+    const m = getWorkstationMultipliers(base)
+    expect(m.xpMultiplier).toBeCloseTo(1.0025, 6)
+    expect(m.durationMultiplier).toBe(1)
+  })
+
+  it('awaken workstation XP nodes add +10% each', () => {
+    const m = getWorkstationMultipliers({ ...base, awakenXpTier: 5 })
+    expect(m.xpMultiplier).toBeCloseTo(1 + (0.25 + 50) / 100, 6)
+  })
+
+  it('awaken speed nodes reduce duration by 15% each', () => {
+    const m = getWorkstationMultipliers({ ...base, awakenSpeedTier: 4 })
+    expect(m.durationMultiplier).toBeCloseTo(1 - 60 / 100, 6)
+  })
+
+  it('tool gives XP when not in speed mode', () => {
+    const m = getWorkstationMultipliers({ ...base, toolLevel: 10, speedMode: false })
+    expect(m.xpMultiplier).toBeCloseTo(1 + (0.25 + 50) / 100, 6)
+    expect(m.durationMultiplier).toBe(1)
+  })
+
+  it('tool converts to duration (and forfeits XP) in speed mode', () => {
+    const m = getWorkstationMultipliers({ ...base, toolLevel: 10, speedMode: true })
+    expect(m.xpMultiplier).toBeCloseTo(1.0025, 6) // only player level
+    expect(m.durationMultiplier).toBeCloseTo(1 - 20 / 100, 6) // 10 × 2%
+  })
+})
+
+describe('buildWorkstationPlan', () => {
+  const RECIPES: WorkstationRecipe[] = [
+    {
+      itemId: 'a',
+      itemName: 'A',
+      levelRequirement: 1,
+      experience: 10,
+      craftTime: 10,
+      ingredients: [{ id: 'wood', amount: 2 }],
+    },
+    {
+      itemId: 'b',
+      itemName: 'B',
+      levelRequirement: 1,
+      experience: 5,
+      craftTime: 10,
+      ingredients: [{ id: 'wood', amount: 9 }],
+    },
+    {
+      itemId: 'c',
+      itemName: 'C',
+      levelRequirement: 10,
+      experience: 40,
+      craftTime: 10,
+      ingredients: [{ id: 'ore', amount: 3 }],
+    },
+  ]
+
+  // Enough of everything that inventory never constrains the plan.
+  const ABUNDANT: Record<string, number> = { wood: 1e9, ore: 1e9 }
+
+  it('picks the best XP/sec affordable recipe per band', () => {
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 20, NEUTRAL, ABUNDANT)
+    // band [1,10] → A beats B (1.0 vs 0.5 xp/s); band [10,20] → C (4.0)
+    expect(plan.segments.map((s) => s.activityId)).toEqual(['a', 'c'])
+    expect(plan.reachedLevel).toBe(20)
+    // Single-recipe items carry no variant tag (nothing to disambiguate).
+    expect(plan.segments.every((s) => s.variantItemId === undefined)).toBe(true)
+  })
+
+  it('tags and separates recipe variants of one item (e.g. Helmet by its bar)', () => {
+    // Helmet has two variants sharing `hammer` but differing by bar. The high-bar
+    // variant has the better rate, so it goes first until its bar runs out, then the
+    // grind cascades to the low-bar variant — two distinct "Helmet" bands.
+    const HELMETS: WorkstationRecipe[] = [
+      {
+        itemId: 'helmet',
+        itemName: 'Helmet',
+        levelRequirement: 1,
+        experience: 20,
+        craftTime: 10,
+        ingredients: [
+          { id: 'hammer', amount: 1 },
+          { id: 'gold-bar', amount: 1 },
+        ],
+      },
+      {
+        itemId: 'helmet',
+        itemName: 'Helmet',
+        levelRequirement: 1,
+        experience: 30,
+        craftTime: 10,
+        ingredients: [
+          { id: 'hammer', amount: 1 },
+          { id: 'solarite-bar', amount: 1 },
+        ],
+      },
+    ]
+    // Solarite is scarce (5), gold abundant → solarite helmets first, then gold.
+    const plan = buildWorkstationPlan('Furnace', HELMETS, 1, 10, NEUTRAL, {
+      hammer: 1e9,
+      'solarite-bar': 5,
+      'gold-bar': 1e9,
+    })
+    expect(plan.segments.every((s) => s.activityId === 'helmet')).toBe(true)
+    expect(plan.segments.length).toBeGreaterThanOrEqual(2) // distinct variants don't merge
+    expect(plan.segments[0].variantItemId).toBe('solarite-bar')
+    expect(plan.segments[1].variantItemId).toBe('gold-bar')
+    expect(plan.segments[0].xpPerSec).toBeGreaterThan(plan.segments[1].xpPerSec)
+  })
+
+  it('aggregates consumed ingredient cost and matches the XP curve with abundant inventory', () => {
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 20, NEUTRAL, ABUNDANT)
+    expect(plan.totalXp).toBe(xpForSkillLevel(20))
+    const aCycles = Math.ceil((xpForSkillLevel(10) - xpForSkillLevel(1)) / 10)
+    // C continues from where A overshot the level-10 threshold (carryover XP).
+    const cCycles = Math.ceil((xpForSkillLevel(20) - aCycles * 10) / 40)
+    expect(plan.ingredientCost.wood).toBe(aCycles * 2)
+    expect(plan.ingredientCost.ore).toBe(cCycles * 3)
+  })
+
+  it('returns an empty plan when target <= current', () => {
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 30, 30, NEUTRAL, ABUNDANT)
+    expect(plan.segments).toEqual([])
+    expect(plan.ingredientCost).toEqual({})
+    expect(plan.reachedLevel).toBe(30)
+  })
+
+  it('switches to the next affordable recipe when the best one depletes mid-grind', () => {
+    // A (best) and B (worse) unlock together but use different materials. With X
+    // scarce and Y abundant, the path crafts A until X runs out, then falls to B.
+    const R2: WorkstationRecipe[] = [
+      {
+        itemId: 'a',
+        itemName: 'A',
+        levelRequirement: 1,
+        experience: 10,
+        craftTime: 10,
+        ingredients: [{ id: 'x', amount: 2 }],
+      },
+      {
+        itemId: 'b',
+        itemName: 'B',
+        levelRequirement: 1,
+        experience: 8,
+        craftTime: 10,
+        ingredients: [{ id: 'y', amount: 2 }],
+      },
+    ]
+    const plan = buildWorkstationPlan('Furnace', R2, 1, 20, NEUTRAL, { x: 10, y: 1e9 })
+    const ids = plan.segments.map((s) => s.activityId)
+    expect(ids[0]).toBe('a')
+    expect(ids).toContain('b')
+    expect(plan.ingredientCost.x).toBe(10) // all of X consumed before the switch
+    expect(plan.reachedLevel).toBe(20) // Y is abundant, so it still reaches target
+  })
+
+  it('stops at the starting level when nothing is affordable', () => {
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 20, NEUTRAL, {})
+    expect(plan.segments).toEqual([])
+    expect(plan.reachedLevel).toBe(1)
+  })
+
+  it('stops before target when materials run out partway', () => {
+    // Exactly enough wood for a few A crafts, no ore → can never reach C's tier.
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 20, NEUTRAL, { wood: 6 })
+    expect(plan.reachedLevel).toBeLessThan(20)
+    expect(plan.ingredientCost.wood).toBe(6) // consumed all wood, no more
+  })
+
+  it('reaches the target and reports reachedLevel when inventory suffices', () => {
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 12, NEUTRAL, ABUNDANT)
+    expect(plan.reachedLevel).toBe(12)
+    expect(plan.totalCycles).toBeGreaterThan(0)
+  })
+
+  it('marks the queued fraction of a band (partial bar), not the whole card', () => {
+    // 5 of 'a' are queued, but the band needs many more 'a' to progress — the bar
+    // shows only 5 of the band's cycles as queued, never a full fill.
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 5, NEUTRAL, ABUNDANT, { a: 5 })
+    const seg = plan.segments[0]
+    expect(seg.activityId).toBe('a')
+    expect(seg.queuedCycles).toBe(5)
+    expect(seg.cycles).toBeGreaterThan(5) // queued < total → partial, not full
+  })
+
+  it('fully marks a band as queued only when the queue covers all of its crafts', () => {
+    // Queue covers the entire grind: c at level 10 → 12, queued amount exceeds need.
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 10, 12, NEUTRAL, {}, { c: 100 })
+    expect(plan.segments).toHaveLength(1)
+    const seg = plan.segments[0]
+    expect(seg.activityId).toBe('c')
+    expect(seg.queuedCycles).toBe(seg.cycles) // entirely in queue → full bar
+    expect(seg.timeSeconds).toBe(0) // no remaining work
+    expect(plan.reachedLevel).toBe(12)
+  })
+
+  it('lets the queue reach the target even with no inventory (mats already paid)', () => {
+    // c is queued and unlocked at level 10; empty inventory still reaches 12 because
+    // the queued crafts already paid their ingredients.
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 10, 12, NEUTRAL, {}, { c: 100 })
+    expect(plan.reachedLevel).toBe(12)
+    expect(plan.ingredientCost).toEqual({}) // nothing drawn from inventory
+  })
+
+  it('excludes buy-only queued items (no craft recipe) from queue credit', () => {
+    // A buy-only item has no workstation recipe, so it can't be crafted/queued and
+    // earns no skill XP — it must not contribute queuedCycles or change the plan.
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 5, NEUTRAL, ABUNDANT, {
+      'bought-charm': 9999,
+    })
+    expect(plan.segments.every((s) => (s.queuedCycles ?? 0) === 0)).toBe(true)
+    const baseline = buildWorkstationPlan('Furnace', RECIPES, 1, 5, NEUTRAL, ABUNDANT)
+    expect(plan.totalCycles).toBe(baseline.totalCycles)
+    expect(plan.reachedLevel).toBe(baseline.reachedLevel)
+  })
+
+  it('does not spend inventory on queued crafts (only non-queued crafts consume mats)', () => {
+    // Queue covers 5 'a' (free); 4 wood affords 2 more 'a'; then it blocks.
+    const plan = buildWorkstationPlan('Furnace', RECIPES, 1, 5, NEUTRAL, { wood: 4 }, { a: 5 })
+    const seg = plan.segments[0]
+    expect(seg.activityId).toBe('a')
+    expect(seg.queuedCycles).toBe(5)
+    expect(seg.cycles).toBe(7) // 5 queued + 2 affordable
+    expect(plan.ingredientCost.wood).toBe(4) // only the 2 non-queued crafts cost wood
+    expect(plan.reachedLevel).toBeLessThan(5) // out of wood before the target
+  })
+
+  it('orders the in-progress queue first, even if another recipe has higher XP/sec', () => {
+    // 'slow' (rate 0.5) is in the queue (already crafting); 'fast' (rate 2.0) is
+    // affordable. The queued item must lead the grind path, not the optimal one.
+    const ORDER: WorkstationRecipe[] = [
+      {
+        itemId: 'slow',
+        itemName: 'Slow',
+        levelRequirement: 1,
+        experience: 10,
+        craftTime: 20,
+        ingredients: [{ id: 'x', amount: 1 }],
+      },
+      {
+        itemId: 'fast',
+        itemName: 'Fast',
+        levelRequirement: 1,
+        experience: 20,
+        craftTime: 10,
+        ingredients: [{ id: 'y', amount: 1 }],
+      },
+    ]
+    const plan = buildWorkstationPlan('Stove', ORDER, 1, 5, NEUTRAL, { y: 1e9 }, { slow: 3 })
+    expect(plan.segments[0]).toMatchObject({ activityId: 'slow', queuedCycles: 3 })
+    // 'fast' still runs for the remainder, but only after the queued 'slow'.
+    expect(plan.segments.findIndex((s) => s.activityId === 'fast')).toBeGreaterThan(0)
+  })
+
+  it('shows only the queue when it already covers the whole grind (no extra recipe)', () => {
+    // Mirrors the real bug: deep into a level with a huge queue of one item — the
+    // queue alone clears the target, so no other (higher-XP/sec) recipe is added.
+    const ORDER: WorkstationRecipe[] = [
+      {
+        itemId: 'slow',
+        itemName: 'Slow',
+        levelRequirement: 1,
+        experience: 10,
+        craftTime: 20,
+        ingredients: [{ id: 'x', amount: 1 }],
+      },
+      {
+        itemId: 'fast',
+        itemName: 'Fast',
+        levelRequirement: 1,
+        experience: 20,
+        craftTime: 10,
+        ingredients: [{ id: 'y', amount: 1 }],
+      },
+    ]
+    const plan = buildWorkstationPlan('Stove', ORDER, 1, 5, NEUTRAL, { y: 1e9 }, { slow: 100000 })
+    expect(plan.segments).toHaveLength(1)
+    expect(plan.segments[0].activityId).toBe('slow')
+    expect(plan.segments.some((s) => s.activityId === 'fast')).toBe(false)
+  })
+})

--- a/src/utils/planner/sanctuaryConstants.ts
+++ b/src/utils/planner/sanctuaryConstants.ts
@@ -28,6 +28,22 @@ export const JOB_TIER_BENEFITS = [
   { xpBonus: 120, durationReduction: 20, yieldBonus: 1 },
 ]
 
+export interface JobTierBenefits {
+  xpBonus: number
+  durationReduction: number
+  yieldBonus: number
+}
+
+/**
+ * Cumulative sanctuary benefits for a job at the given tier (0–MAX_TIER).
+ * `JOB_TIER_BENEFITS` is already cumulative-by-tier, so this just indexes it
+ * with clamping. Matches the game's `SanctuaryHelpers.getJobBenefits`.
+ */
+export function getJobBenefits(tier: number): JobTierBenefits {
+  const idx = Math.max(0, Math.min(Math.floor(tier), MAX_TIER))
+  return JOB_TIER_BENEFITS[idx] ?? JOB_TIER_BENEFITS[0]
+}
+
 export function jobTierLabel(tier: number, shortDuration = false): string {
   const b = JOB_TIER_BENEFITS[tier] ?? JOB_TIER_BENEFITS[0]
   if (tier === 0) return t('sanctuary.noBonuses')

--- a/src/utils/planner/skillAdvisories.ts
+++ b/src/utils/planner/skillAdvisories.ts
@@ -1,0 +1,228 @@
+import { getPlayerLevel, SKILLING_IDS, xpForSkillLevel } from '@/utils/formulas'
+
+/** Player level grants +0.25 percentage points of XP per level (additive). */
+export const PLAYER_XP_PP_PER_LEVEL = 0.25
+
+export interface PlayerLevelBoostStep {
+  skillId: string
+  fromLevel: number
+  toLevel: number
+  levelsAdded: number
+}
+
+export interface PlayerLevelBoost {
+  steps: PlayerLevelBoostStep[]
+  /** Total XP to raise the listed skills (the cheap source levels). */
+  totalXpCost: number
+  playerLevelFrom: number
+  playerLevelTo: number
+  /** Global XP bonus gained, in percentage points. */
+  xpBonusGain: number
+}
+
+const clamp = (n: number) => Math.max(1, Math.min(99, Math.floor(n)))
+
+/**
+ * Cheapest set of skill-level raises that lift the player level by `targetDeltaPl`.
+ *
+ * Player level = floor(average of all 9 skills), so the cheapest way to add total
+ * levels is always to raise the lowest-level skill (it has the smallest next-level
+ * XP cost). We greedily do that until the player level climbs by the requested
+ * amount. `excludeSkillId` skips the skill you're already planning to grind, so the
+ * advice is about *other* lagging skills. Returns null if the player level is capped
+ * or can't move.
+ */
+export function planPlayerLevelBoost(
+  skillLevels: Record<string, number>,
+  targetDeltaPl: number,
+  excludeSkillId?: string,
+): PlayerLevelBoost | null {
+  const levels: Record<string, number> = {}
+  for (const id of SKILLING_IDS) levels[id] = clamp(skillLevels[id] ?? 1)
+  const start = { ...levels }
+  const plFrom = getPlayerLevel(levels)
+  if (plFrom >= 99) return null
+  const plTarget = Math.min(99, plFrom + Math.max(1, Math.floor(targetDeltaPl)))
+
+  let totalXpCost = 0
+  while (getPlayerLevel(levels) < plTarget) {
+    let pick: string | null = null
+    let minCost = Infinity
+    for (const id of SKILLING_IDS) {
+      if (id === excludeSkillId || levels[id] >= 99) continue
+      const next = xpForSkillLevel(levels[id] + 1) - xpForSkillLevel(levels[id])
+      if (next < minCost) {
+        minCost = next
+        pick = id
+      }
+    }
+    if (!pick) break // every eligible skill is maxed
+    levels[pick] += 1
+    totalXpCost += minCost
+  }
+
+  const plTo = getPlayerLevel(levels)
+  if (plTo <= plFrom) return null
+
+  const steps: PlayerLevelBoostStep[] = SKILLING_IDS.filter((id) => levels[id] > start[id])
+    .map((id) => ({
+      skillId: id,
+      fromLevel: start[id],
+      toLevel: levels[id],
+      levelsAdded: levels[id] - start[id],
+    }))
+    .sort((a, b) => a.fromLevel - b.fromLevel || a.skillId.localeCompare(b.skillId))
+
+  return {
+    steps,
+    totalXpCost,
+    playerLevelFrom: plFrom,
+    playerLevelTo: plTo,
+    xpBonusGain: (plTo - plFrom) * PLAYER_XP_PP_PER_LEVEL,
+  }
+}
+
+export interface JobPartyPick {
+  id: string
+  name: string
+  contribution: number
+}
+
+export interface JobPartyRecommendation {
+  party: JobPartyPick[]
+  score: number
+  reachedTier: number
+}
+
+/**
+ * Best sanctuary party for a single gathering job. Job score is just the sum of
+ * each slotted creature's `jobs[jobKey]` (no awaken multiplier — see useSanctuary),
+ * so for one job the optimal party is simply the top contributors. The sanctuary
+ * party is a *fixed* set of slots, so this fills the whole party (up to `maxSlots`)
+ * with the best eligible creatures — `isEligible` must restrict to creatures the
+ * player has summoned AND awakened. `reachedTier` reports how far that full party
+ * pushes the job's tier.
+ */
+export function recommendPartyForJob(
+  creatures: { id: string; name: string; jobs?: Record<string, number> }[],
+  jobKey: string,
+  thresholdsRaw: number[],
+  maxSlots: number,
+  isEligible: (id: string) => boolean,
+): JobPartyRecommendation {
+  const party = creatures
+    .filter((c) => isEligible(c.id) && (c.jobs?.[jobKey] ?? 0) > 0)
+    .map((c) => ({ id: c.id, name: c.name, contribution: c.jobs?.[jobKey] ?? 0 }))
+    .sort((a, b) => b.contribution - a.contribution)
+    .slice(0, maxSlots)
+
+  const score = party.reduce((sum, pick) => sum + pick.contribution, 0)
+  const reachedTier = thresholdsRaw.filter((t) => score >= t).length
+  return { party, score, reachedTier }
+}
+
+/** A job whose sanctuary tier changes when the recommended party is applied. */
+export interface JobTierDelta {
+  /** Capitalized job name (e.g. 'Chopping'). */
+  job: string
+  from: number
+  to: number
+}
+
+/**
+ * The concrete roster change to turn the player's *current* sanctuary into the
+ * party recommended for one job, plus the collateral tier moves it causes.
+ */
+export interface SanctuaryRosterDiff {
+  /** The job being optimized and how far these swaps lift its tier — the headline
+   * change the swaps below are responsible for. */
+  target: JobTierDelta
+  /** Recommended members already slotted — no action needed. */
+  keep: JobPartyPick[]
+  /** Currently slotted but not in the recommended party — remove these. Least
+   * useful for this job first (a 0-contribution creature is pure dead weight). */
+  swapOut: JobPartyPick[]
+  /** Recommended members not yet slotted — add these. Best first. */
+  swapIn: JobPartyPick[]
+  /** Other jobs whose tier shifts because the sanctuary's 8 slots are shared.
+   * Biggest loss first; only jobs that actually change are listed. */
+  sideEffects: JobTierDelta[]
+}
+
+/**
+ * Diff the player's live sanctuary roster against the single-job-optimal party
+ * from {@link recommendPartyForJob}. Because the sanctuary is one shared 8-slot
+ * party, swapping toward one job's best team rebalances every other job — so this
+ * also reports the collateral tier moves via the injected `jobTiersFor` (the game's
+ * `calculateJobTiersFromSanctuary`). `thisJob` is the capitalized name of the job
+ * being optimized, excluded from the side-effect list.
+ */
+export function buildSanctuaryDiff(
+  creatures: { id: string; name: string; jobs?: Record<string, number> }[],
+  currentIds: string[],
+  recommended: JobPartyPick[],
+  jobKey: string,
+  thisJob: string,
+  jobTiersFor: (ids: string[]) => Record<string, number>,
+): SanctuaryRosterDiff {
+  const byId = new Map(creatures.map((c) => [c.id, c]))
+  const currentSet = new Set(currentIds)
+  const recommendedSet = new Set(recommended.map((p) => p.id))
+
+  const keep = recommended.filter((p) => currentSet.has(p.id))
+  const swapIn = recommended.filter((p) => !currentSet.has(p.id))
+  const swapOut = currentIds
+    .filter((id) => !recommendedSet.has(id))
+    .map((id) => {
+      const c = byId.get(id)
+      return { id, name: c?.name ?? id, contribution: c?.jobs?.[jobKey] ?? 0 }
+    })
+  // Keep currentIds (slot) order so the remove list matches the sanctuary party slots.
+
+  const before = jobTiersFor(currentIds)
+  const after = jobTiersFor([...keep, ...swapIn].map((p) => p.id))
+  const sideEffects: JobTierDelta[] = []
+  for (const job of Object.keys(before)) {
+    if (job === thisJob) continue
+    const from = before[job] ?? 0
+    const to = after[job] ?? 0
+    if (from !== to) sideEffects.push({ job, from, to })
+  }
+  // Biggest tier loss first; gains (rare) sort last.
+  const ordered = sideEffects.toSorted((a, b) => a.to - a.from - (b.to - b.from))
+
+  const target: JobTierDelta = {
+    job: thisJob,
+    from: before[thisJob] ?? 0,
+    to: after[thisJob] ?? 0,
+  }
+
+  return { target, keep, swapOut, swapIn, sideEffects: ordered }
+}
+
+export interface BoostValuation {
+  timeBefore: number
+  timeAfter: number
+  timeSaved: number
+}
+
+/**
+ * Value a player-level boost against one grind. The bonus stack is additive, so a
+ * `xpBonusGain` of W percentage points lifts the XP multiplier by W/100, and grind
+ * time scales as 1/xpMultiplier. This is the saving on *this* grind alone — the
+ * boost also helps every future grind, so treat it as a lower bound.
+ */
+export function valueBoostOnGrind(
+  boost: PlayerLevelBoost,
+  currentXpMultiplier: number,
+  grindTimeSeconds: number,
+): BoostValuation {
+  const newMult = currentXpMultiplier + boost.xpBonusGain / 100
+  const timeAfter =
+    newMult > 0 ? grindTimeSeconds * (currentXpMultiplier / newMult) : grindTimeSeconds
+  return {
+    timeBefore: grindTimeSeconds,
+    timeAfter,
+    timeSaved: Math.max(0, grindTimeSeconds - timeAfter),
+  }
+}

--- a/src/utils/planner/skillPlanner.ts
+++ b/src/utils/planner/skillPlanner.ts
@@ -1,0 +1,494 @@
+import { getPlayerLevelXpBonus, getSkillLevel, xpForSkillLevel } from '@/utils/formulas'
+
+import { getJobBenefits } from './sanctuaryConstants'
+
+// ── Bonus magnitudes (verified against recovered-source) ──────────────
+// Awaken tree: each gathering skill_xp node = +10% XP, each skill_duration = -5%.
+// Tool: +5% XP per level. Sanctuary + player-level come from their own helpers.
+export const AWAKEN_XP_PER_TIER = 10
+export const AWAKEN_DURATION_PER_TIER = 5
+export const TOOL_XP_PER_LEVEL = 5
+// Workstations: each workstation_xp node = +10% XP, each workstation_speed = -15%.
+// In speed mode the tool's XP bonus is forfeited and converts to -2% duration/level.
+export const WORKSTATION_XP_PER_TIER = 10
+export const WORKSTATION_SPEED_PER_TIER = 15
+export const WORKSTATION_TOOL_SPEED_PER_LEVEL = 2
+
+export interface SkillBonusInputs {
+  /** Sanctuary job tier (0–MAX_TIER) for this skill. */
+  jobTier: number
+  /** Count of purchased awaken `skill_xp` nodes. */
+  awakenXpTier: number
+  /** Count of purchased awaken `skill_duration` nodes. */
+  awakenDurationTier: number
+  /** Level of the tool that boosts this skill (0–10). */
+  toolLevel: number
+  /** Current player level (1–99) — drives the player-level XP bonus. */
+  playerLevel: number
+}
+
+export interface SkillMultipliers {
+  xpMultiplier: number
+  durationMultiplier: number
+}
+
+export interface SkillActivity {
+  id: string
+  name: string
+  /** Primary output item id, used to resolve the activity's icon. Falls back to `id`. */
+  iconItemId?: string
+  levelRequirement: number
+  xpRate: number
+  duration: number
+}
+
+export interface SkillSegment {
+  activityId: string
+  activityName: string
+  /** Item id used to resolve the activity's icon (primary output for gathering, crafted item for workstations). */
+  iconItemId: string
+  fromLevel: number
+  toLevel: number
+  unlockLevel: number
+  xpPerCycle: number
+  effectiveDuration: number
+  xpPerSec: number
+  bandXp: number
+  cycles: number
+  timeSeconds: number
+  /** Workstation only: how many of `cycles` are already in the in-game queue (in
+   * progress). Drives the sky-blue "in queue" portion of the bar; ≤ `cycles`. */
+  queuedCycles?: number
+  /** Workstation only: the ingredient that distinguishes this recipe variant from
+   * its siblings (e.g. the bar a Helmet is forged from). Lets the UI tell apart the
+   * multiple "Helmet" bands a grind produces as it cascades down bar tiers. */
+  variantItemId?: string
+}
+
+export interface SkillPlan {
+  skillId: string
+  currentLevel: number
+  targetLevel: number
+  totalXp: number
+  totalCycles: number
+  totalTimeSeconds: number
+  segments: SkillSegment[]
+}
+
+/**
+ * Build the XP and duration multipliers the game applies to a gathering skill.
+ *
+ *   xpMultiplier       = 1 + (sanctuary + awaken + playerLevel + tool)% / 100
+ *   durationMultiplier = max(0.01, 1 - (sanctuary + awaken)% / 100)
+ *
+ * Mirrors `bonuses/helpers.ts` `getGatheringXpBonus` / `getGatheringDurationReduction`.
+ */
+export function getSkillMultipliers(inputs: SkillBonusInputs): SkillMultipliers {
+  const benefits = getJobBenefits(inputs.jobTier)
+
+  const xpPercent =
+    benefits.xpBonus +
+    inputs.awakenXpTier * AWAKEN_XP_PER_TIER +
+    getPlayerLevelXpBonus(inputs.playerLevel) +
+    inputs.toolLevel * TOOL_XP_PER_LEVEL
+
+  const durationPercent =
+    benefits.durationReduction + inputs.awakenDurationTier * AWAKEN_DURATION_PER_TIER
+
+  return {
+    xpMultiplier: 1 + xpPercent / 100,
+    durationMultiplier: Math.max(0.01, 1 - durationPercent / 100),
+  }
+}
+
+/** XP per second for one activity under the given multipliers (game: XP/cycle ÷ duration/cycle). */
+export function getActivityXpPerSec(xpRate: number, duration: number, m: SkillMultipliers): number {
+  const xpPerCycle = xpRate * m.xpMultiplier
+  const effectiveDuration = Math.max(1, duration * m.durationMultiplier)
+  return xpPerCycle / effectiveDuration
+}
+
+/** Highest-`levelRequirement` activity unlocked at `level` (activities sorted ascending). */
+function activityForLevel(sortedAsc: SkillActivity[], level: number): SkillActivity | null {
+  let best: SkillActivity | null = null
+  for (const activity of sortedAsc) {
+    if (activity.levelRequirement <= level) best = activity
+    else break
+  }
+  return best
+}
+
+const clampLevel = (level: number) => Math.max(1, Math.min(99, Math.floor(level)))
+
+/**
+ * Deterministic gathering plan: grind the highest-unlocked activity, switching
+ * exactly at unlock thresholds. No search — for gathering, XP/sec is monotonic
+ * per tier and bonuses scale all activities uniformly, so the highest-unlocked
+ * activity is always optimal. (Workstations are not built here.)
+ */
+export function buildGatheringPlan(
+  skillId: string,
+  activities: SkillActivity[],
+  currentLevel: number,
+  targetLevel: number,
+  m: SkillMultipliers,
+): SkillPlan {
+  const cur = clampLevel(currentLevel)
+  const tgt = clampLevel(targetLevel)
+  const sorted = [...activities].sort((a, b) => a.levelRequirement - b.levelRequirement)
+
+  const base: SkillPlan = {
+    skillId,
+    currentLevel: cur,
+    targetLevel: tgt,
+    totalXp: 0,
+    totalCycles: 0,
+    totalTimeSeconds: 0,
+    segments: [],
+  }
+  if (tgt <= cur || sorted.length === 0) return base
+
+  // Segment boundaries: current, every unlock strictly inside (cur, tgt), and target.
+  const unlocks = sorted.map((a) => a.levelRequirement).filter((lvl) => lvl > cur && lvl < tgt)
+  const boundaries = [...new Set([cur, ...unlocks, tgt])].sort((a, b) => a - b)
+
+  const segments: SkillSegment[] = []
+  let totalXp = 0
+  let totalCycles = 0
+  let totalTimeSeconds = 0
+
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    const fromLevel = boundaries[i]
+    const toLevel = boundaries[i + 1]
+    const active = activityForLevel(sorted, fromLevel)
+    if (!active) continue
+
+    const bandXp = xpForSkillLevel(toLevel) - xpForSkillLevel(fromLevel)
+    const xpPerCycle = active.xpRate * m.xpMultiplier
+    const effectiveDuration = Math.max(1, active.duration * m.durationMultiplier)
+    const cycles = Math.ceil(bandXp / xpPerCycle)
+    const timeSeconds = cycles * effectiveDuration
+
+    segments.push({
+      activityId: active.id,
+      activityName: active.name,
+      iconItemId: active.iconItemId ?? active.id,
+      fromLevel,
+      toLevel,
+      unlockLevel: active.levelRequirement,
+      xpPerCycle,
+      effectiveDuration,
+      xpPerSec: xpPerCycle / effectiveDuration,
+      bandXp,
+      cycles,
+      timeSeconds,
+    })
+
+    totalXp += bandXp
+    totalCycles += cycles
+    totalTimeSeconds += timeSeconds
+  }
+
+  return { ...base, totalXp, totalCycles, totalTimeSeconds, segments }
+}
+
+// ── Workstations (Furnace / Stove / Workbench) ────────────────────────
+
+export interface WorkstationBonusInputs {
+  /** Count of purchased workstation_xp nodes. */
+  awakenXpTier: number
+  /** Count of purchased workstation_speed nodes. */
+  awakenSpeedTier: number
+  /** Tool level (0–10) for this workstation. */
+  toolLevel: number
+  /** Whether the workstation tool is in speed mode (tool XP → duration). */
+  speedMode: boolean
+  /** Current player level (1–99). */
+  playerLevel: number
+}
+
+export interface WorkstationRecipe {
+  itemId: string
+  itemName: string
+  levelRequirement: number
+  experience: number
+  craftTime: number
+  ingredients: { id: string; amount: number }[]
+}
+
+export interface WorkstationPlan extends SkillPlan {
+  /** Total ingredients actually consumed by this plan (sum across segments). */
+  ingredientCost: Record<string, number>
+  /** Level the affordable path reaches; equals targetLevel when inventory suffices. */
+  reachedLevel: number
+}
+
+/**
+ * Workstation XP/duration multipliers. Mirrors `bonuses/helpers.ts`
+ * `getWorkstationXpBonus` / `getWorkstationDurationReduction`: no sanctuary
+ * bonus, and the tool bonus is XP unless speed mode (then it is duration).
+ */
+export function getWorkstationMultipliers(i: WorkstationBonusInputs): SkillMultipliers {
+  const xpPercent =
+    i.awakenXpTier * WORKSTATION_XP_PER_TIER +
+    getPlayerLevelXpBonus(i.playerLevel) +
+    (i.speedMode ? 0 : i.toolLevel * TOOL_XP_PER_LEVEL)
+
+  const durationPercent =
+    i.awakenSpeedTier * WORKSTATION_SPEED_PER_TIER +
+    (i.speedMode ? i.toolLevel * WORKSTATION_TOOL_SPEED_PER_LEVEL : 0)
+
+  return {
+    xpMultiplier: 1 + xpPercent / 100,
+    durationMultiplier: Math.max(0.01, 1 - durationPercent / 100),
+  }
+}
+
+/** Recipes unlocked at `level` with a positive craft time. */
+function unlockedRecipes(recipes: WorkstationRecipe[], level: number): WorkstationRecipe[] {
+  return recipes.filter((r) => r.levelRequirement <= level && r.craftTime > 0)
+}
+
+/** Inventory fully covers one cycle of every ingredient (everything is consumed). */
+function isAffordable(recipe: WorkstationRecipe, inv: Record<string, number>): boolean {
+  return recipe.ingredients.every((ing) => (inv[ing.id] ?? 0) >= ing.amount)
+}
+
+/** Highest XP/sec recipe in `pool` (ties: first, i.e. lowest level requirement). */
+function bestByRate(pool: WorkstationRecipe[]): WorkstationRecipe | null {
+  let best: WorkstationRecipe | null = null
+  let bestRate = -1
+  for (const r of pool) {
+    const rate = r.experience / r.craftTime
+    if (rate > bestRate) {
+      bestRate = rate
+      best = r
+    }
+  }
+  return best
+}
+
+/** Smallest recipe level requirement strictly above `level`, or Infinity if none. */
+function nextUnlockLevel(recipes: WorkstationRecipe[], level: number): number {
+  let next = Infinity
+  for (const r of recipes) {
+    if (r.craftTime <= 0) continue
+    if (r.levelRequirement > level && r.levelRequirement < next) next = r.levelRequirement
+  }
+  return next
+}
+
+/** A workstation recipe producing `itemId` (for queued items). Picks the highest-XP
+ * variant when an item has several recipes; null if none crafts it here. */
+function recipeForItem(recipes: WorkstationRecipe[], itemId: string): WorkstationRecipe | null {
+  let best: WorkstationRecipe | null = null
+  for (const r of recipes) {
+    if (r.itemId !== itemId || r.craftTime <= 0) continue
+    if (!best || r.experience > best.experience) best = r
+  }
+  return best
+}
+
+/**
+ * The ingredient that distinguishes `recipe` from its sibling variants (same item,
+ * same workstation) — the one not shared by all of them, e.g. the bar a Helmet is
+ * forged from. Undefined when the item has a single recipe (nothing to disambiguate).
+ */
+function variantIngredientId(
+  recipe: WorkstationRecipe,
+  recipes: WorkstationRecipe[],
+): string | undefined {
+  const siblings = recipes.filter((r) => r.itemId === recipe.itemId && r.craftTime > 0)
+  if (siblings.length <= 1) return undefined
+  // Ingredient ids present in every sibling — these don't tell variants apart.
+  let common = new Set(siblings[0].ingredients.map((i) => i.id))
+  for (const s of siblings.slice(1)) {
+    const ids = new Set(s.ingredients.map((i) => i.id))
+    common = new Set([...common].filter((id) => ids.has(id)))
+  }
+  return recipe.ingredients.find((i) => !common.has(i.id))?.id
+}
+
+/** Merge adjacent segments that craft the same recipe variant (e.g. across an unlock
+ * that didn't change the pick), summing cycles/queued/time/xp and extending the band.
+ * Different variants of one item (e.g. Solarite vs Gold Helmet) never merge — they
+ * have different XP rates and consume different materials. */
+function mergeSegments(segments: SkillSegment[]): SkillSegment[] {
+  const out: SkillSegment[] = []
+  for (const seg of segments) {
+    const prev = out[out.length - 1]
+    if (prev && prev.activityId === seg.activityId && prev.variantItemId === seg.variantItemId) {
+      prev.toLevel = seg.toLevel
+      prev.bandXp += seg.bandXp
+      prev.cycles += seg.cycles
+      prev.queuedCycles = (prev.queuedCycles ?? 0) + (seg.queuedCycles ?? 0)
+      prev.timeSeconds += seg.timeSeconds
+    } else {
+      out.push({ ...seg })
+    }
+  }
+  return out
+}
+
+/**
+ * Inventory-aware workstation leveling plan. Unlike gathering, recipes don't
+ * share a progression, so the planner greedily crafts the best XP/sec recipe it
+ * can *afford* from the running inventory, switching recipes at the earliest of:
+ * target reached, a better recipe unlocking, or the active recipe's materials
+ * running out. When nothing is affordable it stops and reports the blocker.
+ * Every listed ingredient is treated as consumed per craft.
+ *
+ * The in-game workstation `queued` amounts (itemId → output count) feed the plan:
+ * within each band the queue covers some of the crafts for free — those already
+ * paid their ingredients (so they don't draw on `inventory`, which parseSave keeps
+ * net of queue reservations) yet still grant XP. The covered count is recorded as
+ * `queuedCycles` on the segment (the sky-blue "in queue" portion of its bar) and
+ * its time is excluded from the segment (it's already in progress). Buy-only items
+ * (no workstation recipe) can never be queued, so they never contribute.
+ */
+export function buildWorkstationPlan(
+  workstation: string,
+  recipes: WorkstationRecipe[],
+  currentLevel: number,
+  targetLevel: number,
+  m: SkillMultipliers,
+  inventory: Record<string, number>,
+  queued: Record<string, number> = {},
+): WorkstationPlan {
+  const cur = clampLevel(currentLevel)
+  const tgt = clampLevel(targetLevel)
+
+  const base: WorkstationPlan = {
+    skillId: workstation,
+    currentLevel: cur,
+    targetLevel: tgt,
+    totalXp: 0,
+    totalCycles: 0,
+    totalTimeSeconds: 0,
+    segments: [],
+    ingredientCost: {},
+    reachedLevel: cur,
+  }
+  if (tgt <= cur || recipes.length === 0) return base
+
+  const inv: Record<string, number> = { ...inventory }
+  // Per-item queue pool, drawn down as bands consume it. Buy-only items (no recipe
+  // at this workstation) can't be queued, so drop them up front.
+  const queuePool: Record<string, number> = {}
+  for (const [itemId, count] of Object.entries(queued)) {
+    if (count > 0 && recipeForItem(recipes, itemId)) queuePool[itemId] = count
+  }
+  const goal = xpForSkillLevel(tgt)
+  const startXp = xpForSkillLevel(cur)
+
+  const rawSegments: SkillSegment[] = []
+  const ingredientCost: Record<string, number> = {}
+  let xp = startXp
+
+  // Phase 1 — queue head start. The in-game queue is already crafting, so it leads
+  // the grind path. Queued crafts are free (mats already paid) and grant XP, raising
+  // the level before the affordability grind handles the remainder. Ordered by unlock
+  // level so the level rises sensibly; queued items are all unlocked at `cur` already.
+  const queuedItems = Object.keys(queuePool)
+    .map((itemId) => ({ itemId, recipe: recipeForItem(recipes, itemId)! }))
+    .sort((a, b) => a.recipe.levelRequirement - b.recipe.levelRequirement)
+
+  for (const { itemId, recipe } of queuedItems) {
+    if (xp >= goal) break
+    const xpPerCycle = recipe.experience * m.xpMultiplier
+    const effectiveDuration = Math.max(1, recipe.craftTime * m.durationMultiplier)
+    const cycles = Math.min(queuePool[itemId], Math.ceil((goal - xp) / xpPerCycle))
+    if (cycles <= 0) continue
+    queuePool[itemId] -= cycles
+
+    const fromLevel = getSkillLevel(xp)
+    const xpEnd = xp + cycles * xpPerCycle
+    rawSegments.push({
+      activityId: itemId,
+      activityName: recipe.itemName,
+      iconItemId: itemId,
+      fromLevel,
+      toLevel: Math.min(tgt, getSkillLevel(xpEnd)),
+      unlockLevel: recipe.levelRequirement,
+      xpPerCycle,
+      effectiveDuration,
+      xpPerSec: xpPerCycle / effectiveDuration,
+      bandXp: cycles * xpPerCycle,
+      cycles,
+      // Queued crafts are already in progress, not remaining work → no added time.
+      timeSeconds: 0,
+      queuedCycles: cycles,
+      variantItemId: variantIngredientId(recipe, recipes),
+    })
+    xp = xpEnd
+  }
+
+  // Phase 2 — affordability grind for whatever the queue didn't cover, from the
+  // post-queue level using current (queue-net) inventory. A queued item that's still
+  // the best pick merges with its Phase-1 segment (mergeSegments), so its card shows
+  // a partial queued bar rather than two separate cards.
+  while (xp < goal) {
+    const level = getSkillLevel(xp)
+    const unlocked = unlockedRecipes(recipes, level)
+    const affordable = unlocked.filter((r) => isAffordable(r, inv))
+
+    // Nothing affordable at this level — the grind can't progress, so stop here.
+    if (affordable.length === 0) break
+
+    const recipe = bestByRate(affordable)!
+    const xpPerCycle = recipe.experience * m.xpMultiplier
+    const effectiveDuration = Math.max(1, recipe.craftTime * m.durationMultiplier)
+
+    const cyclesToTarget = Math.ceil((goal - xp) / xpPerCycle)
+    const unlock = nextUnlockLevel(recipes, level)
+    const cyclesToUnlock =
+      unlock === Infinity ? Infinity : Math.ceil((xpForSkillLevel(unlock) - xp) / xpPerCycle)
+    const cyclesByInventory = Math.min(
+      ...recipe.ingredients.map((ing) => Math.floor((inv[ing.id] ?? 0) / ing.amount)),
+    )
+    const cycles = Math.min(cyclesToTarget, cyclesToUnlock, cyclesByInventory)
+
+    const fromLevel = level
+    const xpEnd = xp + cycles * xpPerCycle
+    for (const ing of recipe.ingredients) {
+      inv[ing.id] = (inv[ing.id] ?? 0) - ing.amount * cycles
+      ingredientCost[ing.id] = (ingredientCost[ing.id] ?? 0) + ing.amount * cycles
+    }
+    rawSegments.push({
+      activityId: recipe.itemId,
+      activityName: recipe.itemName,
+      iconItemId: recipe.itemId,
+      fromLevel,
+      toLevel: Math.min(tgt, getSkillLevel(xpEnd)),
+      unlockLevel: recipe.levelRequirement,
+      xpPerCycle,
+      effectiveDuration,
+      xpPerSec: xpPerCycle / effectiveDuration,
+      bandXp: cycles * xpPerCycle,
+      cycles,
+      timeSeconds: cycles * effectiveDuration,
+      queuedCycles: 0,
+      variantItemId: variantIngredientId(recipe, recipes),
+    })
+
+    xp = xpEnd
+  }
+
+  const segments = mergeSegments(rawSegments)
+  // Where the grind stopped: the target when inventory sufficed, otherwise the
+  // level the affordable path got to before it ran out of materials.
+  const reachedLevel = Math.min(tgt, getSkillLevel(xp))
+  const totalCycles = segments.reduce((sum, s) => sum + s.cycles, 0)
+  const totalTimeSeconds = segments.reduce((sum, s) => sum + s.timeSeconds, 0)
+  const totalXp = xpForSkillLevel(reachedLevel) - startXp
+
+  return {
+    ...base,
+    totalXp,
+    totalCycles,
+    totalTimeSeconds,
+    segments,
+    ingredientCost,
+    reachedLevel,
+  }
+}

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
 import { AlertCircle, ChevronDown, Clock3, Layers, Plus, Trash2, X, Zap } from 'lucide-vue-next'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -11,12 +11,20 @@ import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
 import AppTooltip from '@/components/shared/AppTooltip.vue'
 import RightClickHint from '@/components/shared/RightClickHint.vue'
+import SanctuaryPlannerSuggestion from '@/components/skill-planner/SanctuaryPlannerSuggestion.vue'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
+import { useCreatures } from '@/composables/useCreatures'
 import { useSanctuary } from '@/composables/useSanctuary'
 import type { Creature, ElementType, Jobs } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { typeColor } from '@/utils/format'
-import { helpersIcon, machinesIcon, expeditionsIcon, dungeonsIcon, jobIcons } from '@/utils/icons'
+import { typeColor } from '@/utils/format/format'
+import {
+  helpersIcon,
+  machinesIcon,
+  expeditionsIcon,
+  dungeonsIcon,
+  jobIcons,
+} from '@/utils/format/icons'
+import { getCreatureImage } from '@/utils/images/creatureImages'
 import {
   MAX_SANCTUARY_SLOTS,
   SANCTUARY_JOBS,
@@ -29,7 +37,9 @@ import {
   progressPercent,
   targetPercent,
   isScoreAtThreshold,
-} from '@/utils/sanctuaryConstants'
+} from '@/utils/planner/sanctuaryConstants'
+import { buildSanctuaryDiff, recommendPartyForJob } from '@/utils/planner/skillAdvisories'
+import { calculateJobTiersFromSanctuary } from '@/utils/save/parseSave'
 
 const { t } = useI18n()
 
@@ -55,12 +65,14 @@ const {
   setTargetTier,
   setAllTargets,
   clearSanctuary,
+  setParty,
   isOwned,
   isAwakened,
   getCreatureStatus,
   jobScores,
   jobTiers,
 } = useSanctuary()
+const { creatures } = useCreatures()
 const {
   selectedCreature: inspectedCreature,
   drawerOpen: creatureDrawerOpen,
@@ -98,7 +110,86 @@ const creatureTypes: ElementType[] = ['Fire', 'Water', 'Wind', 'Earth']
 const sortByJob = ref<string>('recommended')
 
 
-const hasTargets = computed(() => Object.values(targetTiers.value).some((t_val) => t_val > 0))
+// Deep-link from a planner "Open in Sanctuary" advisory: ?job=<Job>&target=<tier>.
+// Rather than silently overwriting the player's target tier, we surface a visible
+// suggestion panel (so original vs suggested is obvious) with the recommended party,
+// the remove/add/keep swap, and the shared-slot trade-off. The picker is still sorted
+// by the job; on mobile the picker is its own section, so switch to it and scroll in.
+const suggestionJob = ref<string | null>(null)
+const suggestionTier = ref(0)
+
+
+onMounted(() => {
+  const job = typeof route.query.job === 'string' ? route.query.job : null
+  if (!job || !(SANCTUARY_JOBS as readonly string[]).includes(job)) return
+  sortByJob.value = job
+  const target = Number(route.query.target)
+  if (Number.isFinite(target) && target > 0) {
+    suggestionJob.value = job
+    suggestionTier.value = target
+    // Suggestions can include excluded/busy creatures, so reveal them in the picker.
+    showExcludedCreatures.value = true
+  }
+  if (!isDesktop.value) mobileSection.value = 'creatures'
+  nextTick(() => {
+    document
+      .getElementById('creature-browser')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  })
+})
+
+
+// Recommended single-job party + the concrete roster diff (remove/add/keep + the
+// collateral tier moves on other shared-slot jobs) for the suggested job.
+const suggestion = computed(() => {
+  const job = suggestionJob.value
+  if (!job) return null
+  const rec = recommendPartyForJob(
+    creatures.value,
+    job.toLowerCase(),
+    TIER_THRESHOLDS_RAW,
+    MAX_SANCTUARY_SLOTS,
+    // Include excluded/busy creatures — they're still the best fit; the tiles flag
+    // their status and we auto-enable "Show Excluded" so they appear in the picker.
+    (id) => isOwned(id) && isAwakened(id),
+  )
+  const diff = buildSanctuaryDiff(
+    creatures.value,
+    sanctuaryCreatureIds.value,
+    rec.party,
+    job.toLowerCase(),
+    job,
+    calculateJobTiersFromSanctuary,
+  )
+  // Order the Add list to match the "Select Creature" picker (displayRecommended),
+  // so the two line up; creatures not in the picker (filtered out) sort last.
+  const pickerOrder = new Map(displayRecommended.value.map((r, i) => [r.creature.id, i]))
+  const swapIn = [...diff.swapIn].toSorted(
+    (a, b) =>
+      (pickerOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+      (pickerOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+  )
+  return { job, rec, diff: { ...diff, swapIn } }
+})
+
+
+function applySuggestion() {
+  const s = suggestion.value
+  if (!s) return
+  setTargetTier(s.job, suggestionTier.value)
+  setParty(s.rec.party)
+  suggestionJob.value = null
+  suggestionTier.value = 0
+}
+
+
+function dismissSuggestion() {
+  suggestionJob.value = null
+  suggestionTier.value = 0
+}
+
+
+const hasTargets = computed(() => Object.values(targetTiers.value).some((t) => t > 0))
 
 
 const highlightedJobs = computed<Set<string>>(() => {
@@ -129,7 +220,16 @@ const allCreatureTiersSelected = computed(() => {
 
 watch(
   creatureTierOptions,
-  (tiers) => {
+  (tiers, oldTiers) => {
+    // If the user had every previous tier selected (i.e. no active tier filter), keep
+    // selecting all — otherwise a newly-appearing tier would silently make the filter
+    // look partial ("all but one or two"). Only preserve a genuine partial selection.
+    const wasAllSelected =
+      !oldTiers || oldTiers.every((tier) => selectedCreatureTiers.value.includes(tier))
+    if (wasAllSelected) {
+      selectedCreatureTiers.value = [...tiers]
+      return
+    }
     const preserved = selectedCreatureTiers.value.filter((tier) => tiers.includes(tier))
     selectedCreatureTiers.value = preserved.length ? preserved : [...tiers]
   },
@@ -333,13 +433,29 @@ function chooseCreature(creature: Creature) {
       </div>
       <button
         v-if="sanctuaryCreatureIds.length > 0"
-        class="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-400 transition hover:bg-red-500/20"
+        class="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs font-semibold text-danger-strong transition hover:bg-danger/20"
         @click="clearAll"
       >
         <Trash2 class="size-3.5" />
         {{ t('sanctuaryView.clearAll') }}
       </button>
     </div>
+
+    <!-- Skill Planner suggestion (deep-link arrival) -->
+    <SanctuaryPlannerSuggestion
+      v-if="suggestion"
+      :job="suggestion.job"
+      :suggested-tier="suggestionTier"
+      :diff="suggestion.diff"
+      @apply="applySuggestion"
+      @dismiss="dismissSuggestion"
+      @inspect="
+        (id) => {
+          const c = creatures.find((cr) => cr.id === id)
+          if (c) toggleInspectCreature(c)
+        }
+      "
+    />
 
     <!-- Mobile tabs -->
     <div class="surface-card p-2 lg:hidden">
@@ -389,7 +505,7 @@ function chooseCreature(creature: Creature) {
                 </span>
               </h3>
               <button
-                class="focus-ring inline-flex items-center gap-1 rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1 text-[10px] font-semibold text-red-400 transition hover:bg-red-500/20"
+                class="focus-ring inline-flex items-center gap-1 rounded-md border border-danger/30 bg-danger/10 px-2 py-1 text-3xs font-semibold text-danger-strong transition hover:bg-danger/20"
                 :class="sanctuaryCreatureIds.length === 0 ? 'invisible' : ''"
                 @click="clearSanctuary"
               >
@@ -425,7 +541,7 @@ function chooseCreature(creature: Creature) {
                       <div
                         class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-0.5 py-0.5"
                       >
-                        <p class="truncate text-center text-[8px] font-semibold text-white">
+                        <p class="truncate text-center text-3xs font-semibold text-white">
                           {{ slot.name }}
                         </p>
                       </div>
@@ -440,7 +556,7 @@ function chooseCreature(creature: Creature) {
                   <template v-else>
                     <div class="flex size-full flex-col items-center justify-center">
                       <Plus class="size-3 text-muted-foreground/50" />
-                      <span v-if="activeSlotIndex === index" class="text-[8px] text-primary">
+                      <span v-if="activeSlotIndex === index" class="text-3xs text-primary">
                         {{ t('sanctuaryView.select') }}
                       </span>
                     </div>
@@ -462,9 +578,7 @@ function chooseCreature(creature: Creature) {
                   :text="t('sanctuaryView.unreachableTooltip')"
                   position="bottom"
                 >
-                  <div
-                    class="flex items-center gap-1 text-[10px] font-semibold text-amber-600 dark:text-amber-400"
-                  >
+                  <div class="flex items-center gap-1 text-3xs font-semibold text-warning-strong">
                     <AlertCircle class="size-3 shrink-0" />
                     <template v-for="(job, i) in unreachableTargets" :key="job">
                       <span v-if="i > 0">,</span>
@@ -479,7 +593,7 @@ function chooseCreature(creature: Creature) {
                   </div>
                 </AppTooltip>
                 <button
-                  class="focus-ring inline-flex items-center gap-1 rounded-md border border-red-500/30 bg-red-500/10 px-2 py-1 text-[10px] font-semibold text-red-400 transition hover:bg-red-500/20"
+                  class="focus-ring inline-flex items-center gap-1 rounded-md border border-danger/30 bg-danger/10 px-2 py-1 text-3xs font-semibold text-danger-strong transition hover:bg-danger/20"
                   :class="hasTargets ? '' : 'invisible'"
                   @click="setAllTargets(0)"
                 >
@@ -506,27 +620,27 @@ function chooseCreature(creature: Creature) {
                   <div v-if="jp.tier > 0" class="ml-auto flex flex-wrap justify-end gap-1">
                     <span
                       v-if="JOB_TIER_BENEFITS[jp.tier].xpBonus > 0"
-                      class="inline-flex items-center gap-0.5 rounded-full border border-emerald-500/25 bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+                      class="inline-flex items-center gap-0.5 rounded-full border border-success/25 bg-success/10 px-1.5 py-0.5 text-3xs font-semibold text-success-strong dark:bg-success/15 dark:text-success-strong"
                     >
                       <Zap class="size-2.5" />
                       {{ t('sanctuary.xpBonus', { n: JOB_TIER_BENEFITS[jp.tier].xpBonus }) }}
                     </span>
                     <span
                       v-if="JOB_TIER_BENEFITS[jp.tier].durationReduction > 0"
-                      class="inline-flex items-center gap-0.5 rounded-full border border-amber-500/25 bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400"
+                      class="inline-flex items-center gap-0.5 rounded-full border border-warning/25 bg-warning/10 px-1.5 py-0.5 text-3xs font-semibold text-warning-strong dark:bg-warning/15 dark:text-warning-strong"
                     >
                       <Clock3 class="size-2.5" />
                       -{{ JOB_TIER_BENEFITS[jp.tier].durationReduction }}%
                     </span>
                     <span
                       v-if="JOB_TIER_BENEFITS[jp.tier].yieldBonus > 0"
-                      class="inline-flex items-center gap-0.5 rounded-full border border-violet-500/25 bg-violet-100 px-1.5 py-0.5 text-[10px] font-semibold text-violet-700 dark:bg-violet-500/15 dark:text-violet-400"
+                      class="inline-flex items-center gap-0.5 rounded-full border border-reserved/25 bg-reserved/10 px-1.5 py-0.5 text-3xs font-semibold text-reserved-strong dark:bg-reserved/15 dark:text-reserved-strong"
                     >
                       <Layers class="size-2.5" />
                       +{{ JOB_TIER_BENEFITS[jp.tier].yieldBonus }}
                     </span>
                   </div>
-                  <span v-else class="ml-auto text-[10px] text-muted-foreground/50">
+                  <span v-else class="ml-auto text-3xs text-muted-foreground/50">
                     {{ t('sanctuary.noBonuses') }}
                   </span>
                 </div>
@@ -565,12 +679,8 @@ function chooseCreature(creature: Creature) {
                     <span
                       v-for="t_val in [1, 2, 3, 4, 5]"
                       :key="t_val"
-                      class="absolute -translate-x-1/2 text-[8px] font-semibold"
-                      :class="
-                        jp.tier >= t_val
-                          ? 'text-emerald-600 dark:text-emerald-400'
-                          : 'text-muted-foreground/50'
-                      "
+                      class="absolute -translate-x-1/2 text-3xs font-semibold"
+                      :class="jp.tier >= t_val ? 'text-success-strong' : 'text-muted-foreground/50'"
                       :style="{ left: `${targetPercent(t_val)}%` }"
                     >
                       <Zap v-if="tierBenefitType(t_val) === 'xp'" class="mx-auto size-2.5" />
@@ -584,10 +694,10 @@ function chooseCreature(creature: Creature) {
                 </div>
 
                 <!-- Score -->
-                <div class="text-[11px]">
+                <div class="text-2xs">
                   <span class="text-muted-foreground">
                     <template v-if="jp.isMaxed">
-                      <span class="font-semibold text-emerald-600 dark:text-emerald-400">{{
+                      <span class="font-semibold text-success-strong">{{
                         t('sanctuaryView.allBonusesUnlocked')
                       }}</span>
                     </template>
@@ -603,22 +713,22 @@ function chooseCreature(creature: Creature) {
                 <!-- Target selector -->
                 <div class="mt-2">
                   <span
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-widest text-muted-foreground"
+                    class="mb-1 block text-3xs font-bold uppercase tracking-widest text-muted-foreground"
                     >{{ t('sanctuaryView.setTarget') }}</span
                   >
                   <div class="flex gap-1">
                     <button
                       v-for="t_val in [1, 2, 3, 4, 5]"
                       :key="t_val"
-                      class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded-md border px-1 py-1 text-[10px] font-medium transition"
+                      class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded-md border px-1 py-1 text-3xs font-medium transition"
                       :class="
                         (targetTiers[jp.job] ?? 0) === t_val
                           ? 'border-transparent bg-primary text-primary-foreground shadow-glow'
                           : jp.tier >= t_val
-                            ? 'border-emerald-500/30 bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400'
+                            ? 'border-success/30 bg-success/10 text-success-strong dark:bg-success/20 dark:text-success-strong'
                             : 'border-border bg-muted/40 text-muted-foreground hover:border-primary/50 hover:text-foreground'
                       "
-                      :title="`Tier ${t_val}: ${jobTierLabel(t_val)}`"
+                      :title="`${t('sanctuaryView.tierLabel', { n: t_val })}: ${jobTierLabel(t_val)}`"
                       @click="
                         setTargetTier(jp.job, (targetTiers[jp.job] ?? 0) === t_val ? 0 : t_val)
                       "
@@ -632,7 +742,7 @@ function chooseCreature(creature: Creature) {
                         />
                         <Layers v-else class="size-2.5" />
                       </template>
-                      <span class="hidden text-[9px] sm:inline">{{
+                      <span class="hidden text-3xs sm:inline">{{
                         tierIncrementalLabel(t_val)
                       }}</span>
                     </button>
@@ -646,6 +756,7 @@ function chooseCreature(creature: Creature) {
 
       <!-- ═══ Right: Creature Browser ═══ -->
       <section
+        id="creature-browser"
         class="surface-card flex flex-col overflow-hidden"
         :class="!isDesktop && mobileSection !== 'creatures' ? 'hidden' : ''"
       >
@@ -753,7 +864,7 @@ function chooseCreature(creature: Creature) {
         <div class="flex items-center gap-3 border-b border-border/70 py-1.5 pl-[20px] pr-[20px]">
           <AppTooltip :text="t('sanctuaryView.recommended')" position="top">
             <button
-              class="focus-ring inline-flex w-12 shrink-0 items-center justify-center rounded-md border px-1 py-1 text-[10px] font-medium transition"
+              class="focus-ring inline-flex w-12 shrink-0 items-center justify-center rounded-md border px-1 py-1 text-3xs font-medium transition"
               :class="
                 sortByJob === 'recommended'
                   ? 'border-transparent bg-primary text-primary-foreground shadow-glow'
@@ -768,7 +879,7 @@ function chooseCreature(creature: Creature) {
             <button
               v-for="job in SANCTUARY_JOBS"
               :key="job"
-              class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded-md border px-1 py-1 text-[10px] font-medium transition"
+              class="focus-ring inline-flex flex-1 items-center justify-center gap-0.5 rounded-md border px-1 py-1 text-3xs font-medium transition"
               :class="
                 sortByJob === job
                   ? 'border-transparent bg-primary text-primary-foreground shadow-glow'
@@ -818,36 +929,36 @@ function chooseCreature(creature: Creature) {
                   />
                   <!-- Tier badge -->
                   <span
-                    class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-[9px] font-bold text-muted-foreground shadow-sm"
+                    class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-3xs font-bold text-muted-foreground shadow-sm"
                   >
                     T{{ creature.tier + 1 }}
                   </span>
                   <img
                     v-if="getCreatureStatus(creature.id) === 'helper'"
                     :src="helpersIcon"
-                    alt="Helper"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    :alt="t('sanctuaryView.statusHelper')"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                   <img
                     v-else-if="getCreatureStatus(creature.id) === 'machine'"
                     :src="machinesIcon"
-                    alt="Machine"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    :alt="t('sanctuaryView.statusMachine')"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                   <img
                     v-else-if="getCreatureStatus(creature.id) === 'expedition'"
                     :src="expeditionsIcon"
                     alt="Expedition"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                   <img
                     v-else-if="getCreatureStatus(creature.id) === 'dungeon'"
                     :src="dungeonsIcon"
-                    alt="Dungeon"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    :alt="t('sanctuaryView.statusDungeon')"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                 </div>
@@ -870,7 +981,7 @@ function chooseCreature(creature: Creature) {
                       :class="
                         isAwakened(creature.id)
                           ? 'text-pink-500 dark:text-pink-400'
-                          : 'text-amber-500 dark:text-amber-400'
+                          : 'text-warning-strong'
                       "
                       >★</span
                     >
@@ -880,13 +991,13 @@ function chooseCreature(creature: Creature) {
                       position="top"
                     >
                       <span
-                        class="shrink-0 cursor-help rounded border border-amber-500/30 bg-amber-500/10 px-1 py-px text-[9px] font-semibold text-amber-500 dark:text-amber-400"
+                        class="shrink-0 cursor-help rounded border border-warning/30 bg-warning/10 px-1 py-px text-3xs font-semibold text-warning-strong"
                         >{{ t('sanctuaryView.notAwakened') }}</span
                       >
                     </AppTooltip>
                     <span v-if="score > 0" class="ml-auto flex shrink-0 items-baseline gap-1">
                       <span class="font-mono text-sm font-semibold text-primary">{{ score }}</span>
-                      <span class="text-[10px] text-muted-foreground">{{
+                      <span class="text-3xs text-muted-foreground">{{
                         hasTargets ? t('sanctuaryView.value') : t('sanctuaryView.total')
                       }}</span>
                     </span>
@@ -911,7 +1022,7 @@ function chooseCreature(creature: Creature) {
                         loading="lazy"
                       />
                       <span
-                        class="w-3 shrink-0 font-mono text-[10px] font-semibold"
+                        class="w-3 shrink-0 font-mono text-3xs font-semibold"
                         :class="
                           highlightedJobs.has(job)
                             ? 'text-primary'

--- a/src/views/SkillPlanner.vue
+++ b/src/views/SkillPlanner.vue
@@ -1,0 +1,394 @@
+<script setup lang="ts">
+import { ArrowRight, Bot, Clock3, Target, TrendingUp, Trophy, Zap } from 'lucide-vue-next'
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+
+import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
+import PlannerEmptyState from '@/components/craft-planner/PlannerEmptyState.vue'
+import SectionEyebrow from '@/components/shared/SectionEyebrow.vue'
+import SectionHead from '@/components/shared/SectionHead.vue'
+import AdvisoryRow from '@/components/skill-planner/AdvisoryRow.vue'
+import SkillPlanSegments from '@/components/skill-planner/SkillPlanSegments.vue'
+import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
+import { useGameConfig } from '@/composables/useGameConfig'
+import { useSkillPlanner, WORKSTATION_IDS, type SkillAdvisory } from '@/composables/useSkillPlanner'
+import { formatDuration, formatNumber, itemName } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
+
+const GATHERING_SKILLS = ['Chopping', 'Mining', 'Digging', 'Exploring', 'Fishing', 'Farming']
+const WORKSTATIONS = WORKSTATION_IDS
+const ALL_SKILLS = [...GATHERING_SKILLS, ...WORKSTATIONS]
+
+
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const { skillLevels } = useGameConfig()
+const {
+  selectedCreature: inspectedCreature,
+  drawerOpen: creatureDrawerOpen,
+  toggleCreatureById,
+  closeDrawer: closeCreatureDrawer,
+} = useCreatureDrawer()
+
+
+function titleCase(id: string): string {
+  return id.charAt(0).toUpperCase() + id.slice(1).toLowerCase()
+}
+
+
+const initialSkill = (() => {
+  const q = typeof route.query.skill === 'string' ? titleCase(route.query.skill) : ''
+  return ALL_SKILLS.includes(q) ? q : 'Mining'
+})()
+
+
+const skillId = ref(initialSkill)
+const targetLevel = ref(Number(route.query.target) > 1 ? Number(route.query.target) : 70)
+
+
+const {
+  plan,
+  isWorkstation,
+  isMaxLevel,
+  targetPresets,
+  ingredientCost,
+  playerLevelDelta,
+  playerLevelXpBonusGain,
+  playerLevelGain,
+  advisories,
+} = useSkillPlanner(skillId, targetLevel)
+
+
+const ingredientList = computed(() =>
+  Object.entries(ingredientCost.value)
+    .map(([id, amount]) => ({ id, name: itemName(id), amount }))
+    .sort((a, b) => b.amount - a.amount),
+)
+
+
+function configLevel(id: string): number {
+  return skillLevels.value[id] ?? 1
+}
+
+
+/** Accordion key for an advisory row (its lever, or the singleton playerLevel). */
+function advisoryKey(adv: SkillAdvisory): string {
+  return adv.kind === 'bonus' ? adv.lever : 'playerLevel'
+}
+
+
+// Single-open accordion: only one advisory plan is expanded at a time; all
+// collapsed on load. Toggling an open row closes it; opening another replaces it.
+const openAdvisory = ref<string | null>(null)
+function toggleAdvisory(adv: SkillAdvisory) {
+  const k = advisoryKey(adv)
+  openAdvisory.value = openAdvisory.value === k ? null : k
+}
+
+
+// Keep the target on a valid preset: if the current pick isn't an available
+// summon tier (e.g. after switching skills), snap to the highest one.
+watch(
+  targetPresets,
+  (presets) => {
+    if (presets.length && !presets.some((p) => p.level === targetLevel.value)) {
+      // Snap to the highest resource tier, not the max-out preset.
+      const resourceTiers = presets.filter((p) => !p.isMax)
+      const fallback = resourceTiers.length ? resourceTiers : presets
+      targetLevel.value = fallback[fallback.length - 1].level
+    }
+  },
+  { immediate: true },
+)
+
+
+// URL sync
+watch([skillId, targetLevel], ([id, target]) => {
+  const query: Record<string, string> = { tab: 'skills', skill: id.toLowerCase() }
+  if (target !== 70) query.target = String(target)
+  router.replace({ path: route.path, query })
+})
+
+
+watch(
+  () => route.query.skill,
+  (val) => {
+    if (typeof val === 'string') {
+      const next = titleCase(val)
+      if (ALL_SKILLS.includes(next) && next !== skillId.value) skillId.value = next
+    }
+  },
+)
+</script>
+
+<template>
+  <section class="space-y-8">
+    <!-- Hero -->
+    <header class="border-b border-border/60 pb-5">
+      <SectionEyebrow>{{ t('skillPlanner.eyebrow') }}</SectionEyebrow>
+      <h1
+        class="mt-2 flex items-center gap-3 text-4xl font-black tracking-tight text-foreground sm:text-5xl"
+      >
+        <img
+          v-if="sourceIcons[skillId]"
+          :src="sourceIcons[skillId]"
+          alt=""
+          class="size-9 shrink-0 sm:size-11"
+          loading="lazy"
+        />
+        {{ t('skillPlanner.heading', { skill: skillId }) }}
+      </h1>
+      <p class="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+        {{ t('skillPlanner.subheading') }}
+      </p>
+    </header>
+
+    <!-- Controls: skill + target flow together as one setup region -->
+    <div class="space-y-4">
+      <div>
+        <p class="section-title mb-1.5">{{ t('skillPlanner.controls.gathering') }}</p>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="id in GATHERING_SKILLS"
+            :key="id"
+            class="focus-ring inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition"
+            :class="
+              skillId === id
+                ? 'border-primary/60 bg-primary/15 text-primary'
+                : 'border-border/60 bg-card/60 text-muted-foreground hover:text-foreground'
+            "
+            @click="skillId = id"
+          >
+            <img
+              v-if="sourceIcons[id]"
+              :src="sourceIcons[id]"
+              alt=""
+              class="size-4 shrink-0"
+              loading="lazy"
+            />
+            {{ id }}
+            <span class="ml-1 text-xs opacity-70">LVL {{ configLevel(id) }}</span>
+          </button>
+        </div>
+      </div>
+      <div>
+        <p class="section-title mb-1.5">{{ t('skillPlanner.controls.workstations') }}</p>
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="id in WORKSTATIONS"
+            :key="id"
+            class="focus-ring inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition"
+            :class="
+              skillId === id
+                ? 'border-primary/60 bg-primary/15 text-primary'
+                : 'border-border/60 bg-card/60 text-muted-foreground hover:text-foreground'
+            "
+            @click="skillId = id"
+          >
+            <img
+              v-if="sourceIcons[id]"
+              :src="sourceIcons[id]"
+              alt=""
+              class="size-4 shrink-0"
+              loading="lazy"
+            />
+            {{ id }}
+            <span class="ml-1 text-xs opacity-70">LVL {{ configLevel(id) }}</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Target -->
+      <div>
+        <p class="section-title mb-1.5">{{ t('skillPlanner.controls.targetLevel') }}</p>
+        <div v-if="targetPresets.length" class="flex flex-wrap items-center gap-2">
+          <button
+            v-for="preset in targetPresets"
+            :key="preset.level"
+            class="focus-ring inline-flex items-center gap-1.5 rounded-lg border py-1.5 pl-1.5 pr-2.5 text-sm font-medium transition"
+            :class="
+              targetLevel === preset.level
+                ? 'border-primary/60 bg-primary/15 text-primary'
+                : 'border-border/60 bg-card/60 text-muted-foreground hover:text-foreground'
+            "
+            :title="
+              preset.isMax
+                ? t('skillPlanner.controls.maxOut')
+                : t('skillPlanner.controls.unlocksAtLevel', {
+                    item: preset.itemName,
+                    level: preset.level,
+                  })
+            "
+            @click="targetLevel = preset.level"
+          >
+            <Trophy v-if="preset.isMax" class="size-4 shrink-0 opacity-70" />
+            <img
+              v-else-if="getItemImage({ id: preset.itemId ?? '' })"
+              :src="getItemImage({ id: preset.itemId ?? '' })"
+              :alt="preset.itemName"
+              class="size-5 shrink-0"
+              loading="lazy"
+            />
+            {{ preset.level }}
+          </button>
+        </div>
+        <p v-else class="text-sm text-muted-foreground">
+          {{ t('skillPlanner.controls.atTopTier') }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <PlannerEmptyState
+      v-if="isMaxLevel || !plan || plan.segments.length === 0"
+      :title="t('skillPlanner.empty.title')"
+      :subtitle="t('skillPlanner.empty.subtitle')"
+    />
+    <template v-else>
+      <!-- Summary stat bar -->
+      <section v-if="plan.segments.length">
+        <SectionHead
+          :kicker="t('skillPlanner.summary.kicker')"
+          :title="t('skillPlanner.summary.title')"
+        />
+        <div
+          class="grid grid-cols-2 divide-border/60 overflow-hidden rounded-xl border border-border/60 bg-card/60 sm:grid-cols-4 sm:divide-x"
+        >
+          <div class="border-b border-border/60 p-4 sm:border-b-0">
+            <div
+              class="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              <Zap class="size-3.5 text-warning-strong" /> {{ t('skillPlanner.summary.totalXp') }}
+            </div>
+            <p class="mt-1 text-2xl font-black tabular-nums text-foreground">
+              {{ formatNumber(Math.round(plan.totalXp)) }}
+            </p>
+          </div>
+          <div class="border-b border-border/60 p-4 sm:border-b-0">
+            <div
+              class="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              <Target class="size-3.5 text-info-strong" />
+              {{
+                isWorkstation
+                  ? t('skillPlanner.summary.totalCrafts')
+                  : t('skillPlanner.summary.totalCycles')
+              }}
+            </div>
+            <p class="mt-1 text-2xl font-black tabular-nums text-foreground">
+              {{ formatNumber(plan.totalCycles) }}
+            </p>
+          </div>
+          <div class="p-4">
+            <div
+              class="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              <component :is="isWorkstation ? Bot : Clock3" class="size-3.5 text-success-strong" />
+              {{
+                isWorkstation
+                  ? t('skillPlanner.summary.totalAutocraft')
+                  : t('skillPlanner.summary.totalFocusTime')
+              }}
+            </div>
+            <p class="mt-1 text-2xl font-black tabular-nums text-foreground">
+              {{ formatDuration(plan.totalTimeSeconds) }}
+            </p>
+          </div>
+          <div class="p-4">
+            <div
+              class="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              <TrendingUp class="size-3.5 text-reserved-strong" />
+              {{ t('skillPlanner.summary.playerLevel') }}
+            </div>
+            <div class="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+              <span class="text-2xl font-black tabular-nums text-foreground">
+                {{ playerLevelDelta > 0 ? `+${playerLevelDelta}` : playerLevelDelta }}
+              </span>
+              <span
+                v-if="playerLevelDelta > 0"
+                class="inline-flex items-center gap-1 text-sm font-medium tabular-nums text-muted-foreground"
+              >
+                ({{ playerLevelGain.levelFrom }}
+                <ArrowRight class="size-3" />
+                {{ playerLevelGain.levelTo }})
+              </span>
+            </div>
+            <p
+              class="mt-0.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-sm font-semibold tabular-nums text-success-strong"
+              :class="{ invisible: playerLevelXpBonusGain <= 0 }"
+            >
+              {{
+                t('skillPlanner.summary.xpBonusGain', { value: +playerLevelXpBonusGain.toFixed(2) })
+              }}
+              <span class="inline-flex items-center gap-1 font-medium text-muted-foreground">
+                ({{ playerLevelGain.xpBonusFrom.toFixed(2) }}%
+                <ArrowRight class="size-3" />
+                {{ playerLevelGain.xpBonusTo.toFixed(2) }}%)
+              </span>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Ways to improve: ranked efficiency advisories -->
+      <section v-if="advisories.length">
+        <SectionHead
+          :kicker="t('skillPlanner.waysToImprove.kicker')"
+          :title="t('skillPlanner.waysToImprove.title')"
+        />
+        <ul
+          class="divide-y divide-border/50 overflow-hidden rounded-xl border border-border/60 bg-card/40"
+        >
+          <li v-for="adv in advisories" :key="advisoryKey(adv)">
+            <AdvisoryRow
+              :advisory="adv"
+              :open="openAdvisory === advisoryKey(adv)"
+              @toggle="toggleAdvisory(adv)"
+              @inspect="toggleCreatureById"
+            />
+          </li>
+        </ul>
+      </section>
+
+      <SkillPlanSegments v-if="plan.segments.length" :plan="plan" :is-workstation="isWorkstation" />
+
+      <section v-if="isWorkstation && ingredientList.length">
+        <SectionHead
+          :kicker="t('skillPlanner.ingredients.kicker')"
+          :title="t('skillPlanner.ingredients.title')"
+        >
+          <template #aside>{{ t('skillPlanner.ingredients.aside') }}</template>
+        </SectionHead>
+        <div class="flex flex-wrap gap-2">
+          <div
+            v-for="ing in ingredientList"
+            :key="ing.id"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-border/60 bg-background px-2.5 py-1 text-sm"
+          >
+            <img
+              v-if="getItemImage({ id: ing.id })"
+              :src="getItemImage({ id: ing.id })"
+              :alt="ing.name"
+              class="size-5 object-contain"
+              loading="lazy"
+            />
+            <span class="font-medium">{{ ing.name }}</span>
+            <span class="font-mono text-sm font-semibold text-muted-foreground"
+              >x{{ formatNumber(ing.amount) }}</span
+            >
+          </div>
+        </div>
+      </section>
+    </template>
+
+    <CreatureDetail
+      :creature="inspectedCreature"
+      :open="creatureDrawerOpen"
+      @close="closeCreatureDrawer"
+    />
+  </section>
+</template>


### PR DESCRIPTION
## Description

Fourth PR in the Planner v2 stacked rebuild (targets `planner-v2`). Adds the inventory-aware skill/job leveling planner and the actionable Sanctuary handoff, so a plan computed in the skill planner can be opened and applied in the Sanctuary.

## Summary
- Add the skill/job planning engine (`utils/planner/skillPlanner`, `skillAdvisories`) and relocate `sanctuaryConstants` into `utils/planner`
- Add skill-planner composables (`useSkillPlanner`, `useSkillAdvisories`, `useSkillOverrides`)
- Add the `SkillPlanner` view and advisory components (`AdvisoryRow`, `SanctuaryPartyDiff`, `SanctuaryPlannerSuggestion`, `CreatureDiffTile`, `SkillPlanSegments`, awaken point sources, `advisoryPresentation`)
- Wire the inventory-aware Sanctuary handoff: `useSanctuary` updates, `useExpeditionAllocation` / `useExpeditionLadder`, the new `ExpeditionLadderSection`, and config-section updates
- Add coverage for the planner engine, advisories, and party diff