### PR TITLE
feat(items): item detail v2 and supporting views

### DIFF
--- a/src/components/__tests__/CreatureCard.test.ts
+++ b/src/components/__tests__/CreatureCard.test.ts
@@ -3,11 +3,11 @@ import { mount } from '@vue/test-utils'
 import CreatureCard from '@/components/beastiary/CreatureCard.vue'
 import type { Creature } from '@/types'
 
-vi.mock('@/utils/creatureImages', () => ({
+vi.mock('@/utils/images/creatureImages', () => ({
   getCreatureImage: () => undefined,
 }))
 
-vi.mock('@/utils/icons', () => ({
+vi.mock('@/utils/format/icons', () => ({
   jobIcons: {},
   jobColors: {},
 }))

--- a/src/components/__tests__/ItemCard.test.ts
+++ b/src/components/__tests__/ItemCard.test.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils'
 import ItemCard from '@/components/items/ItemCard.vue'
 import type { Item } from '@/types'
 
-vi.mock('@/utils/itemImages', () => ({
+vi.mock('@/utils/images/itemImages', () => ({
   getItemImage: () => undefined,
 }))
 

--- a/src/components/beastiary/BeastiaryToolbar.vue
+++ b/src/components/beastiary/BeastiaryToolbar.vue
@@ -9,8 +9,8 @@ import summonedIcon from '@/assets/icons/summoned.webp'
 import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
 import type { ElementType } from '@/types'
-import { toTitleCase, typeColor } from '@/utils/format'
-import { jobIcons } from '@/utils/icons'
+import { toTitleCase, typeColor } from '@/utils/format/format'
+import { jobIcons } from '@/utils/format/icons'
 
 const props = defineProps<{
   searchQuery: string
@@ -75,7 +75,7 @@ const hasActiveFilters = computed(
   <div class="surface-card p-4 sm:p-5">
     <div class="flex flex-wrap items-center gap-3">
       <!-- Search input with icon -->
-      <label class="relative min-w-[220px] flex-1">
+      <label class="relative min-w-[var(--sidebar-width)] flex-1">
         <Search
           class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
         />
@@ -135,7 +135,7 @@ const hasActiveFilters = computed(
         {{ t('common.filters') }}
         <span
           v-if="hasActiveFilters"
-          class="flex size-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground"
+          class="flex size-5 items-center justify-center rounded-full bg-primary text-3xs font-bold text-primary-foreground"
           >!</span
         >
       </button>

--- a/src/components/beastiary/CreatureCard.vue
+++ b/src/components/beastiary/CreatureCard.vue
@@ -2,10 +2,10 @@
 import { computed } from 'vue'
 
 import type { Creature, JobKey } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { toTitleCase } from '@/utils/format'
+import { toTitleCase } from '@/utils/format/format'
+import { jobIcons } from '@/utils/format/icons'
 import { jobLabels, jobColors } from '@/utils/formulas'
-import { jobIcons } from '@/utils/icons'
+import { getCreatureImage } from '@/utils/images/creatureImages'
 
 const props = defineProps<{
   creature: Creature
@@ -123,11 +123,11 @@ const jobEntries = computed(() =>
   flex-direction: column;
 }
 .card:hover {
-  border-color: oklch(0.65 0.18 285 / 0.5);
+  border-color: oklch(var(--reserved) / 0.5);
 }
 .card.selected {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px oklch(0.65 0.18 285 / 0.25);
+  box-shadow: 0 0 0 2px oklch(var(--reserved) / 0.25);
 }
 
 .accent-bar {
@@ -144,13 +144,13 @@ const jobEntries = computed(() =>
   width: 20px;
   height: 20px;
   border-radius: var(--radius-sm);
-  border: 2px solid oklch(0.6 0.04 285 / 0.5);
+  border: 2px solid color-mix(in oklch, var(--color-text-muted) 50%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
   transition: all 0.15s ease;
   padding: 0;
-  background: oklch(0.12 0.02 285 / 0.6);
+  background: oklch(var(--scrim) / 0.6);
   backdrop-filter: blur(4px);
 }
 .checkbox:hover {
@@ -180,7 +180,7 @@ const jobEntries = computed(() =>
   padding: 1px 8px;
   font-size: 12px;
   font-family: 'Geist Mono', monospace;
-  background: oklch(0.12 0.02 285 / 0.7);
+  background: oklch(var(--scrim) / 0.7);
   backdrop-filter: blur(4px);
   border-radius: var(--radius-sm);
   color: var(--color-text);
@@ -254,7 +254,7 @@ const jobEntries = computed(() =>
   align-items: center;
   justify-content: space-between;
   padding: 4px 10px 8px;
-  border-top: 1px solid oklch(0.28 0.04 285 / 0.4);
+  border-top: 1px solid color-mix(in oklch, var(--color-border) 40%, transparent);
   margin-top: auto;
 }
 

--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
-import { Minus, Plus, TrendingUp, X } from 'lucide-vue-next'
+import { Sparkles, TrendingUp, X } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import awakenedSummonedIcon from '@/assets/icons/awakened_summoned.webp'
 import summonedIcon from '@/assets/icons/summoned.webp'
 import AppTooltip from '@/components/shared/AppTooltip.vue'
+import CreatureAssignmentBadge from '@/components/shared/CreatureAssignmentBadge.vue'
+import LevelStepper from '@/components/shared/LevelStepper.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, CreatureStats, Jobs } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { itemName, toTitleCase, typeColor, typeColorVar } from '@/utils/format'
+import { itemName, toTitleCase, typeColor, typeColorVar } from '@/utils/format/format'
+import { jobIcons } from '@/utils/format/icons'
 import {
   getBestExpeditionsForCreature,
   jobColors,
@@ -18,15 +20,8 @@ import {
   maxLevelForState,
   statLabels,
 } from '@/utils/formulas'
-import {
-  jobIcons,
-  sanctuaryIcon,
-  helpersIcon,
-  machinesIcon,
-  dungeonsIcon,
-  expeditionsIcon,
-} from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+import { getItemImage } from '@/utils/images/itemImages'
 
 import ProficiencyRing from './ProficiencyRing.vue'
 import StatRadarChart from './StatRadarChart.vue'
@@ -60,16 +55,14 @@ const { t } = useI18n()
 const maxJobLevel = 10
 
 
-const assignmentBadge = computed(() => {
-  if (!props.creature) return null
-  const id = props.creature.id
-  if (sanctuaryCreatureIds.value.includes(id)) return { icon: sanctuaryIcon, label: 'Sanctuary' }
-  if (helperCreatureIds.value.includes(id)) return { icon: helpersIcon, label: 'Helper' }
-  if (machineCreatureIds.value.includes(id)) return { icon: machinesIcon, label: 'Machine' }
-  if (dungeonParty.value.includes(id)) return { icon: dungeonsIcon, label: 'Dungeon' }
-  if (expeditionCreatureIds.value.has(id)) return { icon: expeditionsIcon, label: 'Expedition' }
+function assignmentLabel(id: string): string | null {
+  if (sanctuaryCreatureIds.value.includes(id)) return 'Sanctuary'
+  if (helperCreatureIds.value.includes(id)) return 'Helper'
+  if (machineCreatureIds.value.includes(id)) return 'Machine'
+  if (dungeonParty.value.includes(id)) return 'Dungeon'
+  if (expeditionCreatureIds.value.has(id)) return 'Expedition'
   return null
-})
+}
 
 
 const jobEntries = computed(() => Object.entries(jobLabels) as [keyof Jobs, string][])
@@ -115,7 +108,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
     <Transition name="fade">
       <div
         v-if="open && creature"
-        class="fixed inset-0 z-50 bg-background/60 backdrop-blur-sm"
+        class="fixed inset-0 z-[120] bg-background/60 backdrop-blur-sm"
         @click="emit('close')"
         @contextmenu.prevent="emit('close')"
       />
@@ -125,7 +118,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
     <Transition name="slide">
       <div
         v-if="open && creature"
-        class="fixed inset-y-0 right-0 z-50 w-full max-w-[420px] overflow-y-auto border-l border-border bg-card shadow-2xl"
+        class="fixed inset-y-0 right-0 z-[120] w-full max-w-[420px] overflow-y-auto border-l border-border bg-card shadow-2xl"
       >
         <!-- Gradient header with centered hero -->
         <div
@@ -146,25 +139,28 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
             <img
               :src="getCreatureImage(creature)"
               :alt="`${creature.name} artwork`"
-              class="size-24 rounded-2xl border-2 border-border object-cover shadow-lg"
+              class="size-24 rounded-xl border-2 border-border object-cover shadow-lg"
               :style="{ backgroundColor: `hsl(${typeColorVar(creature.types[0])} / 0.1)` }"
               loading="lazy"
             />
             <span
-              class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1.5 py-0.5 font-mono text-[11px] font-bold text-muted-foreground shadow-sm"
+              class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1.5 py-0.5 font-mono text-2xs font-bold text-muted-foreground shadow-sm"
             >
               T{{ creature.tier + 1 }}
             </span>
             <AppTooltip
-              v-if="assignmentBadge"
-              :text="t('beastiary.detail.assignedTo', { label: assignmentBadge.label })"
+              v-if="assignmentLabel(creature.id)"
+              :text="t('beastiary.detail.assignedTo', { label: assignmentLabel(creature.id) })"
               position="right"
             >
-              <img
-                :src="assignmentBadge.icon"
-                :alt="assignmentBadge.label"
-                class="absolute -bottom-1 -right-1 size-7 rounded-full border-2 border-background bg-background"
-                loading="lazy"
+              <CreatureAssignmentBadge
+                :creature-id="creature.id"
+                :sanctuary-creature-ids="sanctuaryCreatureIds"
+                :helper-creature-ids="helperCreatureIds"
+                :machine-creature-ids="machineCreatureIds"
+                :expedition-creature-ids="expeditionCreatureIds"
+                :dungeon-party="dungeonParty"
+                img-class="absolute -left-1 -top-1 size-7 rounded-full border-2 border-background bg-background"
               />
             </AppTooltip>
           </div>
@@ -230,7 +226,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                     <img :src="awakenedSummonedIcon" alt="" class="size-4" loading="lazy" />
                     {{ t('beastiary.detail.awakened') }}
                   </span>
-                  <p class="text-[11px] text-muted-foreground">
+                  <p class="text-2xs text-muted-foreground">
                     {{
                       isAwakened(creature.id)
                         ? t('beastiary.detail.awakenedCapRaised')
@@ -258,44 +254,35 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                 <span class="text-sm font-medium text-foreground">{{
                   t('beastiary.detail.level')
                 }}</span>
-                <div
-                  class="ml-auto inline-flex items-center overflow-hidden rounded-md border border-input bg-background/85"
-                >
-                  <button
-                    class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                    :disabled="getLevel(creature.id) <= 1"
-                    :aria-label="t('beastiary.detail.decreaseCreatureLevel')"
-                    @click="stepLevel(creature.id, -1)"
-                  >
-                    <Minus class="size-3" />
-                  </button>
-                  <input
-                    type="text"
-                    inputmode="numeric"
-                    pattern="[0-9]*"
-                    class="focus-ring h-7 w-11 border-x border-input bg-transparent text-center font-mono text-xs"
-                    :value="getLevel(creature.id)"
-                    :aria-label="t('beastiary.detail.creatureLevel')"
-                    @blur="normalizeLevelOnBlur(creature.id, $event)"
-                  />
-                  <button
-                    class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                    :disabled="getLevel(creature.id) >= maxLevelForState(isAwakened(creature.id))"
-                    :aria-label="t('beastiary.detail.increaseCreatureLevel')"
-                    @click="stepLevel(creature.id, 1)"
-                  >
-                    <Plus class="size-3" />
-                  </button>
-                </div>
+                <LevelStepper
+                  class="ml-auto"
+                  :model-value="getLevel(creature.id)"
+                  :min="1"
+                  :max="maxLevelForState(isAwakened(creature.id))"
+                  :decrease-label="t('beastiary.detail.decreaseCreatureLevel')"
+                  :increase-label="t('beastiary.detail.increaseCreatureLevel')"
+                  :input-label="t('beastiary.detail.creatureLevel')"
+                  @step="stepLevel(creature.id, $event)"
+                  @normalize="normalizeLevelOnBlur(creature.id, $event)"
+                />
               </div>
             </div>
 
             <router-link
-              :to="{ path: '/planner', query: { tab: 'levelup', creature: creature.id } }"
+              :to="{ name: 'planner-creature', query: { tab: 'awaken', creature: creature.id } }"
               class="focus-ring bg-primary/12 hover:bg-primary/18 flex w-full items-center justify-center gap-2 rounded-lg border border-primary/35 px-4 py-2.5 text-sm font-semibold text-primary transition"
             >
               <TrendingUp class="size-4" />
               {{ t('beastiary.detail.planLeveling') }}
+            </router-link>
+
+            <router-link
+              v-if="!isOwned(creature.id) && creature.summoningCost.length"
+              :to="{ name: 'planner-creature', query: { creature: creature.id } }"
+              class="focus-ring bg-primary/12 hover:bg-primary/18 flex w-full items-center justify-center gap-2 rounded-lg border border-primary/35 px-4 py-2.5 text-sm font-semibold text-primary transition"
+            >
+              <Sparkles class="size-4" />
+              {{ t('beastiary.detail.planSummoning') }}
             </router-link>
           </div>
 
@@ -308,7 +295,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
               <h3 class="section-title">{{ t('beastiary.detail.stats') }}</h3>
               <span
                 v-if="selectedCreatureStats"
-                class="rounded-md border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-[11px] font-semibold text-primary"
+                class="rounded-md border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-2xs font-semibold text-primary"
               >
                 {{ t('beastiary.detail.lvlBadge', { level: getLevel(creature.id) }) }}
               </span>
@@ -330,13 +317,10 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                 <p class="font-mono text-xs">
                   {{ (selectedCreatureStats ?? creature.stats)[statKey] }}
                 </p>
-                <p
-                  v-if="selectedCreatureStats"
-                  class="font-mono text-[10px] text-muted-foreground/60"
-                >
+                <p v-if="selectedCreatureStats" class="font-mono text-3xs text-muted-foreground/60">
                   {{ t('beastiary.detail.baseStat', { value: creature.stats[statKey] }) }}
                 </p>
-                <p class="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                <p class="mt-1 text-3xs uppercase tracking-wide text-muted-foreground">
                   {{ statLabel }}
                 </p>
               </div>
@@ -348,7 +332,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
             <div class="mb-3 flex items-baseline justify-between">
               <h3 class="section-title">{{ t('beastiary.detail.jobLevels') }}</h3>
               <span
-                class="rounded-md border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-[11px] font-semibold text-primary"
+                class="rounded-md border border-primary/30 bg-primary/10 px-2 py-0.5 font-mono text-2xs font-semibold text-primary"
               >
                 {{
                   t('beastiary.detail.totalJobPoints', {

--- a/src/components/beastiary/CreatureGrid.vue
+++ b/src/components/beastiary/CreatureGrid.vue
@@ -7,9 +7,9 @@ import notSummonedIcon from '@/assets/icons/not_summoned.webp'
 import summonedIcon from '@/assets/icons/summoned.webp'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import type { Creature } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { typeColor, typeColorVar } from '@/utils/format'
+import { typeColor, typeColorVar } from '@/utils/format/format'
 import { maxLevelForState } from '@/utils/formulas'
+import { getCreatureImage } from '@/utils/images/creatureImages'
 
 defineProps<{
   groups: { tier: number; creatures: Creature[] }[]
@@ -100,7 +100,7 @@ const { isOwned, isAwakened, getLevel, setLevel, setAwakened, stepLevel, normali
 
           <!-- Tier badge -->
           <span
-            class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] font-bold text-muted-foreground shadow-sm"
+            class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1.5 py-0.5 font-mono text-3xs font-bold text-muted-foreground shadow-sm"
           >
             T{{ creature.tier + 1 }}
           </span>
@@ -110,7 +110,7 @@ const { isOwned, isAwakened, getLevel, setLevel, setAwakened, stepLevel, normali
             <span
               v-for="type in creature.types"
               :key="type"
-              class="rounded-full border px-1.5 py-px text-[10px] font-semibold leading-tight shadow-sm"
+              class="rounded-full border px-1.5 py-px text-3xs font-semibold leading-tight shadow-sm"
               :style="{
                 color: typeColor(type),
                 backgroundColor: `hsl(${typeColorVar(type)} / 0.15)`,
@@ -207,7 +207,7 @@ const { isOwned, isAwakened, getLevel, setLevel, setAwakened, stepLevel, normali
               />
               <!-- Awakened toggle -->
               <button
-                class="flex w-full items-center justify-center gap-1.5 rounded-md border px-2 py-1 text-[10px] font-semibold transition"
+                class="flex w-full items-center justify-center gap-1.5 rounded-md border px-2 py-1 text-3xs font-semibold transition"
                 :class="
                   isAwakened(creature.id)
                     ? 'border-pink-500/40 bg-pink-500/10 text-pink-400'

--- a/src/components/beastiary/CreaturesTable.vue
+++ b/src/components/beastiary/CreaturesTable.vue
@@ -2,10 +2,11 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import SortableHeader from '@/components/shared/SortableHeader.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import type { Creature, CreatureStats, Jobs } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { toTitleCase, typeColor, typeColorVar } from '@/utils/format'
+import { toTitleCase, typeColor, typeColorVar } from '@/utils/format/format'
+import { jobIcons } from '@/utils/format/icons'
 import {
   jobColors,
   jobLabels,
@@ -13,7 +14,7 @@ import {
   statLabels,
   traitAbbreviations,
 } from '@/utils/formulas'
-import { jobIcons } from '@/utils/icons'
+import { getCreatureImage } from '@/utils/images/creatureImages'
 
 const props = defineProps<{
   creatures: Creature[]
@@ -110,184 +111,89 @@ const sortedCreatures = computed(() => {
       <table class="min-w-full text-sm" role="grid">
         <thead class="bg-muted/50">
           <tr>
-            <th
-              class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :aria-sort="
-                tableSortKey === 'name'
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy('name')"
-              >
-                {{ t('beastiary.table.name') }}
-                <span :class="tableSortKey === 'name' ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
-              class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :aria-sort="
-                tableSortKey === 'type'
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy('type')"
-              >
-                {{ t('beastiary.table.type') }}
-                <span :class="tableSortKey === 'type' ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
-              class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :aria-sort="
-                tableSortKey === 'trait'
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy('trait')"
-              >
-                {{ t('beastiary.table.trait') }}
-                <span :class="tableSortKey === 'trait' ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
-              class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :aria-sort="
-                tableSortKey === 'level'
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy('level')"
-              >
-                {{ t('beastiary.table.lvl') }}
-                <span :class="tableSortKey === 'level' ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
+            <SortableHeader
+              sort-key="name"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="t('beastiary.table.name')"
+              align="left"
+              @sort="sortBy"
+            />
+            <SortableHeader
+              sort-key="type"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="t('beastiary.table.type')"
+              align="left"
+              @sort="sortBy"
+            />
+            <SortableHeader
+              sort-key="trait"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="t('beastiary.table.trait')"
+              align="left"
+              @sort="sortBy"
+            />
+            <SortableHeader
+              sort-key="level"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="t('beastiary.table.lvl')"
+              align="center"
+              @sort="sortBy"
+            />
+            <SortableHeader
               v-for="([statKey], index) in statEntries"
               :key="statKey"
-              class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :class="{ 'border-l border-border/40': index === 0 }"
-              :aria-sort="
-                tableSortKey === statKey
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy(statKey)"
-              >
-                {{ statAbbreviations[statKey] }}
-                <span :class="tableSortKey === statKey ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
-              class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :aria-sort="
-                tableSortKey === 'statTotal'
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy('statTotal')"
-              >
-                {{ t('beastiary.table.total') }}
-                <span :class="tableSortKey === 'statTotal' ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
+              :sort-key="statKey"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="statAbbreviations[statKey]"
+              align="center"
+              :th-class="index === 0 ? 'border-l border-border/40' : ''"
+              @sort="sortBy"
+            />
+            <SortableHeader
+              sort-key="statTotal"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="t('beastiary.table.total')"
+              align="center"
+              @sort="sortBy"
+            />
+            <SortableHeader
               v-for="([jobKey, jobName], index) in jobEntries"
               :key="jobKey"
-              class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :class="{ 'border-l border-border/40': index === 0 }"
-              :aria-sort="
-                tableSortKey === jobKey
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
+              :sort-key="jobKey"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              align="center"
+              :th-class="index === 0 ? 'border-l border-border/40' : ''"
+              @sort="sortBy"
             >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy(jobKey)"
-              >
-                <img
-                  v-if="jobIcons[jobKey]"
-                  :src="jobIcons[jobKey]"
-                  alt=""
-                  class="size-3.5"
-                  loading="lazy"
-                />
-                <span
-                  v-else
-                  class="inline-block size-1.5 rounded-full"
-                  :style="{ backgroundColor: jobColors[jobKey] }"
-                ></span>
-                {{ jobName.slice(0, 3) }}
-                <span :class="tableSortKey === jobKey ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
-            <th
-              class="px-2 py-3 text-center text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-              :aria-sort="
-                tableSortKey === 'jobTotal'
-                  ? tableSortDirection === 'asc'
-                    ? 'ascending'
-                    : 'descending'
-                  : 'none'
-              "
-            >
-              <button
-                class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                @click="sortBy('jobTotal')"
-              >
-                {{ t('beastiary.table.total') }}
-                <span :class="tableSortKey === 'jobTotal' ? 'text-primary' : 'opacity-0'">{{
-                  tableSortDirection === 'asc' ? '▲' : '▼'
-                }}</span>
-              </button>
-            </th>
+              <img
+                v-if="jobIcons[jobKey]"
+                :src="jobIcons[jobKey]"
+                alt=""
+                class="size-3.5"
+                loading="lazy"
+              />
+              <span
+                v-else
+                class="inline-block size-1.5 rounded-full"
+                :style="{ backgroundColor: jobColors[jobKey] }"
+              ></span>
+              {{ jobName.slice(0, 3) }}
+            </SortableHeader>
+            <SortableHeader
+              sort-key="jobTotal"
+              :active-key="tableSortKey"
+              :direction="tableSortDirection"
+              :label="t('beastiary.table.total')"
+              align="center"
+              @sort="sortBy"
+            />
           </tr>
         </thead>
         <tbody class="divide-y divide-border/60">
@@ -331,7 +237,7 @@ const sortedCreatures = computed(() => {
                   />
                   <span v-else>{{ creature.name.charAt(0) }}</span>
                   <span
-                    class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-[9px] font-bold text-muted-foreground shadow-sm"
+                    class="absolute -right-1.5 -top-1.5 z-10 rounded-md border border-border bg-card px-1 py-px font-mono text-3xs font-bold text-muted-foreground shadow-sm"
                   >
                     T{{ creature.tier + 1 }}
                   </span>
@@ -349,7 +255,7 @@ const sortedCreatures = computed(() => {
                   <span
                     v-if="isOwned(creature.id)"
                     class="text-xs"
-                    :class="isAwakened(creature.id) ? 'text-pink-400' : 'text-amber-400'"
+                    :class="isAwakened(creature.id) ? 'text-pink-400' : 'text-warning-strong'"
                     >★</span
                   >
                 </div>
@@ -393,7 +299,7 @@ const sortedCreatures = computed(() => {
             >
               <template v-if="getLevel(creature.id) > 1">
                 <p>{{ creature.stats[statKey] * getLevel(creature.id) }}</p>
-                <p class="text-[10px] text-muted-foreground/60">
+                <p class="text-3xs text-muted-foreground/60">
                   {{ creature.stats[statKey] }}
                 </p>
               </template>
@@ -406,7 +312,7 @@ const sortedCreatures = computed(() => {
             >
               <template v-if="getLevel(creature.id) > 1">
                 <p>{{ totalStats(creature) * getLevel(creature.id) }}</p>
-                <p class="text-[10px] font-normal text-muted-foreground/60">
+                <p class="text-3xs font-normal text-muted-foreground/60">
                   {{ totalStats(creature) }}
                 </p>
               </template>

--- a/src/components/beastiary/SummoningCost.vue
+++ b/src/components/beastiary/SummoningCost.vue
@@ -2,9 +2,8 @@
 import { useI18n } from 'vue-i18n'
 
 import { useItems } from '@/composables/useItems'
-import { activeLocale } from '@/i18n'
-import { toTitleCase } from '@/utils/format'
-import { getItemImage } from '@/utils/itemImages'
+import { formatNumber, toTitleCase } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -39,7 +38,7 @@ const { getItemById } = useItems()
           getItemById(cost.id)?.name ?? toTitleCase(cost.id)
         }}</span>
         <span class="font-mono text-sm font-semibold text-muted-foreground"
-          >x{{ cost.amount.toLocaleString(activeLocale()) }}</span
+          >x{{ formatNumber(cost.amount) }}</span
         >
       </router-link>
     </div>

--- a/src/components/expeditions/CreatureSelector.vue
+++ b/src/components/expeditions/CreatureSelector.vue
@@ -1,25 +1,20 @@
 <script setup lang="ts">
-import { ChevronDown, Info, Minus, Plus, Target } from 'lucide-vue-next'
+import { ChevronDown, Info, Target } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import summonedIcon from '@/assets/icons/summoned.webp'
 import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import CreatureAssignmentBadge from '@/components/shared/CreatureAssignmentBadge.vue'
+import LevelStepper from '@/components/shared/LevelStepper.vue'
 import RightClickHint from '@/components/shared/RightClickHint.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
 import type { Creature, ElementType, Expedition, ExpeditionStatWeights } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { toTitleCase, typeColor } from '@/utils/format'
+import { toTitleCase, typeColor } from '@/utils/format/format'
 import { statAbbreviations } from '@/utils/formulas'
-import {
-  sanctuaryIcon,
-  helpersIcon,
-  machinesIcon,
-  expeditionsIcon,
-  dungeonsIcon,
-} from '@/utils/icons'
+import { getCreatureImage } from '@/utils/images/creatureImages'
 
 const { t } = useI18n()
 
@@ -338,7 +333,7 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
 
       <div class="flex items-start gap-2 rounded-lg bg-muted/30 px-3 py-2">
         <Info class="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-        <p class="text-[11px] text-muted-foreground">
+        <p class="text-2xs text-muted-foreground">
           {{ t('expeditions.selector.levelHint') }}
         </p>
       </div>
@@ -365,40 +360,14 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
                 class="size-10 rounded-md border border-border object-cover"
                 loading="lazy"
               />
-              <img
-                v-if="sanctuaryCreatureIds.includes(creature.id)"
-                :src="sanctuaryIcon"
-                alt="Sanctuary"
-                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                loading="lazy"
-              />
-              <img
-                v-else-if="helperCreatureIds.includes(creature.id)"
-                :src="helpersIcon"
-                alt="Helper"
-                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                loading="lazy"
-              />
-              <img
-                v-else-if="machineCreatureIds.includes(creature.id)"
-                :src="machinesIcon"
-                alt="Machine"
-                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                loading="lazy"
-              />
-              <img
-                v-else-if="expeditionCreatureIds.has(creature.id)"
-                :src="expeditionsIcon"
-                alt="Expedition"
-                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                loading="lazy"
-              />
-              <img
-                v-else-if="dungeonParty.includes(creature.id)"
-                :src="dungeonsIcon"
-                alt="Dungeon"
-                class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
-                loading="lazy"
+              <CreatureAssignmentBadge
+                :creature-id="creature.id"
+                :sanctuary-creature-ids="sanctuaryCreatureIds"
+                :helper-creature-ids="helperCreatureIds"
+                :machine-creature-ids="machineCreatureIds"
+                :expedition-creature-ids="expeditionCreatureIds"
+                :dungeon-party="dungeonParty"
+                img-class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
               />
             </div>
 
@@ -418,7 +387,7 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
                   :class="
                     isAwakened(creature.id)
                       ? 'text-pink-600 dark:text-pink-400'
-                      : 'text-amber-700 dark:text-amber-400'
+                      : 'text-warning-strong'
                   "
                   >★</span
                 >
@@ -439,50 +408,28 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
 
           <div class="text-right" @click.stop>
             <p
-              class="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+              class="mb-1 text-3xs font-semibold uppercase tracking-[0.16em] text-muted-foreground"
             >
               {{ t('common.lvl') }}
               <span
                 v-if="suggestedLevel != null"
                 class="ml-1 normal-case tracking-normal"
-                :class="
-                  level >= suggestedLevel
-                    ? 'text-emerald-700 dark:text-emerald-400'
-                    : 'text-amber-700 dark:text-amber-400'
-                "
+                :class="level >= suggestedLevel ? 'text-success-strong' : 'text-warning-strong'"
               >
                 {{ t('common.suggested', { n: suggestedLevel }) }}
               </span>
             </p>
-            <div
-              class="inline-flex items-center overflow-hidden rounded-md border border-input bg-background/85"
-            >
-              <button
-                class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                :disabled="level <= 1"
-                :aria-label="t('common.decreaseLevel')"
-                @click.stop="emit('step-level', creature.id, level, -1)"
-              >
-                <Minus class="size-3" />
-              </button>
-              <input
-                type="text"
-                inputmode="numeric"
-                pattern="[0-9]*"
-                class="focus-ring h-7 w-11 border-x border-input bg-transparent text-center font-mono text-xs"
-                :value="level"
-                :aria-label="t('common.creatureLevel')"
-                @blur="emit('normalize-level', creature.id, level, $event)"
-              />
-              <button
-                class="focus-ring inline-flex h-7 w-7 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                :disabled="level >= 120"
-                :aria-label="t('common.increaseLevel')"
-                @click.stop="emit('step-level', creature.id, level, 1)"
-              >
-                <Plus class="size-3" />
-              </button>
-            </div>
+            <LevelStepper
+              :model-value="level"
+              :min="1"
+              :max="120"
+              :decrease-label="t('common.decreaseLevel')"
+              :increase-label="t('common.increaseLevel')"
+              :input-label="t('common.creatureLevel')"
+              @click.stop
+              @step="emit('step-level', creature.id, level, $event)"
+              @normalize="emit('normalize-level', creature.id, level, $event)"
+            />
             <p class="mt-1 font-mono text-sm font-semibold text-primary">{{ rating }}</p>
           </div>
         </div>
@@ -493,7 +440,7 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
             :key="key"
             class="grid grid-cols-[28px_minmax(0,1fr)] items-center gap-2"
           >
-            <span class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">{{
+            <span class="text-3xs font-bold uppercase tracking-wide text-muted-foreground">{{
               statAbbreviations[key]
             }}</span>
             <div class="h-1.5 rounded-full bg-muted">

--- a/src/components/expeditions/ExpeditionDetail.vue
+++ b/src/components/expeditions/ExpeditionDetail.vue
@@ -1,17 +1,23 @@
 <script setup lang="ts">
-import { ChevronDown, Compass, Minus, Plus, X } from 'lucide-vue-next'
+import { ChevronDown, Compass, Plus, X } from 'lucide-vue-next'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import LevelStepper from '@/components/shared/LevelStepper.vue'
 import RightClickHint from '@/components/shared/RightClickHint.vue'
-import { activeLocale } from '@/i18n'
 import type { Creature, Expedition, ExpeditionStatWeights } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { TIER_UNLOCK_REQUIREMENTS } from '@/utils/expeditionUnlocks'
-import { formatDecimal, formatDuration, itemName, toTitleCase } from '@/utils/format'
+import {
+  formatDecimal,
+  formatDuration,
+  formatNumber,
+  itemName,
+  toTitleCase,
+} from '@/utils/format/format'
+import { expeditionTierIcons } from '@/utils/format/icons'
 import { statLabels, tierModifiers } from '@/utils/formulas'
-import { expeditionTierIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+import { getItemImage } from '@/utils/images/itemImages'
+import { TIER_UNLOCK_REQUIREMENTS } from '@/utils/planner/expeditionUnlocks'
 
 const { t } = useI18n()
 
@@ -95,16 +101,16 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
       <!-- Quick Facts: Biome, Trait -->
       <div class="grid grid-cols-2 gap-2 text-sm">
         <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-          <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+          <p class="text-2xs uppercase tracking-wide text-muted-foreground">
             {{ t('expeditions.detail.biome') }}
           </p>
           <p class="font-semibold">{{ toTitleCase(expedition.biome) }}</p>
         </div>
         <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-          <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+          <p class="text-2xs uppercase tracking-wide text-muted-foreground">
             {{ t('expeditions.detail.trait') }}
           </p>
-          <p class="font-semibold text-amber-700 dark:text-amber-300">
+          <p class="font-semibold text-warning-strong">
             {{ expedition.trait ? toTitleCase(expedition.trait) : t('expeditions.detail.none') }}
           </p>
         </div>
@@ -158,7 +164,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
               </div>
               <span class="text-xs font-semibold">{{ creature.name }}</span>
               <span
-                class="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-semibold text-primary"
+                class="rounded-full bg-primary/15 px-2 py-0.5 text-3xs font-semibold text-primary"
                 >{{ percent }}%</span
               >
             </div>
@@ -183,13 +189,13 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
         <div class="mt-3 space-y-4" :class="showAdvancedDetails ? 'block' : 'hidden'">
           <div class="grid grid-cols-2 gap-2 text-sm">
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('expeditions.detail.rating') }}
               </p>
               <p class="font-mono font-semibold">{{ difficultyRating }}</p>
             </div>
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('expeditions.detail.xpPool') }}
               </p>
               <p class="font-semibold">
@@ -197,7 +203,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
               </p>
             </div>
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('expeditions.detail.unlockAfter') }}
               </p>
               <p class="font-semibold">
@@ -209,7 +215,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
               v-if="selectedTier > 1"
               class="rounded-lg border border-border bg-muted/35 px-3 py-2"
             >
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('expeditions.detail.tierRequires', { tier: selectedTier }) }}
               </p>
               <p class="font-semibold">
@@ -280,43 +286,27 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             {{ t('expeditions.detail.loopCount') }}
           </h4>
           <div class="flex items-center gap-2">
-            <div
-              class="inline-flex items-center overflow-hidden rounded-md border border-input bg-background/85"
-            >
-              <button
-                class="focus-ring inline-flex h-8 w-8 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                :disabled="loopCount <= 0"
-                :aria-label="t('expeditions.detail.decreaseLoopCount')"
-                @click="stepLoopCount(-10)"
-              >
-                <Minus class="size-3" />
-              </button>
-              <input
-                type="text"
-                inputmode="numeric"
-                pattern="[0-9]*"
-                class="focus-ring h-8 w-14 border-x border-input bg-transparent text-center font-mono text-sm"
-                :value="loopCount"
-                :aria-label="t('expeditions.detail.loopCountLabel')"
-                @blur="normalizeLoopCountOnBlur($event)"
-              />
-              <button
-                class="focus-ring inline-flex h-8 w-8 items-center justify-center text-muted-foreground transition hover:bg-muted/60 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                :disabled="loopCount >= 200"
-                :aria-label="t('expeditions.detail.increaseLoopCount')"
-                @click="stepLoopCount(10)"
-              >
-                <Plus class="size-3" />
-              </button>
-            </div>
+            <LevelStepper
+              :model-value="loopCount"
+              :min="0"
+              :max="200"
+              :step="10"
+              :decrease-label="t('expeditions.detail.decreaseLoopCount')"
+              :increase-label="t('expeditions.detail.increaseLoopCount')"
+              :input-label="t('expeditions.detail.loopCountLabel')"
+              button-class="h-8 w-8"
+              input-class="h-8 w-14 text-sm"
+              @step="stepLoopCount($event)"
+              @normalize="normalizeLoopCountOnBlur($event)"
+            />
             <span
               v-if="loopBonusPercent > 0"
-              class="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+              class="rounded-full bg-success/10 px-2 py-0.5 text-xs font-semibold text-success-strong dark:bg-success/15 dark:text-success-strong"
             >
               +{{ loopBonusPercent }}%
             </span>
           </div>
-          <p class="text-[11px] text-muted-foreground">{{ t('expeditions.detail.loopHint') }}</p>
+          <p class="text-2xs text-muted-foreground">{{ t('expeditions.detail.loopHint') }}</p>
         </div>
       </div>
 
@@ -351,12 +341,12 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
                     loading="lazy"
                   />
                   <span
-                    class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
+                    class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-3xs font-semibold text-cyan-300"
                   >
                     {{ getCreatureSlotRating(slot) }}
                   </span>
                   <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1.5 py-1">
-                    <p class="truncate text-center text-[10px] font-semibold text-white">
+                    <p class="truncate text-center text-3xs font-semibold text-white">
                       {{ slot.name }}
                     </p>
                   </div>
@@ -371,7 +361,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
               <template v-else>
                 <div class="flex size-full flex-col items-center justify-center gap-1">
                   <Plus class="size-4 text-muted-foreground/50" />
-                  <span v-if="activeSlotIndex === index" class="text-[9px] text-primary">{{
+                  <span v-if="activeSlotIndex === index" class="text-3xs text-primary">{{
                     t('common.select')
                   }}</span>
                 </div>
@@ -379,7 +369,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             </div>
             <span
               v-if="slot"
-              class="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-semibold text-foreground"
+              class="rounded-full bg-muted/40 px-2 py-0.5 text-3xs font-semibold text-foreground"
             >
               {{ t('levelPlanner.stats.level', { n: creatureLevels[slot.id] || 1 }) }}
             </span>
@@ -405,11 +395,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             <p class="text-muted-foreground">{{ t('expeditions.detail.scoreRatio') }}</p>
             <p
               class="font-mono text-sm font-semibold"
-              :class="
-                scoreRatio && scoreRatio >= 1
-                  ? 'text-emerald-700 dark:text-emerald-400'
-                  : 'text-amber-700 dark:text-amber-400'
-              "
+              :class="scoreRatio && scoreRatio >= 1 ? 'text-success-strong' : 'text-warning-strong'"
             >
               {{ scoreRatio ? formatDecimal(scoreRatio) : '—' }}
             </p>
@@ -421,7 +407,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             </p>
             <p
               v-if="loopCount > 0 && estimatedDuration"
-              class="mt-0.5 text-[10px] text-muted-foreground"
+              class="mt-0.5 text-3xs text-muted-foreground"
             >
               {{ formatDuration(estimatedDuration * loopCount) }}
             </p>
@@ -429,10 +415,10 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
           <div class="rounded-md bg-card px-2 py-2">
             <p class="text-muted-foreground">{{ t('expeditions.detail.xpPerCreature') }}</p>
             <p class="font-mono text-sm font-semibold">
-              {{ totalXp ? totalXp.toLocaleString(activeLocale()) : '—' }}
+              {{ totalXp ? formatNumber(totalXp) : '—' }}
               <span
                 v-if="loopBonusPercent > 0 && totalXp"
-                class="ml-0.5 inline-block rounded bg-emerald-100 px-1 py-px text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+                class="ml-0.5 inline-block rounded bg-success/10 px-1 py-px text-3xs font-semibold text-success-strong dark:bg-success/15 dark:text-success-strong"
               >
                 +{{ loopBonusPercent }}%
               </span>
@@ -442,13 +428,13 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             <p class="text-muted-foreground">{{ t('expeditions.detail.xpRate') }}</p>
             <div class="flex items-center justify-center gap-2">
               <p class="font-mono text-sm font-semibold">
-                {{ xpPerMinute ? Math.round(xpPerMinute).toLocaleString(activeLocale()) : '—'
-                }}<span class="text-[10px] text-muted-foreground">/m</span>
+                {{ xpPerMinute ? formatNumber(Math.round(xpPerMinute)) : '—'
+                }}<span class="text-3xs text-muted-foreground">/m</span>
               </p>
               <div class="h-4 border-l border-border/50" />
               <p class="font-mono text-sm font-semibold">
                 {{ xpPerMinute ? formatDecimal(xpPerMinute / 60) : '—'
-                }}<span class="text-[10px] text-muted-foreground">/s</span>
+                }}<span class="text-3xs text-muted-foreground">/s</span>
               </p>
             </div>
           </div>
@@ -461,12 +447,12 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
             class="flex items-center gap-2"
           >
             <span
-              class="w-16 shrink-0 truncate font-mono text-[10px] font-semibold text-muted-foreground"
+              class="w-16 shrink-0 truncate font-mono text-3xs font-semibold text-muted-foreground"
             >
               {{ entry.creature.name }}
             </span>
             <span
-              class="w-7 shrink-0 text-right font-mono text-[10px] font-semibold text-muted-foreground"
+              class="w-7 shrink-0 text-right font-mono text-3xs font-semibold text-muted-foreground"
             >
               {{ entry.currentLevel }}
             </span>
@@ -476,7 +462,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
                 :style="{ width: `${entry.progress * 100}%` }"
               />
             </div>
-            <span class="w-7 shrink-0 font-mono text-[10px] font-semibold text-foreground">
+            <span class="w-7 shrink-0 font-mono text-3xs font-semibold text-foreground">
               {{ entry.targetLevel }}
             </span>
           </div>

--- a/src/components/expeditions/ExpeditionList.vue
+++ b/src/components/expeditions/ExpeditionList.vue
@@ -2,7 +2,7 @@
 import { useI18n } from 'vue-i18n'
 
 import type { Expedition } from '@/types'
-import { toTitleCase } from '@/utils/format'
+import { toTitleCase } from '@/utils/format/format'
 
 const { t } = useI18n()
 

--- a/src/components/items/ItemCard.vue
+++ b/src/components/items/ItemCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Item } from '@/types'
-import { itemTypeColor } from '@/utils/format'
-import { getItemImage } from '@/utils/itemImages'
+import { itemTypeColor } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
 
 defineProps<{
   item: Item
@@ -52,7 +52,7 @@ defineEmits<{
         {{ item.name }}
       </h3>
       <span
-        class="mt-1 inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold"
+        class="mt-1 inline-block rounded-full px-2 py-0.5 text-3xs font-semibold"
         :style="{
           color: itemTypeColor(item.type),
           backgroundColor: `color-mix(in oklch, ${itemTypeColor(item.type)} 12%, transparent)`,

--- a/src/components/items/ItemDetail.vue
+++ b/src/components/items/ItemDetail.vue
@@ -1,22 +1,19 @@
 <script setup lang="ts">
-import { X, ChevronRight, ChevronDown, GitBranch } from 'lucide-vue-next'
-import { computed, ref } from 'vue'
+import { X, GitBranch } from 'lucide-vue-next'
+import { computed, toRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import RightClickHint from '@/components/shared/RightClickHint.vue'
-import { useItems } from '@/composables/useItems'
-import expeditionsData from '@/data/expeditions.json'
-import { summoningIndex } from '@/data/indexes'
+import ItemExpeditions from '@/components/items/ItemExpeditions.vue'
+import ItemJobSources from '@/components/items/ItemJobSources.vue'
+import ItemLootTable from '@/components/items/ItemLootTable.vue'
+import ItemRecipeList from '@/components/items/ItemRecipeList.vue'
+import ItemSummoning from '@/components/items/ItemSummoning.vue'
+import { useItemDetail } from '@/composables/useItemDetail'
 import type { Item } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { itemTypeColor, toTitleCase, formatDuration, formatChance } from '@/utils/format'
-import { sourceIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { itemTypeColor } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
-
-
-const expeditionById = new Map(expeditionsData.map((e) => [e.id, e]))
 
 
 const props = withDefaults(
@@ -37,163 +34,23 @@ const emit = defineEmits<{
 }>()
 
 
-const { getJobSources, getRecipeUsages, getContainerSources, getItemById } = useItems()
+const item = toRef(props, 'item')
 
 
-const summoningCreatures = computed(() => summoningIndex.get(props.item.id) ?? [])
+const {
+  summoningCreatures,
+  jobSources,
+  containerSources,
+  expeditionSources,
+  groupedJobSources,
+  dedupedRecipeUsages,
+  mergedRecipes,
+} = useItemDetail(item)
 
 
-const jobSources = computed(() => {
-  const sources = getJobSources(props.item.id)
-  // For containers, deduplicate to just show the skill name
-  if (props.item.type === 'Container') {
-    const seen = new Set<string>()
-    return sources.filter((s) => {
-      if (seen.has(s.jobId)) return false
-      seen.add(s.jobId)
-      return true
-    })
-  }
-  return sources
-})
-const recipeUsages = computed(() => getRecipeUsages(props.item.id))
-const containerSources = computed(() => getContainerSources(props.item.id))
-
-
-const expeditionSources = computed(() => {
-  return (props.item.sources ?? [])
-    .filter((s) => s?.startsWith('expedition_'))
-    .map((s) => {
-      const expId = s.replace('expedition_', '')
-      return expeditionById.get(expId)
-    })
-    .filter(Boolean) as typeof expeditionsData
-})
-
-
-const expandedJobs = ref<Set<string>>(new Set())
-
-
-const groupedJobSources = computed(() => {
-  const groups = new Map<string, typeof jobSources.value>()
-  for (const js of jobSources.value) {
-    const arr = groups.get(js.jobId)
-    if (arr) arr.push(js)
-    else groups.set(js.jobId, [js])
-  }
-  return [...groups.entries()].map(([jobId, sources]) => {
-    const levels = sources.map((s) => s.levelRequirement)
-    const chances = sources.map((s) => s.chance)
-    return {
-      jobId,
-      sources,
-      count: sources.length,
-      levelRange: [Math.min(...levels), Math.max(...levels)] as [number, number],
-      chanceRange: [Math.min(...chances), Math.max(...chances)] as [number, number],
-    }
-  })
-})
-
-
-function toggleJobGroup(jobId: string) {
-  if (expandedJobs.value.has(jobId)) expandedJobs.value.delete(jobId)
-  else expandedJobs.value.add(jobId)
-}
-
-
-const dedupedRecipeUsages = computed(() => {
-  const seen = new Set<string>()
-  return recipeUsages.value.filter((u) => {
-    if (seen.has(u.outputItemId)) return false
-    seen.add(u.outputItemId)
-    return true
-  })
-})
-
-
-interface MergedRecipe {
-  workstation: string
-  levelRequirement: number
-  craftTime: number
-  experience: [number, number]
-  outputAmount: number
-  sharedIngredients: { id: string; amount: number }[]
-  varyingIngredients: { id: string; amount: number }[][]
-}
-
-
-const mergedRecipes = computed<MergedRecipe[]>(() => {
-  const groups = new Map<string, typeof props.item.recipes>()
-  for (const r of props.item.recipes) {
-    const key = `${r.workstation}|${r.levelRequirement}`
-    const arr = groups.get(key)
-    if (arr) arr.push(r)
-    else groups.set(key, [r])
-  }
-
-  return [...groups.values()].map((recipes) => {
-    const first = recipes[0]
-    if (recipes.length === 1) {
-      return {
-        workstation: first.workstation,
-        levelRequirement: first.levelRequirement,
-        craftTime: first.craftTime,
-        experience: [first.experience, first.experience] as [number, number],
-        outputAmount: first.outputAmount,
-        sharedIngredients: first.ingredients,
-        varyingIngredients: [],
-      }
-    }
-
-    // Find shared vs varying ingredients
-    const ingredientSets = recipes.map((r) => new Map(r.ingredients.map((i) => [i.id, i.amount])))
-    const allIds = new Set(recipes.flatMap((r) => r.ingredients.map((i) => i.id)))
-    const shared: { id: string; amount: number }[] = []
-    const varyingIds = new Set<string>()
-
-    for (const id of allIds) {
-      const amounts = ingredientSets.map((m) => m.get(id))
-      if (amounts.every((a) => a === amounts[0] && a !== undefined)) {
-        shared.push({ id, amount: amounts[0]! })
-      } else {
-        varyingIds.add(id)
-      }
-    }
-
-    const varying = recipes.map((r) => r.ingredients.filter((i) => varyingIds.has(i.id)))
-
-    const xpValues = recipes.map((r) => r.experience)
-
-    return {
-      workstation: first.workstation,
-      levelRequirement: first.levelRequirement,
-      craftTime: first.craftTime,
-      experience: [Math.min(...xpValues), Math.max(...xpValues)] as [number, number],
-      outputAmount: first.outputAmount,
-      sharedIngredients: shared,
-      varyingIngredients: varying,
-    }
-  })
-})
-
-
-const expandedVariants = ref<Set<number>>(new Set())
-
-
-function toggleVariants(recipeIdx: number) {
-  if (expandedVariants.value.has(recipeIdx)) expandedVariants.value.delete(recipeIdx)
-  else expandedVariants.value.add(recipeIdx)
-}
-
-
-const jobColorMap: Record<string, string> = {
-  Chopping: 'var(--color-job-chopping)',
-  Mining: 'var(--color-job-mining)',
-  Digging: 'var(--color-job-digging)',
-  Exploring: 'var(--color-job-exploring)',
-  Fishing: 'var(--color-job-fishing)',
-  Farming: 'var(--color-job-farming)',
-}
+const hasJobOrContainerSources = computed(
+  () => jobSources.value.length > 0 || containerSources.value.length > 0,
+)
 </script>
 
 <template>
@@ -289,286 +146,23 @@ const jobColorMap: Record<string, string> = {
       </section>
 
       <!-- Obtained From -->
-      <section
-        v-if="jobSources.length || containerSources.length"
-        class="border-t border-border/60 pt-4"
-      >
-        <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
-          {{ t('items.detail.obtainedFrom') }}
-        </h3>
-        <div class="space-y-2">
-          <!-- Job activity sources -->
-          <template v-for="group in groupedJobSources" :key="group.jobId">
-            <!-- Single source: render flat (no collapse) -->
-            <div
-              v-if="group.count === 1"
-              class="-mx-1 flex items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
-            >
-              <img
-                v-if="sourceIcons[group.jobId]"
-                :src="sourceIcons[group.jobId]"
-                alt=""
-                class="size-4 shrink-0"
-                loading="lazy"
-              />
-              <span
-                v-else
-                class="size-1.5 shrink-0 rounded-full"
-                :style="{ backgroundColor: jobColorMap[group.jobId] ?? 'var(--color-text-muted)' }"
-              />
-              <div class="min-w-0 flex-1">
-                <span class="text-sm font-semibold" :style="{ color: jobColorMap[group.jobId] }">{{
-                  group.jobId
-                }}</span>
-                <span v-if="item.type !== 'Container'" class="text-sm text-muted-foreground">
-                  &middot; {{ group.sources[0].activityName }}</span
-                >
-              </div>
-              <span
-                v-if="item.type !== 'Container'"
-                class="shrink-0 font-mono text-sm"
-                style="color: var(--color-primary)"
-                >{{ t('items.detail.levelShort') }}{{ group.sources[0].levelRequirement }}</span
-              >
-              <span
-                v-if="item.type !== 'Container'"
-                class="shrink-0 font-mono text-sm"
-                style="color: var(--color-green)"
-                >{{ formatChance(group.sources[0].chance) }}</span
-              >
-            </div>
-
-            <!-- Multiple sources: collapsible group -->
-            <template v-else>
-              <div
-                class="-mx-1 flex cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
-                @click="toggleJobGroup(group.jobId)"
-              >
-                <img
-                  v-if="sourceIcons[group.jobId]"
-                  :src="sourceIcons[group.jobId]"
-                  alt=""
-                  class="size-4 shrink-0"
-                  loading="lazy"
-                />
-                <span
-                  v-else
-                  class="size-1.5 shrink-0 rounded-full"
-                  :style="{
-                    backgroundColor: jobColorMap[group.jobId] ?? 'var(--color-text-muted)',
-                  }"
-                />
-                <div class="min-w-0 flex-1">
-                  <span
-                    class="text-sm font-semibold"
-                    :style="{ color: jobColorMap[group.jobId] }"
-                    >{{ group.jobId }}</span
-                  >
-                  <span class="text-sm text-muted-foreground">
-                    &middot; {{ t('items.detail.variants', { count: group.count }) }}</span
-                  >
-                </div>
-                <span class="shrink-0 font-mono text-sm" style="color: var(--color-primary)">
-                  {{ t('items.detail.levelShort') }}{{ group.levelRange[0]
-                  }}{{
-                    group.levelRange[0] !== group.levelRange[1] ? `–${group.levelRange[1]}` : ''
-                  }}
-                </span>
-                <span class="shrink-0 font-mono text-sm" style="color: var(--color-green)">
-                  {{ formatChance(group.chanceRange[0])
-                  }}{{
-                    group.chanceRange[0] !== group.chanceRange[1]
-                      ? `–${formatChance(group.chanceRange[1])}`
-                      : ''
-                  }}
-                </span>
-                <component
-                  :is="expandedJobs.has(group.jobId) ? ChevronDown : ChevronRight"
-                  class="size-4 shrink-0 text-muted-foreground"
-                />
-              </div>
-
-              <!-- Expanded children -->
-              <template v-if="expandedJobs.has(group.jobId)">
-                <div
-                  v-for="(js, idx) in group.sources"
-                  :key="`${group.jobId}-${idx}`"
-                  class="-mx-1 flex items-center gap-3 rounded-lg py-1 pl-8 pr-3 transition hover:bg-muted/20"
-                >
-                  <div class="min-w-0 flex-1">
-                    <span class="text-sm text-muted-foreground">{{ js.activityName }}</span>
-                  </div>
-                  <span class="shrink-0 font-mono text-sm" style="color: var(--color-primary)"
-                    >{{ t('items.detail.levelShort') }}{{ js.levelRequirement }}</span
-                  >
-                  <span class="shrink-0 font-mono text-sm" style="color: var(--color-green)">{{
-                    formatChance(js.chance)
-                  }}</span>
-                </div>
-              </template>
-            </template>
-          </template>
-
-          <!-- Container sources -->
-          <div
-            v-for="(cs, idx) in containerSources"
-            :key="`container-${idx}`"
-            class="-mx-1 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
-            @click="emit('select-item', cs.containerId)"
-          >
-            <img
-              v-if="getItemImage({ id: cs.containerId })"
-              :src="getItemImage({ id: cs.containerId })"
-              :alt="cs.containerName"
-              class="size-5 shrink-0 object-contain"
-              loading="lazy"
-            />
-            <span
-              v-else
-              class="size-1.5 shrink-0 rounded-full"
-              style="background-color: var(--color-item-container)"
-            />
-            <span class="flex-1 text-sm font-semibold text-foreground">{{ cs.containerName }}</span>
-            <span class="font-mono text-sm" style="color: var(--color-yellow)"
-              >x{{ cs.amount }}</span
-            >
-            <span class="font-mono text-sm" style="color: var(--color-green)">{{
-              formatChance(cs.chance)
-            }}</span>
-          </div>
-        </div>
-      </section>
+      <ItemJobSources
+        v-if="hasJobOrContainerSources"
+        :item-type="item.type"
+        :grouped-job-sources="groupedJobSources"
+        :container-sources="containerSources"
+        @select-item="emit('select-item', $event)"
+      />
 
       <!-- Expeditions -->
-      <section v-if="expeditionSources.length" class="border-t border-border/60 pt-4">
-        <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
-          {{ t('items.detail.expeditions') }}
-        </h3>
-        <div class="space-y-2">
-          <div
-            v-for="exp in expeditionSources"
-            :key="exp.id"
-            class="-mx-1 flex items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
-          >
-            <span
-              class="size-1.5 shrink-0 rounded-full"
-              style="background-color: var(--color-item-gathered)"
-            />
-            <div class="min-w-0 flex-1">
-              <span class="text-sm font-semibold text-foreground">{{ exp.name }}</span>
-            </div>
-          </div>
-        </div>
-      </section>
+      <ItemExpeditions v-if="expeditionSources.length" :expeditions="expeditionSources" />
 
       <!-- Recipes (how to craft this item) -->
-      <section v-if="item.recipes.length" class="border-t border-border/60 pt-4">
-        <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
-          {{ t('items.detail.recipes') }}
-        </h3>
-        <div class="space-y-3">
-          <div v-for="(recipe, idx) in mergedRecipes" :key="idx" class="rounded-xl bg-muted/20 p-3">
-            <!-- Header -->
-            <p class="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground">
-              <img
-                v-if="sourceIcons[recipe.workstation]"
-                :src="sourceIcons[recipe.workstation]"
-                alt=""
-                class="size-4"
-                loading="lazy"
-              />
-              {{ recipe.workstation }}
-            </p>
-
-            <!-- Stats bar -->
-            <div class="mb-3 flex flex-wrap gap-3 text-sm">
-              <span style="color: var(--color-primary)"
-                >{{ t('items.detail.levelShort') }}{{ recipe.levelRequirement }}</span
-              >
-              <span class="text-foreground">{{ formatDuration(recipe.craftTime) }}</span>
-              <span style="color: var(--color-green)">
-                {{ recipe.experience[0]
-                }}{{
-                  recipe.experience[0] !== recipe.experience[1] ? `–${recipe.experience[1]}` : ''
-                }}
-                XP
-              </span>
-              <span v-if="recipe.outputAmount > 1" style="color: var(--color-yellow)"
-                >x{{ recipe.outputAmount }}</span
-              >
-            </div>
-
-            <!-- Divider -->
-            <div class="mb-2 border-t border-border/40" />
-
-            <!-- Shared ingredients -->
-            <div class="space-y-1">
-              <div
-                v-for="ingredient in recipe.sharedIngredients"
-                :key="ingredient.id"
-                class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 transition hover:bg-muted/50"
-                @click="emit('select-item', ingredient.id)"
-              >
-                <img
-                  v-if="getItemImage({ id: ingredient.id })"
-                  :src="getItemImage({ id: ingredient.id })"
-                  :alt="getItemById(ingredient.id)?.name"
-                  class="size-5 shrink-0 object-contain"
-                  loading="lazy"
-                />
-                <span v-else class="size-1.5 shrink-0 rounded-full bg-accent/60" />
-                <span class="flex-1 text-sm text-foreground transition hover:text-primary">{{
-                  getItemById(ingredient.id)?.name ?? toTitleCase(ingredient.id)
-                }}</span>
-                <span class="font-mono text-sm font-semibold" style="color: var(--color-yellow)"
-                  >x{{ ingredient.amount }}</span
-                >
-              </div>
-
-              <!-- Varying ingredients (dropdown) -->
-              <div v-if="recipe.varyingIngredients.length">
-                <div
-                  class="flex cursor-pointer select-none items-center gap-2 rounded px-1 py-0.5 transition hover:bg-muted/50"
-                  @click="toggleVariants(idx)"
-                >
-                  <span class="size-1.5 shrink-0 rounded-full bg-accent/60" />
-                  <span class="flex-1 text-sm text-muted-foreground">
-                    {{
-                      t('items.detail.oneOfVariants', { count: recipe.varyingIngredients.length })
-                    }}
-                  </span>
-                  <component
-                    :is="expandedVariants.has(idx) ? ChevronDown : ChevronRight"
-                    class="size-4 shrink-0 text-muted-foreground"
-                  />
-                </div>
-                <div v-if="expandedVariants.has(idx)" class="ml-4 mt-0.5 space-y-0.5">
-                  <div
-                    v-for="variant in [
-                      ...new Set(recipe.varyingIngredients.flatMap((v) => v.map((i) => i.id))),
-                    ]"
-                    :key="variant"
-                    class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 transition hover:bg-muted/50"
-                    @click="emit('select-item', variant)"
-                  >
-                    <img
-                      v-if="getItemImage({ id: variant })"
-                      :src="getItemImage({ id: variant })"
-                      :alt="getItemById(variant)?.name"
-                      class="size-5 shrink-0 object-contain"
-                      loading="lazy"
-                    />
-                    <span v-else class="size-1.5 shrink-0 rounded-full bg-accent/40" />
-                    <span class="flex-1 text-sm text-foreground transition hover:text-primary">
-                      {{ getItemById(variant)?.name ?? toTitleCase(variant) }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
+      <ItemRecipeList
+        v-if="item.recipes.length"
+        :recipes="mergedRecipes"
+        @select-item="emit('select-item', $event)"
+      />
 
       <!-- Used As Ingredient -->
       <section v-if="dedupedRecipeUsages.length" class="border-t border-border/60 pt-4">
@@ -604,75 +198,18 @@ const jobColorMap: Record<string, string> = {
       </section>
 
       <!-- Loot Table -->
-      <section v-if="item.lootTable?.length" class="border-t border-border/60 pt-4">
-        <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
-          {{ t('items.detail.lootTable') }}
-        </h3>
-        <div class="space-y-2">
-          <div
-            v-for="entry in item.lootTable"
-            :key="entry.id"
-            class="-mx-1 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
-            @click="emit('select-item', entry.id)"
-          >
-            <img
-              v-if="getItemImage({ id: entry.id })"
-              :src="getItemImage({ id: entry.id })"
-              :alt="getItemById(entry.id)?.name"
-              class="size-5 shrink-0 object-contain"
-              loading="lazy"
-            />
-            <span v-else class="size-1.5 shrink-0 rounded-full bg-accent/60" />
-            <span
-              class="flex-1 text-sm font-semibold text-foreground transition hover:text-primary"
-              >{{ getItemById(entry.id)?.name ?? toTitleCase(entry.id) }}</span
-            >
-            <span class="font-mono text-sm" style="color: var(--color-yellow)"
-              >x{{ entry.amount }}</span
-            >
-            <span class="font-mono text-sm" style="color: var(--color-green)">{{
-              formatChance(entry.chance)
-            }}</span>
-          </div>
-        </div>
-      </section>
+      <ItemLootTable
+        v-if="item.lootTable?.length"
+        :entries="item.lootTable"
+        @select-item="emit('select-item', $event)"
+      />
 
       <!-- Summoning -->
-      <section v-if="summoningCreatures.length" class="border-t border-border/60 pt-4">
-        <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
-          {{ t('items.detail.summoning') }}
-        </h3>
-        <div class="grid grid-cols-4 gap-3">
-          <RightClickHint
-            v-for="creature in summoningCreatures"
-            :key="creature.id"
-            @contextmenu="emit('select-creature', creature.id)"
-          >
-            <div
-              class="relative aspect-square overflow-hidden rounded-lg bg-muted/20 transition hover:ring-1 hover:ring-accent/40"
-            >
-              <img
-                v-if="getCreatureImage({ id: creature.id, image: '' })"
-                :src="getCreatureImage({ id: creature.id, image: '' })"
-                :alt="`${creature.name} artwork`"
-                class="size-full object-cover"
-                loading="lazy"
-              />
-              <div
-                v-else
-                class="flex size-full items-center justify-center text-2xl font-bold text-muted-foreground/50"
-              >
-                {{ creature.name.charAt(0) }}
-              </div>
-              <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
-                <p class="truncate text-center text-[10px] font-semibold text-white">
-                  {{ creature.name }}
-                </p>
-              </div>
-            </div>
-          </RightClickHint>
-        </div>
-      </section>
+      <ItemSummoning
+        v-if="summoningCreatures.length"
+        :creatures="summoningCreatures"
+        @select-creature="emit('select-creature', $event)"
+      />
     </div>
   </div>
 </template>

--- a/src/components/items/ItemExpeditions.vue
+++ b/src/components/items/ItemExpeditions.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+defineProps<{
+  expeditions: { id: string; name: string }[]
+}>()
+
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section class="border-t border-border/60 pt-4">
+    <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
+      {{ t('items.detail.expeditions') }}
+    </h3>
+    <div class="space-y-2">
+      <div
+        v-for="exp in expeditions"
+        :key="exp.id"
+        class="-mx-1 flex items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
+      >
+        <span
+          class="size-1.5 shrink-0 rounded-full"
+          style="background-color: var(--color-item-gathered)"
+        />
+        <div class="min-w-0 flex-1">
+          <span class="text-sm font-semibold text-foreground">{{ exp.name }}</span>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/items/ItemJobSources.vue
+++ b/src/components/items/ItemJobSources.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { ChevronRight, ChevronDown } from 'lucide-vue-next'
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { ContainerSource, ItemType, JobActivitySource } from '@/types'
+import { formatChance } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
+
+interface JobSourceGroup {
+  jobId: string
+  sources: JobActivitySource[]
+  count: number
+  levelRange: [number, number]
+  chanceRange: [number, number]
+}
+
+
+defineProps<{
+  itemType: ItemType
+  groupedJobSources: JobSourceGroup[]
+  containerSources: ContainerSource[]
+}>()
+
+
+const emit = defineEmits<{
+  'select-item': [id: string]
+}>()
+
+
+const { t } = useI18n()
+
+
+const expandedJobs = ref<Set<string>>(new Set())
+
+
+function toggleJobGroup(jobId: string) {
+  if (expandedJobs.value.has(jobId)) expandedJobs.value.delete(jobId)
+  else expandedJobs.value.add(jobId)
+}
+
+
+const jobColorMap: Record<string, string> = {
+  Chopping: 'var(--color-job-chopping)',
+  Mining: 'var(--color-job-mining)',
+  Digging: 'var(--color-job-digging)',
+  Exploring: 'var(--color-job-exploring)',
+  Fishing: 'var(--color-job-fishing)',
+  Farming: 'var(--color-job-farming)',
+}
+</script>
+
+<template>
+  <section class="border-t border-border/60 pt-4">
+    <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
+      {{ t('items.detail.obtainedFrom') }}
+    </h3>
+    <div class="space-y-2">
+      <!-- Job activity sources -->
+      <template v-for="group in groupedJobSources" :key="group.jobId">
+        <!-- Single source: render flat (no collapse) -->
+        <div
+          v-if="group.count === 1"
+          class="-mx-1 flex items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
+        >
+          <img
+            v-if="sourceIcons[group.jobId]"
+            :src="sourceIcons[group.jobId]"
+            alt=""
+            class="size-4 shrink-0"
+            loading="lazy"
+          />
+          <span
+            v-else
+            class="size-1.5 shrink-0 rounded-full"
+            :style="{ backgroundColor: jobColorMap[group.jobId] ?? 'var(--color-text-muted)' }"
+          />
+          <div class="min-w-0 flex-1">
+            <span class="text-sm font-semibold" :style="{ color: jobColorMap[group.jobId] }">{{
+              group.jobId
+            }}</span>
+            <span v-if="itemType !== 'Container'" class="text-sm text-muted-foreground">
+              &middot; {{ group.sources[0].activityName }}</span
+            >
+          </div>
+          <span
+            v-if="itemType !== 'Container'"
+            class="shrink-0 font-mono text-sm"
+            style="color: var(--color-primary)"
+            >{{ t('items.detail.levelShort') }}{{ group.sources[0].levelRequirement }}</span
+          >
+          <span
+            v-if="itemType !== 'Container'"
+            class="shrink-0 font-mono text-sm"
+            style="color: var(--color-green)"
+            >{{ formatChance(group.sources[0].chance) }}</span
+          >
+        </div>
+
+        <!-- Multiple sources: collapsible group -->
+        <template v-else>
+          <div
+            class="-mx-1 flex cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
+            @click="toggleJobGroup(group.jobId)"
+          >
+            <img
+              v-if="sourceIcons[group.jobId]"
+              :src="sourceIcons[group.jobId]"
+              alt=""
+              class="size-4 shrink-0"
+              loading="lazy"
+            />
+            <span
+              v-else
+              class="size-1.5 shrink-0 rounded-full"
+              :style="{
+                backgroundColor: jobColorMap[group.jobId] ?? 'var(--color-text-muted)',
+              }"
+            />
+            <div class="min-w-0 flex-1">
+              <span class="text-sm font-semibold" :style="{ color: jobColorMap[group.jobId] }">{{
+                group.jobId
+              }}</span>
+              <span class="text-sm text-muted-foreground">
+                &middot; {{ t('items.detail.variants', { count: group.count }) }}</span
+              >
+            </div>
+            <span class="shrink-0 font-mono text-sm" style="color: var(--color-primary)">
+              {{ t('items.detail.levelShort') }}{{ group.levelRange[0]
+              }}{{ group.levelRange[0] !== group.levelRange[1] ? `–${group.levelRange[1]}` : '' }}
+            </span>
+            <span class="shrink-0 font-mono text-sm" style="color: var(--color-green)">
+              {{ formatChance(group.chanceRange[0])
+              }}{{
+                group.chanceRange[0] !== group.chanceRange[1]
+                  ? `–${formatChance(group.chanceRange[1])}`
+                  : ''
+              }}
+            </span>
+            <component
+              :is="expandedJobs.has(group.jobId) ? ChevronDown : ChevronRight"
+              class="size-4 shrink-0 text-muted-foreground"
+            />
+          </div>
+
+          <!-- Expanded children -->
+          <template v-if="expandedJobs.has(group.jobId)">
+            <div
+              v-for="(js, idx) in group.sources"
+              :key="`${group.jobId}-${idx}`"
+              class="-mx-1 flex items-center gap-3 rounded-lg py-1 pl-8 pr-3 transition hover:bg-muted/20"
+            >
+              <div class="min-w-0 flex-1">
+                <span class="text-sm text-muted-foreground">{{ js.activityName }}</span>
+              </div>
+              <span class="shrink-0 font-mono text-sm" style="color: var(--color-primary)"
+                >{{ t('items.detail.levelShort') }}{{ js.levelRequirement }}</span
+              >
+              <span class="shrink-0 font-mono text-sm" style="color: var(--color-green)">{{
+                formatChance(js.chance)
+              }}</span>
+            </div>
+          </template>
+        </template>
+      </template>
+
+      <!-- Container sources -->
+      <div
+        v-for="(cs, idx) in containerSources"
+        :key="`container-${idx}`"
+        class="-mx-1 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
+        @click="emit('select-item', cs.containerId)"
+      >
+        <img
+          v-if="getItemImage({ id: cs.containerId })"
+          :src="getItemImage({ id: cs.containerId })"
+          :alt="cs.containerName"
+          class="size-5 shrink-0 object-contain"
+          loading="lazy"
+        />
+        <span
+          v-else
+          class="size-1.5 shrink-0 rounded-full"
+          style="background-color: var(--color-item-container)"
+        />
+        <span class="flex-1 text-sm font-semibold text-foreground">{{ cs.containerName }}</span>
+        <span class="font-mono text-sm" style="color: var(--color-yellow)">x{{ cs.amount }}</span>
+        <span class="font-mono text-sm" style="color: var(--color-green)">{{
+          formatChance(cs.chance)
+        }}</span>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/items/ItemLootTable.vue
+++ b/src/components/items/ItemLootTable.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import { useItems } from '@/composables/useItems'
+import type { LootTableEntry } from '@/types'
+import { toTitleCase, formatChance } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
+
+defineProps<{
+  entries: LootTableEntry[]
+}>()
+
+
+const emit = defineEmits<{
+  'select-item': [id: string]
+}>()
+
+
+const { t } = useI18n()
+const { getItemById } = useItems()
+</script>
+
+<template>
+  <section class="border-t border-border/60 pt-4">
+    <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
+      {{ t('items.detail.lootTable') }}
+    </h3>
+    <div class="space-y-2">
+      <div
+        v-for="entry in entries"
+        :key="entry.id"
+        class="-mx-1 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-1.5 transition hover:bg-muted/20"
+        @click="emit('select-item', entry.id)"
+      >
+        <img
+          v-if="getItemImage({ id: entry.id })"
+          :src="getItemImage({ id: entry.id })"
+          :alt="getItemById(entry.id)?.name"
+          class="size-5 shrink-0 object-contain"
+          loading="lazy"
+        />
+        <span v-else class="size-1.5 shrink-0 rounded-full bg-accent/60" />
+        <span class="flex-1 text-sm font-semibold text-foreground transition hover:text-primary">{{
+          getItemById(entry.id)?.name ?? toTitleCase(entry.id)
+        }}</span>
+        <span class="font-mono text-sm" style="color: var(--color-yellow)"
+          >x{{ entry.amount }}</span
+        >
+        <span class="font-mono text-sm" style="color: var(--color-green)">{{
+          formatChance(entry.chance)
+        }}</span>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/items/ItemRecipeList.vue
+++ b/src/components/items/ItemRecipeList.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { ChevronRight, ChevronDown } from 'lucide-vue-next'
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import type { MergedRecipe } from '@/composables/useItemDetail'
+import { useItems } from '@/composables/useItems'
+import { toTitleCase, formatDuration } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
+
+defineProps<{
+  recipes: MergedRecipe[]
+}>()
+
+
+const emit = defineEmits<{
+  'select-item': [id: string]
+}>()
+
+
+const { t } = useI18n()
+const { getItemById } = useItems()
+
+
+const expandedVariants = ref<Set<number>>(new Set())
+
+
+function toggleVariants(recipeIdx: number) {
+  if (expandedVariants.value.has(recipeIdx)) expandedVariants.value.delete(recipeIdx)
+  else expandedVariants.value.add(recipeIdx)
+}
+</script>
+
+<template>
+  <section class="border-t border-border/60 pt-4">
+    <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
+      {{ t('items.detail.recipes') }}
+    </h3>
+    <div class="space-y-3">
+      <div v-for="(recipe, idx) in recipes" :key="idx" class="rounded-xl bg-muted/20 p-3">
+        <!-- Header -->
+        <p class="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground">
+          <img
+            v-if="sourceIcons[recipe.workstation]"
+            :src="sourceIcons[recipe.workstation]"
+            alt=""
+            class="size-4"
+            loading="lazy"
+          />
+          {{ recipe.workstation }}
+        </p>
+
+        <!-- Stats bar -->
+        <div class="mb-3 flex flex-wrap gap-3 text-sm">
+          <span style="color: var(--color-primary)"
+            >{{ t('items.detail.levelShort') }}{{ recipe.levelRequirement }}</span
+          >
+          <span class="text-foreground">{{ formatDuration(recipe.craftTime) }}</span>
+          <span style="color: var(--color-green)">
+            {{ recipe.experience[0]
+            }}{{ recipe.experience[0] !== recipe.experience[1] ? `–${recipe.experience[1]}` : '' }}
+            XP
+          </span>
+          <span v-if="recipe.outputAmount > 1" style="color: var(--color-yellow)"
+            >x{{ recipe.outputAmount }}</span
+          >
+        </div>
+
+        <!-- Divider -->
+        <div class="mb-2 border-t border-border/40" />
+
+        <!-- Shared ingredients -->
+        <div class="space-y-1">
+          <div
+            v-for="ingredient in recipe.sharedIngredients"
+            :key="ingredient.id"
+            class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 transition hover:bg-muted/50"
+            @click="emit('select-item', ingredient.id)"
+          >
+            <img
+              v-if="getItemImage({ id: ingredient.id })"
+              :src="getItemImage({ id: ingredient.id })"
+              :alt="getItemById(ingredient.id)?.name"
+              class="size-5 shrink-0 object-contain"
+              loading="lazy"
+            />
+            <span v-else class="size-1.5 shrink-0 rounded-full bg-accent/60" />
+            <span class="flex-1 text-sm text-foreground transition hover:text-primary">{{
+              getItemById(ingredient.id)?.name ?? toTitleCase(ingredient.id)
+            }}</span>
+            <span class="font-mono text-sm font-semibold" style="color: var(--color-yellow)"
+              >x{{ ingredient.amount }}</span
+            >
+          </div>
+
+          <!-- Varying ingredients (dropdown) -->
+          <div v-if="recipe.varyingIngredients.length">
+            <div
+              class="flex cursor-pointer select-none items-center gap-2 rounded px-1 py-0.5 transition hover:bg-muted/50"
+              @click="toggleVariants(idx)"
+            >
+              <span class="size-1.5 shrink-0 rounded-full bg-accent/60" />
+              <span class="flex-1 text-sm text-muted-foreground">
+                {{ t('items.detail.oneOfVariants', { count: recipe.varyingIngredients.length }) }}
+              </span>
+              <component
+                :is="expandedVariants.has(idx) ? ChevronDown : ChevronRight"
+                class="size-4 shrink-0 text-muted-foreground"
+              />
+            </div>
+            <div v-if="expandedVariants.has(idx)" class="ml-4 mt-0.5 space-y-0.5">
+              <div
+                v-for="variant in [
+                  ...new Set(recipe.varyingIngredients.flatMap((v) => v.map((i) => i.id))),
+                ]"
+                :key="variant"
+                class="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 transition hover:bg-muted/50"
+                @click="emit('select-item', variant)"
+              >
+                <img
+                  v-if="getItemImage({ id: variant })"
+                  :src="getItemImage({ id: variant })"
+                  :alt="getItemById(variant)?.name"
+                  class="size-5 shrink-0 object-contain"
+                  loading="lazy"
+                />
+                <span v-else class="size-1.5 shrink-0 rounded-full bg-accent/40" />
+                <span class="flex-1 text-sm text-foreground transition hover:text-primary">
+                  {{ getItemById(variant)?.name ?? toTitleCase(variant) }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/items/ItemSummoning.vue
+++ b/src/components/items/ItemSummoning.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import RightClickHint from '@/components/shared/RightClickHint.vue'
+import type { SummoningReference } from '@/types'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+
+defineProps<{
+  creatures: SummoningReference[]
+}>()
+
+
+const emit = defineEmits<{
+  'select-creature': [id: string]
+}>()
+
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <section class="border-t border-border/60 pt-4">
+    <h3 class="mb-3 text-xs font-bold uppercase tracking-[0.16em] text-muted-foreground">
+      {{ t('items.detail.summoning') }}
+    </h3>
+    <div class="grid grid-cols-4 gap-3">
+      <RightClickHint
+        v-for="creature in creatures"
+        :key="creature.id"
+        @contextmenu="emit('select-creature', creature.id)"
+      >
+        <div
+          class="relative aspect-square overflow-hidden rounded-lg bg-muted/20 transition hover:ring-1 hover:ring-accent/40"
+        >
+          <img
+            v-if="getCreatureImage({ id: creature.id, image: '' })"
+            :src="getCreatureImage({ id: creature.id, image: '' })"
+            :alt="`${creature.name} artwork`"
+            class="size-full object-cover"
+            loading="lazy"
+          />
+          <div
+            v-else
+            class="flex size-full items-center justify-center text-2xl font-bold text-muted-foreground/50"
+          >
+            {{ creature.name.charAt(0) }}
+          </div>
+          <div class="absolute inset-x-0 bottom-0 bg-black/75 px-1.5 py-1">
+            <p class="truncate text-center text-3xs font-semibold text-white">
+              {{ creature.name }}
+            </p>
+          </div>
+        </div>
+      </RightClickHint>
+    </div>
+  </section>
+</template>

--- a/src/components/items/ItemsToolbar.vue
+++ b/src/components/items/ItemsToolbar.vue
@@ -7,8 +7,8 @@ import ActiveFilters from '@/components/shared/ActiveFilters.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
 import type { SourceCategory } from '@/composables/useItems'
 import type { ItemType } from '@/types'
-import { itemTypeColor, sourceLabel } from '@/utils/format'
-import { sourceIcons } from '@/utils/icons'
+import { itemTypeColor, sourceLabel } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
 
 const props = defineProps<{
   searchQuery: string
@@ -81,7 +81,7 @@ const showFilters = ref(false)
 <template>
   <div class="surface-card p-4 sm:p-5">
     <div class="flex flex-wrap items-center gap-3">
-      <label class="relative min-w-[220px] flex-1">
+      <label class="relative min-w-[var(--sidebar-width)] flex-1">
         <Search
           class="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
         />
@@ -139,7 +139,7 @@ const showFilters = ref(false)
         {{ t('common.filters') }}
         <span
           v-if="hasActiveFilters"
-          class="flex size-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground"
+          class="flex size-5 items-center justify-center rounded-full bg-primary text-3xs font-bold text-primary-foreground"
           >!</span
         >
       </button>

--- a/src/composables/plannerTourDemo.ts
+++ b/src/composables/plannerTourDemo.ts
@@ -1,0 +1,85 @@
+import type { TourObjective } from './usePlannerTour'
+
+/**
+ * Bridge between the tour (owned by the planner shell) and the live planner views
+ * that hold the actual state. On an empty planner there's nothing for the tour to
+ * highlight, so each view registers a pair of handlers: `seed` briefly populates a
+ * few sample creatures so the real components render, and `restore` puts the user's
+ * own selection back when the tour ends.
+ *
+ * The view registers synchronously in setup (the closures capture its refs) and
+ * unregisters on unmount, so the registry only ever holds handlers for the
+ * currently-mounted objective.
+ */
+export type TourDemoHandlers = {
+  /** Populate sample data so the section renders. Returns true if it actually seeded. */
+  seed: () => boolean
+  /** Restore the user's real state. Must be safe to call more than once. */
+  restore: () => void
+  /** Optional: let a step drive one of the view's sub-views (e.g. Summon's Plan vs
+   *  All-materials toggle) so the tour can actually show it. */
+  setView?: (view: string) => void
+}
+
+const registry = new Map<TourObjective, TourDemoHandlers>()
+
+// ===== Crash-safe restore =====
+// The tour always overwrites real planner data with a demo and restores it on exit. If a
+// tour is interrupted before it can restore — a hard refresh, crash, or tab close mid-tour
+// — that in-memory restore is lost. To stop the demo leaking into saved data, a seed first
+// writes the pre-seed raw values here; a normal restore clears them, and any planner mount
+// replays whatever's still armed (a self-heal) before its composables read localStorage.
+const RECOVERY_KEY = 'planner-tour-restore'
+
+/** Replay an interrupted tour's saved originals, if any. Call before reading seeded keys. */
+export function recoverTourDemo(): void {
+  let raw: string | null
+  try {
+    raw = localStorage.getItem(RECOVERY_KEY)
+  } catch {
+    return
+  }
+  if (!raw) return
+  try {
+    for (const [key, value] of Object.entries(JSON.parse(raw) as Record<string, string | null>)) {
+      if (value === null) localStorage.removeItem(key)
+      else localStorage.setItem(key, value)
+    }
+  } catch {
+    // corrupt payload — fall through and clear it
+  }
+  try {
+    localStorage.removeItem(RECOVERY_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/** Arm the recovery snapshot for a seed: maps each key it overwrites to its pre-seed raw value. */
+export function armTourRecovery(entries: Record<string, string | null>): void {
+  try {
+    localStorage.setItem(RECOVERY_KEY, JSON.stringify(entries))
+  } catch {
+    // quota / unavailable — best effort
+  }
+}
+
+/** Clear the recovery snapshot after a successful restore. */
+export function disarmTourRecovery(): void {
+  try {
+    localStorage.removeItem(RECOVERY_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+export function registerTourDemo(objective: TourObjective, handlers: TourDemoHandlers): () => void {
+  registry.set(objective, handlers)
+  return () => {
+    if (registry.get(objective) === handlers) registry.delete(objective)
+  }
+}
+
+export function getTourDemo(objective: TourObjective): TourDemoHandlers | null {
+  return registry.get(objective) ?? null
+}

--- a/src/composables/useDungeons.ts
+++ b/src/composables/useDungeons.ts
@@ -24,19 +24,19 @@ const config = dungeonData as DungeonConfig
 
 const GRADE_COLORS: Record<DungeonGradeLetter, { text: string; bg: string; border: string }> = {
   S: {
-    text: 'text-amber-600 dark:text-amber-300',
-    bg: 'bg-amber-100 dark:bg-amber-500/15',
-    border: 'border-amber-300 dark:border-amber-500/40',
+    text: 'text-warning-strong',
+    bg: 'bg-warning/10 dark:bg-warning/15',
+    border: 'border-warning/30 dark:border-warning/40',
   },
   A: {
-    text: 'text-emerald-700 dark:text-emerald-400',
-    bg: 'bg-emerald-100 dark:bg-emerald-500/15',
-    border: 'border-emerald-300 dark:border-emerald-500/40',
+    text: 'text-success-strong',
+    bg: 'bg-success/10 dark:bg-success/15',
+    border: 'border-success/30 dark:border-success/40',
   },
   B: {
-    text: 'text-sky-700 dark:text-sky-400',
-    bg: 'bg-sky-100 dark:bg-sky-500/15',
-    border: 'border-sky-300 dark:border-sky-500/40',
+    text: 'text-info-strong',
+    bg: 'bg-info/10 dark:bg-info/15',
+    border: 'border-info/30 dark:border-info/40',
   },
   C: {
     text: 'text-orange-700 dark:text-orange-400',
@@ -44,9 +44,9 @@ const GRADE_COLORS: Record<DungeonGradeLetter, { text: string; bg: string; borde
     border: 'border-orange-300 dark:border-orange-500/40',
   },
   F: {
-    text: 'text-red-700 dark:text-red-400',
-    bg: 'bg-red-100 dark:bg-red-500/15',
-    border: 'border-red-300 dark:border-red-500/40',
+    text: 'text-danger-strong',
+    bg: 'bg-danger/10 dark:bg-danger/15',
+    border: 'border-danger/30 dark:border-danger/40',
   },
 }
 

--- a/src/composables/useExpeditionTierSelections.ts
+++ b/src/composables/useExpeditionTierSelections.ts
@@ -2,8 +2,8 @@ import { useLocalStorage } from '@vueuse/core'
 import { computed } from 'vue'
 
 import { useGameConfig } from '@/composables/useGameConfig'
-import { getMaxUnlockedTier, getTotalCompletedExpeditions } from '@/utils/expeditionUnlocks'
-import { expeditions as allExpeditions } from '@/utils/precomputedTables'
+import { getMaxUnlockedTier, getTotalCompletedExpeditions } from '@/utils/planner/expeditionUnlocks'
+import { expeditions as allExpeditions } from '@/utils/save/precomputedTables'
 
 function tiersUpTo(max: number): number[] {
   const result: number[] = []

--- a/src/composables/useExpeditions.ts
+++ b/src/composables/useExpeditions.ts
@@ -368,54 +368,6 @@ export function useExpeditions(creatures: Creature[]) {
     return Array.from(ids).toSorted()
   })
 
-  function exportSetup(): string {
-    const assignedIds = new Set(Object.values(expeditionParties.value).flat())
-    const assignedLevels: Record<string, number> = {}
-    for (const id of assignedIds) {
-      if (creatureLevels.value[id]) {
-        assignedLevels[id] = creatureLevels.value[id]
-      }
-    }
-    return JSON.stringify({
-      parties: expeditionParties.value,
-      levels: assignedLevels,
-      tiers: expeditionTiers.value,
-      loopCounts: expeditionLoopCounts.value,
-    })
-  }
-
-  function importSetup(json: string): boolean {
-    try {
-      const data = JSON.parse(json)
-      if (data.parties && typeof data.parties === 'object') {
-        expeditionParties.value = data.parties
-      }
-      if (data.levels && typeof data.levels === 'object') {
-        creatureLevels.value = data.levels
-      }
-      if (data.tiers && typeof data.tiers === 'object') {
-        expeditionTiers.value = data.tiers
-      }
-      if (data.loopCounts && typeof data.loopCounts === 'object') {
-        expeditionLoopCounts.value = data.loopCounts
-      }
-      // Refresh current view
-      if (selectedExpedition.value) {
-        selectedTier.value = expeditionTiers.value[selectedExpedition.value.id] || 1
-        const ids = expeditionParties.value[selectedExpedition.value.id] || []
-        partySlots.value = Array(selectedExpedition.value.maxPartySize)
-          .fill(null)
-          .map((_, i) => {
-            const id = ids[i]
-            return id ? (creatures.find((c) => c.id === id) ?? null) : null
-          })
-      }
-      return true
-    } catch {
-      return false
-    }
-  }
-
   function resetAllExpeditions() {
     expeditionParties.value = {}
     creatureLevels.value = {}
@@ -461,8 +413,6 @@ export function useExpeditions(creatures: Creature[]) {
     allAssignedCreatureIds,
     expeditionEvaluations,
     totalXpPerSecond,
-    exportSetup,
-    importSetup,
     resetAllExpeditions,
     expeditionTiers,
     expeditionParties,

--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -4,11 +4,12 @@ import { computed, watch } from 'vue'
 import {
   defaultAwakenGatherUpgrades,
   defaultAwakenSpeedTiers,
+  defaultAwakenWorkstationXpTiers,
   defaultGardenFlowers,
 } from '@/data/defaults'
 import type { GardenCell, GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
 import { getPlayerLevel } from '@/utils/formulas'
-import { calculateJobTiersFromSanctuary } from '@/utils/parseSave'
+import { calculateJobTiersFromSanctuary, type SaveConfig } from '@/utils/save/parseSave'
 
 const sanctuaryCreatureIds = useLocalStorage<string[]>('config-sanctuary-creatures', [])
 const helperCreatureIds = useLocalStorage<string[]>('config-helper-creatures', [])
@@ -95,6 +96,10 @@ const awakenSpeedTiers = useLocalStorage<Record<string, number>>(
   'config-awaken-speed',
   defaultAwakenSpeedTiers(),
 )
+const awakenWorkstationXpTiers = useLocalStorage<Record<string, number>>(
+  'config-awaken-workstation-xp',
+  defaultAwakenWorkstationXpTiers(),
+)
 const expeditionCompletions = useLocalStorage<Record<string, Record<number, number>>>(
   'config-expedition-completions',
   {},
@@ -149,6 +154,24 @@ export function useGameConfig() {
   })
 
   const jobTiers = computed(() => calculateJobTiersFromSanctuary(sanctuaryCreatureIds.value))
+
+  // Awaken upgrade clamp bounds.
+  const AWAKEN_GATHER_YIELD_MAX = 2
+  const AWAKEN_GATHER_DURATION_MAX = 4
+  const AWAKEN_GATHER_XP_MAX = 6
+  const AWAKEN_SPEED_MAX = 4
+  const AWAKEN_WORKSTATION_XP_MAX = 5
+  const AWAKEN_GOLD_MAX = 5
+
+  /** Clamp a value to [0, max]. */
+  function clamp(value: number, max: number): number {
+    return Math.max(0, Math.min(max, value))
+  }
+
+  /** Zero-value default for a single AwakenGatherUpgrade entry. */
+  function defaultAwakenGatherUpgrade(): AwakenGatherUpgrade {
+    return { yieldBonus: 0, durationTier: 0, xpTier: 0 }
+  }
 
   function setSanctuaryCreatures(ids: string[]) {
     sanctuaryCreatureIds.value = ids
@@ -255,31 +278,47 @@ export function useGameConfig() {
   }
 
   function setAwakenGatherYieldBonus(jobId: string, yieldBonus: number) {
-    const current = awakenGatherUpgrades.value[jobId] ?? { yieldBonus: 0, durationTier: 0 }
+    const current = awakenGatherUpgrades.value[jobId] ?? defaultAwakenGatherUpgrade()
     awakenGatherUpgrades.value = {
       ...awakenGatherUpgrades.value,
-      [jobId]: { ...current, yieldBonus: Math.max(0, Math.min(2, yieldBonus)) },
+      [jobId]: { ...current, yieldBonus: clamp(yieldBonus, AWAKEN_GATHER_YIELD_MAX) },
     }
   }
 
   function setAwakenGatherDurationTier(jobId: string, tier: number) {
-    const current = awakenGatherUpgrades.value[jobId] ?? { yieldBonus: 0, durationTier: 0 }
+    const current = awakenGatherUpgrades.value[jobId] ?? defaultAwakenGatherUpgrade()
     awakenGatherUpgrades.value = {
       ...awakenGatherUpgrades.value,
-      [jobId]: { ...current, durationTier: Math.max(0, Math.min(4, tier)) },
+      [jobId]: { ...current, durationTier: clamp(tier, AWAKEN_GATHER_DURATION_MAX) },
+    }
+  }
+
+  function setAwakenGatherXpTier(jobId: string, tier: number) {
+    const current = awakenGatherUpgrades.value[jobId] ?? defaultAwakenGatherUpgrade()
+    awakenGatherUpgrades.value = {
+      ...awakenGatherUpgrades.value,
+      [jobId]: { ...current, xpTier: clamp(tier, AWAKEN_GATHER_XP_MAX) },
     }
   }
 
   function setAwakenSpeedTier(workstation: string, tier: number) {
     awakenSpeedTiers.value = {
       ...awakenSpeedTiers.value,
-      [workstation]: Math.max(0, Math.min(4, tier)),
+      [workstation]: clamp(tier, AWAKEN_SPEED_MAX),
+    }
+  }
+
+  function setAwakenWorkstationXpTier(workstation: string, tier: number) {
+    awakenWorkstationXpTiers.value = {
+      ...awakenWorkstationXpTiers.value,
+      [workstation]: clamp(tier, AWAKEN_WORKSTATION_XP_MAX),
     }
   }
 
   function resetAwaken() {
     awakenGatherUpgrades.value = defaultAwakenGatherUpgrades()
     awakenSpeedTiers.value = defaultAwakenSpeedTiers()
+    awakenWorkstationXpTiers.value = defaultAwakenWorkstationXpTiers()
   }
 
   function setExpeditionCompletions(completions: Record<string, Record<number, number>>) {
@@ -321,7 +360,7 @@ export function useGameConfig() {
   }
 
   function setAwakenGoldLevel(level: number) {
-    awakenGoldLevel.value = Math.max(0, Math.min(5, level))
+    awakenGoldLevel.value = clamp(level, AWAKEN_GOLD_MAX)
   }
 
   function setSkillLevels(levels: Record<string, number>) {
@@ -416,32 +455,99 @@ export function useGameConfig() {
     writeDungeonKey('dungeon-creature-levels', null)
   }
 
+  // Apply the config-owned portion of an imported save. Preserves the exact
+  // order and effect of the original ConfigsView.applyAll setter sequence.
+  // View-local concerns (creature collection, summon planner, applied-section
+  // tracking) stay in the view and are not touched here.
+  function applySaveConfig(save: SaveConfig) {
+    setSanctuaryCreatures(save.sanctuary)
+    setHelperCreatures(save.helpers)
+    setMachineCreatures(save.machines)
+    setDungeonParty(save.currentDungeon?.party ?? [])
+
+    inventoryAmounts.value = { ...save.inventory }
+    setCollectedItems([...save.collectedItems])
+
+    setQueuedAmounts({ ...save.queuedAmounts })
+    setQueuedTimes({ ...save.queuedTimes })
+
+    awakenGatherUpgrades.value = { ...save.awakenGatherUpgrades }
+    awakenSpeedTiers.value = { ...save.awakenSpeedTiers }
+    awakenWorkstationXpTiers.value = { ...save.awakenWorkstationXpTiers }
+    setAwakenGoldLevel(save.awakenGoldLevel)
+
+    setExpeditionToolXpBonus(((save.tools?.sword || 0) * 5) / 100 + 1)
+    setToolLevels({ ...save.toolLevels })
+    setToolSpeedModes({ ...save.toolSpeedModes })
+
+    setSkillLevels({ ...save.skillLevels })
+
+    setMachineLevels({ ...save.machineLevels })
+    setMachineRecipes({ ...save.machineRecipes })
+
+    setFabricationAllocations({ ...save.fabricationAllocations })
+
+    setExpeditionCompletions({ ...save.expeditionCompletions })
+
+    setExpeditionParties({ ...save.currentExpedition.parties })
+    setExpeditionCreatureLevels({ ...save.currentExpedition.levels })
+    setExpeditionTiers({ ...save.currentExpedition.tiers })
+    setExpeditionLoopCounts({ ...save.currentExpedition.loopCounts })
+
+    if (save.currentDungeon) applyDungeonStateFromSave(save.currentDungeon)
+  }
+
+  // Reset the config-owned portion of state. Preserves the exact order and
+  // effect of the original ConfigsView.resetAll config resets. View-local
+  // concerns (creature collection, garden, summon planner, saveConfig and
+  // metadata, applied-section tracking) stay in the view.
+  function resetAllConfig() {
+    setSanctuaryCreatures([])
+    setHelperCreatures([])
+    setMachineCreatures([])
+    inventoryAmounts.value = {}
+    resetCollectedItems()
+    resetQueuedAmounts()
+    resetAwaken()
+    setAwakenGoldLevel(0)
+    resetToolLevels()
+    setExpeditionToolXpBonus(1)
+    resetMachines()
+    resetFabrication()
+    expeditionCompletions.value = {}
+    resetExpeditionSetup()
+    resetSkillLevels()
+    resetDungeonParty()
+    resetDungeonStorage()
+  }
+
   return {
-    sanctuaryCreatureIds,
-    helperCreatureIds,
-    machineCreatureIds,
-    expeditionParties,
-    expeditionTiers,
-    expeditionCreatureLevels,
-    expeditionLoopCounts,
+    sanctuaryCreatureIds: sanctuaryCreatureIds,
+    helperCreatureIds: helperCreatureIds,
+    machineCreatureIds: machineCreatureIds,
+    expeditionParties: expeditionParties,
+    expeditionTiers: expeditionTiers,
+    expeditionCreatureLevels: expeditionCreatureLevels,
+    expeditionLoopCounts: expeditionLoopCounts,
     expeditionCreatureIds,
     excludedCreatureIds,
     jobTiers,
-    inventoryAmounts,
-    collectedItems,
+    inventoryAmounts: inventoryAmounts,
+    collectedItems: collectedItems,
     setCollectedItems,
     resetCollectedItems,
-    gardenFlowers,
-    gardenLayout,
-    gardenLayoutFromSave,
-    awakenGatherUpgrades,
-    awakenSpeedTiers,
-    expeditionCompletions,
-    toolLevels,
-    toolSpeedModes,
-    machineLevels,
-    machineRecipes,
-    fabricationAllocations,
+    gardenFlowers: gardenFlowers,
+    gardenLayout: gardenLayout,
+    gardenLayoutFromSave: gardenLayoutFromSave,
+    awakenGatherUpgrades: awakenGatherUpgrades,
+    awakenSpeedTiers: awakenSpeedTiers,
+    awakenWorkstationXpTiers: awakenWorkstationXpTiers,
+    expeditionCompletions: expeditionCompletions,
+    toolLevels: toolLevels,
+    toolSpeedModes: toolSpeedModes,
+    machineLevels: machineLevels,
+    machineRecipes: machineRecipes,
+    fabricationAllocations: fabricationAllocations,
     setSanctuaryCreatures,
     setHelperCreatures,
     setMachineCreatures,
@@ -451,11 +557,13 @@ export function useGameConfig() {
     setExpeditionCreatureLevels,
     setExpeditionLoopCounts,
     resetExpeditionSetup,
-    dungeonParty,
+    dungeonParty: dungeonParty,
     setDungeonParty,
     resetDungeonParty,
     applyDungeonStateFromSave,
     resetDungeonStorage,
+    applySaveConfig,
+    resetAllConfig,
     setInventory,
     resetInventory,
     setGardenFlowerEntries,
@@ -468,7 +576,9 @@ export function useGameConfig() {
     resetGarden,
     setAwakenGatherYieldBonus,
     setAwakenGatherDurationTier,
+    setAwakenGatherXpTier,
     setAwakenSpeedTier,
+    setAwakenWorkstationXpTier,
     resetAwaken,
     setToolLevels,
     setToolSpeedModes,
@@ -480,15 +590,15 @@ export function useGameConfig() {
     resetFabrication,
     resetGameConfig,
     setExpeditionToolXpBonus,
-    expeditionToolXpBonus,
-    awakenGoldLevel,
+    expeditionToolXpBonus: expeditionToolXpBonus,
+    awakenGoldLevel: awakenGoldLevel,
     setAwakenGoldLevel,
-    skillLevels,
+    skillLevels: skillLevels,
     playerLevel,
     setSkillLevels,
     resetSkillLevels,
-    queuedAmounts,
-    queuedTimes,
+    queuedAmounts: queuedAmounts,
+    queuedTimes: queuedTimes,
     setQueuedAmounts,
     setQueuedTimes,
     resetQueuedAmounts,

--- a/src/composables/useGoldIncome.ts
+++ b/src/composables/useGoldIncome.ts
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { useAwakenSimulation } from '@/composables/useAwakenSimulation'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useGameConfig } from '@/composables/useGameConfig'
-import { computeGoldPerMinute } from '@/utils/goldIncome'
+import { computeGoldPerMinute } from '@/utils/planner/goldIncome'
 
 interface GoldIncomeBreakdown {
   awakenedCount: number

--- a/src/composables/usePlannerTour.ts
+++ b/src/composables/usePlannerTour.ts
@@ -1,0 +1,326 @@
+import { useLocalStorage } from '@vueuse/core'
+import type { DriveStep, Driver } from 'driver.js'
+import { nextTick } from 'vue'
+
+import { getTourDemo } from '@/composables/plannerTourDemo'
+import { t } from '@/i18n'
+import { PLANNER_TERMS, type TermKey } from '@/utils/planner/plannerGlossary'
+
+/**
+ * Guided walkthrough for the Creature Planner, built on driver.js.
+ *
+ * One short intro (anchored to the objective selector) plus a dedicated step list
+ * per objective. Step copy pulls term definitions from `plannerGlossary` so the
+ * tour and the inline info-hints stay in sync.
+ *
+ * On an empty planner there'd be nothing to highlight, so before driving we ask the
+ * mounted view (via `plannerTourDemo`) to seed a few sample creatures — the tour
+ * then walks the real, live components and the seed is reverted when it ends. A step
+ * whose anchor still isn't in the DOM (no demo for that objective, or not enough
+ * sample creatures) is not dropped: it becomes a centered card that still explains
+ * the feature.
+ */
+export type TourObjective = 'summon' | 'awaken-rush' | 'prestige-loop'
+
+// Versioned key: bump the suffix to re-trigger the first-visit tour after a redesign.
+const TOUR_SEEN_KEY = 'planner-tour-seen-v2'
+
+/** Short glossary definition, for inlining into step copy. */
+const def = (k: TermKey) => PLANNER_TERMS[k].short
+
+// The one tour that's currently driving, if any. We track its teardown so the shell can
+// end it on navigation/tab-change (driver.js isn't Vue-lifecycle-aware) using the same
+// path as a user-initiated close.
+let activeFinish: (() => void) | null = null
+
+// Built lazily (inside startTour), not at module scope: the step copy calls t(), and
+// t() must run when the tour starts so it picks up the user's current locale. A
+// module-level const would freeze the strings to whatever locale was active at import.
+function buildIntroStep(): DriveStep {
+  return {
+    element: '[data-tour="objective-selector"]',
+    popover: {
+      title: t('planner.tour.welcome.title'),
+      description: t('planner.tour.welcome.body'),
+      side: 'bottom',
+      align: 'start',
+    },
+  }
+}
+
+// Drive Summon's Plan ⇄ All-materials toggle so a step can show the right view. The
+// view-specific anchors (rail, focus) come first while we're in Plan; the toggle is
+// present in both views, so we pre-switch to All-materials as that step settles
+// (onHighlighted) — by the time the user advances, the materials list has rendered and
+// its anchor resolves. Each step also asserts its own view so back-navigation recovers.
+const summonView = (v: 'plan' | 'materials') => () => getTourDemo('summon')?.setView?.(v)
+
+// Built lazily for the same reason as buildIntroStep: t() must run at tour-start so the
+// step titles/bodies reflect the current locale rather than the import-time locale.
+function buildSteps(): Record<TourObjective, DriveStep[]> {
+  return {
+    summon: [
+      {
+        element: '[data-tour="summon-header"]',
+        onHighlightStarted: summonView('plan'),
+        popover: {
+          title: t('planner.tour.summonHeader.title'),
+          description: t('planner.tour.summonHeader.body'),
+          side: 'bottom',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="summon-rail"]',
+        onHighlightStarted: summonView('plan'),
+        popover: {
+          title: t('planner.tour.summonOrder.title'),
+          description: t('planner.tour.summonOrder.body'),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="summon-focus"]',
+        onHighlightStarted: summonView('plan'),
+        popover: {
+          title: t('planner.tour.summonFocus.title'),
+          description: t('planner.tour.summonFocus.body'),
+          side: 'left',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="summon-views"]',
+        onHighlightStarted: summonView('plan'),
+        onHighlighted: summonView('materials'),
+        popover: {
+          title: t('planner.tour.summonViews.title'),
+          description: t('planner.tour.summonViews.body'),
+          side: 'bottom',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="summon-materials"]',
+        onHighlightStarted: summonView('materials'),
+        popover: {
+          title: t('planner.tour.summonMaterials.title'),
+          description: t('planner.tour.summonMaterials.body'),
+          side: 'top',
+          align: 'start',
+        },
+      },
+    ],
+    'awaken-rush': [
+      {
+        element: '[data-tour="awaken-rail"]',
+        popover: {
+          title: t('planner.tour.awakenQueue.title'),
+          description: t('planner.tour.awakenQueue.body'),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-boosters"]',
+        popover: {
+          title: t('planner.tour.awakenBoosters.title'),
+          description: t('planner.tour.awakenBoosters.body'),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-strategy"]',
+        popover: {
+          title: t('planner.tour.awakenStrategy.title'),
+          description: t('planner.tour.awakenStrategy.body'),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-expeditions"]',
+        popover: {
+          title: t('planner.tour.awakenExpeditions.title'),
+          description: t('planner.tour.awakenExpeditions.body'),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-focus"]',
+        popover: {
+          title: t('planner.tour.awakenFocus.title'),
+          description: t('planner.tour.awakenFocus.body'),
+          side: 'left',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-views"]',
+        popover: {
+          title: t('planner.tour.awakenViews.title'),
+          description: t('planner.tour.awakenViews.body'),
+          side: 'bottom',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-timeline"]',
+        popover: {
+          title: t('planner.tour.awakenTimeline.title'),
+          description: t('planner.tour.awakenTimeline.body'),
+          side: 'top',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="awaken-setup"]',
+        popover: {
+          title: t('planner.tour.awakenSetup.title'),
+          description: t('planner.tour.awakenSetup.body'),
+          side: 'bottom',
+          align: 'end',
+        },
+      },
+    ],
+    'prestige-loop': [
+      {
+        element: '[data-tour="prestige-roster"]',
+        popover: {
+          title: t('planner.tour.loopRoster.title'),
+          description: t('planner.tour.loopRoster.body', {
+            anchor: PLANNER_TERMS.rosterRoleAnchor.term,
+            booster: PLANNER_TERMS.rosterRoleBooster.term,
+            climber: PLANNER_TERMS.rosterRoleClimber.term,
+          }),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="prestige-cadence"]',
+        popover: {
+          title: t('planner.tour.loopCadence.title'),
+          description: t('planner.tour.loopCadence.body', { cadence: def('cadence') }),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="prestige-expeditions"]',
+        popover: {
+          title: t('planner.tour.loopExpeditions.title'),
+          description: t('planner.tour.loopExpeditions.body'),
+          side: 'right',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="prestige-hero"]',
+        popover: {
+          title: t('planner.tour.loopHero.title'),
+          description: t('planner.tour.loopHero.body', { prestige: def('prestige') }),
+          side: 'bottom',
+          align: 'start',
+        },
+      },
+      {
+        element: '[data-tour="prestige-tabs"]',
+        popover: {
+          title: t('planner.tour.loopTabs.title'),
+          description: t('planner.tour.loopTabs.body', { levelChart: def('levelChart') }),
+          side: 'bottom',
+          align: 'start',
+        },
+      },
+    ],
+  }
+}
+
+/**
+ * Build the steps driver.js runs. A step whose anchor is on the page highlights it
+ * live; a step whose anchor is missing (no demo seeded for it) becomes a centered
+ * card that keeps its copy — so the tour previews every feature instead of skipping
+ * ahead.
+ */
+function prepareSteps(steps: DriveStep[]): DriveStep[] {
+  return steps.map((step) => {
+    const sel = typeof step.element === 'string' ? step.element : null
+    const present = sel ? document.querySelector(sel) !== null : true
+    return present ? step : { ...step, element: undefined }
+  })
+}
+
+export function usePlannerTour() {
+  const hasSeenTour = useLocalStorage<boolean>(TOUR_SEEN_KEY, false)
+
+  async function startTour(objective: TourObjective, opts: { includeIntro?: boolean } = {}) {
+    // Seed sample data so the live components render, then wait one tick for Vue to
+    // flush the DOM before driver.js queries for the anchors. `nextTick` is microtask-
+    // based, so (unlike requestAnimationFrame) it still resolves in a backgrounded tab.
+    const demo = getTourDemo(objective)
+    const seeded = demo ? demo.seed() : false
+    if (seeded) await nextTick()
+
+    const allSteps = buildSteps()
+    const base = opts.includeIntro
+      ? [buildIntroStep(), ...allSteps[objective]]
+      : allSteps[objective]
+    const steps = prepareSteps(base)
+    if (steps.length === 0) {
+      if (seeded) demo?.restore()
+      return
+    }
+
+    // Lazy-load driver.js (+ its CSS) only when a tour actually runs — keeps the
+    // ~96KB library out of the planner route chunk for the ~95% who never start it.
+    const { driver } = await import('driver.js')
+    await import('driver.js/dist/driver.css')
+
+    // Restore + mark-seen runs from onDestroyStarted, which driver.js calls synchronously
+    // for every close gesture (×, Esc, overlay, Done). We deliberately avoid onDestroyed:
+    // it's gated on driver's active element, which driver sets inside a requestAnimationFrame
+    // — so it can be skipped in a backgrounded tab. `finish` is idempotent and, because we
+    // override onDestroyStarted, is responsible for actually tearing the overlay down.
+    let d: Driver | null = null
+    const finish = () => {
+      if (activeFinish !== finish) return // already finished
+      activeFinish = null
+      hasSeenTour.value = true
+      if (seeded) demo?.restore()
+      d?.destroy() // g(false): removes the overlay without re-entering onDestroyStarted
+    }
+
+    try {
+      d = driver({
+        showProgress: true,
+        allowClose: true,
+        nextBtnText: t('planner.tour.nav.next'),
+        prevBtnText: t('planner.tour.nav.back'),
+        doneBtnText: t('planner.tour.nav.done'),
+        popoverClass: 'planner-tour-popover',
+        steps,
+        onDestroyStarted: finish,
+      })
+      activeFinish = finish
+      d.drive()
+    } catch (err) {
+      activeFinish = null
+      if (seeded) demo?.restore()
+      throw err
+    }
+  }
+
+  // End an in-progress tour from outside (navigation / tab-change): driver.js's overlay
+  // lives on document.body, not in Vue, so the shell calls this on unmount/tab-change —
+  // otherwise the overlay orphans onto the next page and the demo data is never reverted.
+  // It runs the same `finish` path as a user close, so it restores too.
+  function stopTour() {
+    activeFinish?.()
+  }
+
+  return { hasSeenTour, startTour, stopTour }
+}

--- a/src/composables/useRecommendations.ts
+++ b/src/composables/useRecommendations.ts
@@ -1,8 +1,9 @@
 import { computed, type ComputedRef, type Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-import { machineRecipeIndex, machineSpeedMultipliers } from '@/data/indexes'
+import { itemById, machineRecipeIndex, machineSpeedMultipliers } from '@/data/indexes'
 import type { PlannerMethod, PlannerNode } from '@/types'
+import { JOB_TIER_DURATION_REDUCTION } from '@/utils/formulas'
 
 import { useGameConfig } from './useGameConfig'
 
@@ -26,14 +27,31 @@ export function useRecommendations(
 
     const {
       machineLevels,
+      machineRecipes,
       awakenGatherUpgrades,
       awakenSpeedTiers,
       fabricationAllocations,
       jobTiers,
     } = gameConfig
 
-    // Job tier reduction/bonus constants (mirrors useCraftPlanner.ts)
-    const JOB_TIER_DURATION_REDUCTION = [0, 0, 0.1, 0.1, 0.2, 0.2]
+    // Phase C — machine switch advisory. A processor (one recipe at a time) that COULD make a
+    // planned item but is set to a different recipe (or idle) can be retasked to produce it
+    // passively. Pre-scan which processors are wanted by which plan items, to flag contention.
+    const switchWants = new Map<string, { nodeId: string; itemName: string }[]>()
+    for (const node of Object.values(nodesById.value)) {
+      if (node.fulfilled) continue
+      const m = getActiveMethod(node.id)
+      if (!m || m.kind === 'machine') continue // already produced passively by a machine
+      for (const source of machineRecipeIndex.get(node.itemId) ?? []) {
+        if (source.inputItemId == null) continue // generator: always running, nothing to switch
+        const selected = machineRecipes.value[source.machineId]
+        if (selected === 'all' || selected === node.itemId) continue // already makes this item
+        const list = switchWants.get(source.machineId) ?? []
+        list.push({ nodeId: node.id, itemName: node.itemName })
+        switchWants.set(source.machineId, list)
+      }
+    }
+
     const MAX_JOB_TIER = JOB_TIER_DURATION_REDUCTION.length - 1
 
     // Max constants from useGameConfig setters
@@ -49,6 +67,42 @@ export function useRecommendations(
       if (!method) continue
 
       const kind = method.kind
+
+      // --- Machine switch advisory (Phase C) ---
+      // If a processor could make this item but is set elsewhere, retasking it produces the
+      // item passively (saving active gather/craft). Advisory only — does not change selection.
+      if (kind !== 'machine') {
+        const switchable = (machineRecipeIndex.get(node.itemId) ?? []).find((s) => {
+          if (s.inputItemId == null) return false // generator
+          const sel = machineRecipes.value[s.machineId]
+          return sel !== 'all' && sel !== node.itemId
+        })
+        if (switchable) {
+          const sel = machineRecipes.value[switchable.machineId]
+          const current = sel
+            ? (itemById.get(sel)?.name ?? sel)
+            : t('recommendations.machineSwitchIdle')
+          const others = (switchWants.get(switchable.machineId) ?? [])
+            .filter((w) => w.nodeId !== node.id)
+            .map((w) => w.itemName)
+          const contention =
+            others.length > 0
+              ? t('recommendations.machineSwitchContention', {
+                  items: others.slice(0, 2).join(', '),
+                  more: others.length > 2 ? '…' : '',
+                })
+              : ''
+          result[node.id] = {
+            text:
+              t('recommendations.machineSwitch', {
+                machine: switchable.machineName,
+                current,
+                item: node.itemName,
+              }) + contention,
+          }
+          continue
+        }
+      }
 
       // --- Machine upgrade recommendation ---
       if (kind === 'machine') {

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,6 +1,7 @@
 import {
   formatChance,
   formatDuration,
+  formatNumberCompact,
   itemName,
   machineName,
   methodKindClasses,
@@ -9,7 +10,7 @@ import {
   sourceLabel,
   toolName,
   toTitleCase,
-} from '@/utils/format'
+} from '@/utils/format/format'
 
 describe('formatDuration', () => {
   test('zero seconds', () => {
@@ -188,9 +189,9 @@ describe('methodKindClasses', () => {
     expect(classes).toContain('orange')
   })
 
-  test('fabrication kind includes violet classes', () => {
+  test('fabrication kind includes reserved (violet) token classes', () => {
     const classes = methodKindClasses('fabrication')
-    expect(classes).toContain('violet')
+    expect(classes).toContain('reserved')
   })
 })
 
@@ -231,5 +232,27 @@ describe('machineName', () => {
 
   test('falls back to title-cased id for unknown id', () => {
     expect(machineName('totally-fake-machine')).toBe('Totally Fake Machine')
+  })
+})
+
+describe('formatNumberCompact', () => {
+  // Canonical house style (unifies the former PlannerGantt "1.0K" and InventoryGridSection "1k"
+  // helpers): uppercase K/M, trailing ".0" dropped, sub-1000 falls through to formatNumber.
+  test('abbreviates thousands with uppercase K', () => {
+    expect(formatNumberCompact(1_500)).toBe('1.5K')
+  })
+
+  test('abbreviates millions with uppercase M', () => {
+    expect(formatNumberCompact(2_000_000)).toBe('2M')
+  })
+
+  test('drops a trailing .0', () => {
+    expect(formatNumberCompact(3_000)).toBe('3K')
+    expect(formatNumberCompact(5_000_000)).toBe('5M')
+  })
+
+  test('passes values below 1000 through to formatNumber', () => {
+    expect(formatNumberCompact(999)).toBe('999')
+    expect(formatNumberCompact(0)).toBe('0')
   })
 })

--- a/src/utils/__tests__/generateBaselines.test.ts
+++ b/src/utils/__tests__/generateBaselines.test.ts
@@ -11,8 +11,8 @@ import { resolve } from 'path'
 
 import { describe, test } from 'vitest'
 
-import { planPartyLevelingPath } from '@/utils/partyPlanner'
-import { scorePlan } from '@/utils/planScorer'
+import { planPartyLevelingPath } from '@/utils/planner/partyPlanner'
+import { scorePlan } from '@/utils/planner/planScorer'
 
 import collectionFull from './fixtures/collection-full.json'
 import collectionSmall from './fixtures/collection-small.json'

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -1,5 +1,4 @@
-import biomesData from '@/data/biomes.json'
-import expeditionsData from '@/data/expeditions.json'
+import { biomeMap, expeditions } from '@/data/entityMaps'
 import { i18nRecord } from '@/i18n'
 import type {
   Creature,
@@ -66,6 +65,12 @@ export const jobColors: Record<keyof Creature['jobs'], string> = {
   fishing: 'var(--color-job-fishing)',
   farming: 'var(--color-job-farming)',
 }
+
+/** Cumulative duration reduction fraction per sanctuary job tier (index = tier 0–5). */
+export const JOB_TIER_DURATION_REDUCTION: readonly number[] = [0, 0, 0.1, 0.1, 0.2, 0.2]
+
+/** Cumulative yield bonus per sanctuary job tier (index = tier 0–5). */
+export const JOB_TIER_YIELD_BONUS: readonly number[] = [0, 0, 0, 0, 0, 1]
 
 export const tierModifiers = {
   difficulty: [1, 1.5, 2, 2.5, 3],
@@ -210,58 +215,52 @@ interface BestExpeditionEntry {
   statAlignment: number
 }
 
-export function getBestExpeditionsForCreature(
-  creature: Creature,
-  limit: number = 5,
-): BestExpeditionEntry[] {
-  const expeditions = expeditionsData as Expedition[]
-  const biomes = biomesData as Biome[]
-  const biomeMap = new Map(biomes.map((b) => [b.id, b]))
-
-  // Normalize creature stats to proportions (sum to 1)
-  const statKeys: (keyof CreatureStats)[] = [
-    'power',
-    'grit',
-    'agility',
-    'smarts',
-    'looting',
-    'luck',
-  ]
-  const statTotal = statKeys.reduce((sum, k) => sum + creature.stats[k], 0)
-  const creatureProportions = statKeys.map((k) =>
-    statTotal > 0 ? creature.stats[k] / statTotal : 0,
+/**
+ * Stat alignment (0–1): dot product of the creature's stat proportions (its stats
+ * normalized to sum to 1) with the expedition's normalized stat weights. Used for the
+ * display/ranking score in both best-expedition rankings below.
+ */
+function statAlignmentScore(creature: Creature, expedition: Expedition): number {
+  const statTotal = STAT_KEYS.reduce((sum, k) => sum + creature.stats[k], 0)
+  const weightTotal = STAT_KEYS.reduce((sum, k) => sum + expedition.statWeights[k], 0)
+  if (statTotal <= 0 || weightTotal <= 0) return 0
+  return STAT_KEYS.reduce(
+    (sum, k) => sum + (creature.stats[k] / statTotal) * (expedition.statWeights[k] / weightTotal),
+    0,
   )
+}
 
+/**
+ * Shared scaffolding for best-expedition rankings. Handles biome-status, stat-alignment,
+ * and map/sort/slice; callers supply only the per-expedition numeric score.
+ */
+function rankExpeditions(
+  creature: Creature,
+  limit: number,
+  scoreFn: (
+    expedition: Expedition,
+    biome: Biome | undefined,
+    statAlignment: number,
+    traitMatch: boolean,
+  ) => number,
+): BestExpeditionEntry[] {
   return expeditions
     .map((expedition) => {
       const biome = biomeMap.get(expedition.biome)
       const traitMatch = creature.trait === expedition.trait
-
-      // Stat alignment: dot product of creature stat proportions and expedition weights
-      const weights = statKeys.map((k) => expedition.statWeights[k])
-      const weightTotal = weights.reduce((sum, w) => sum + w, 0)
-      const normalizedWeights = weights.map((w) => (weightTotal > 0 ? w / weightTotal : 0))
-      const statAlignment = creatureProportions.reduce(
-        (sum, p, i) => sum + p * normalizedWeights[i],
-        0,
-      )
+      const statAlignment = statAlignmentScore(creature, expedition)
 
       // Biome status
       let biomeStatus: 'advantage' | 'disadvantage' | 'neutral' = 'neutral'
-      let biomeScore = 1.0
       if (biome) {
         const mult = biomeMultiplier(creature, biome)
-        biomeScore = mult
         if (mult > 1) biomeStatus = 'advantage'
         else if (mult < 1) biomeStatus = 'disadvantage'
       }
 
-      // Combined score: stat alignment * biome * trait
-      const score = statAlignment * biomeScore * (traitMatch ? 1.5 : 1.0)
-
       return {
         expedition,
-        score: Math.round(score * 100),
+        score: scoreFn(expedition, biome, statAlignment, traitMatch),
         biomeName: biome?.name ?? expedition.biome,
         traitMatch,
         biomeStatus,
@@ -272,72 +271,37 @@ export function getBestExpeditionsForCreature(
     .slice(0, limit)
 }
 
+export function getBestExpeditionsForCreature(
+  creature: Creature,
+  limit: number = 5,
+): BestExpeditionEntry[] {
+  return rankExpeditions(creature, limit, (_expedition, biome, statAlignment, traitMatch) => {
+    const biomeScore = biome ? biomeMultiplier(creature, biome) : 1.0
+    // Combined score: stat alignment * biome * trait
+    const score = statAlignment * biomeScore * (traitMatch ? 1.5 : 1.0)
+    return Math.round(score * 100)
+  })
+}
+
 export function getBestExpeditionsForLeveling(
   creature: Creature,
   level: number,
   limit: number = 5,
 ): BestExpeditionEntry[] {
-  const expeditions = expeditionsData as Expedition[]
-  const biomes = biomesData as Biome[]
-  const biomeMap = new Map(biomes.map((b) => [b.id, b]))
-
-  return expeditions
-    .map((expedition) => {
-      const biome = biomeMap.get(expedition.biome)
-      const traitMatch = creature.trait === expedition.trait
-
-      // Biome status
-      let biomeStatus: 'advantage' | 'disadvantage' | 'neutral' = 'neutral'
-      if (biome) {
-        const mult = biomeMultiplier(creature, biome)
-        if (mult > 1) biomeStatus = 'advantage'
-        else if (mult < 1) biomeStatus = 'disadvantage'
+  return rankExpeditions(creature, limit, (expedition, biome) => {
+    // Score by best XP/sec across all tiers
+    let bestXpPerSec = 0
+    for (let tier = 1; tier <= 5; tier++) {
+      const rating = calculateCreatureRating(creature, expedition, level, biome)
+      const duration = calculateDuration(rating, expedition, tier)
+      const xpPerRun = calculateExpeditionXp(expedition, tier, 0, 1)
+      if (duration > 0 && xpPerRun > 0) {
+        const xpPerSec = xpPerRun / duration
+        if (xpPerSec > bestXpPerSec) bestXpPerSec = xpPerSec
       }
-
-      // Stat alignment (for display)
-      const statKeys: (keyof CreatureStats)[] = [
-        'power',
-        'grit',
-        'agility',
-        'smarts',
-        'looting',
-        'luck',
-      ]
-      const statTotal = statKeys.reduce((sum, k) => sum + creature.stats[k], 0)
-      const creatureProportions = statKeys.map((k) =>
-        statTotal > 0 ? creature.stats[k] / statTotal : 0,
-      )
-      const weights = statKeys.map((k) => expedition.statWeights[k])
-      const weightTotal = weights.reduce((sum, w) => sum + w, 0)
-      const normalizedWeights = weights.map((w) => (weightTotal > 0 ? w / weightTotal : 0))
-      const statAlignment = creatureProportions.reduce(
-        (sum, p, i) => sum + p * normalizedWeights[i],
-        0,
-      )
-
-      // Score by best XP/sec across all tiers
-      let bestXpPerSec = 0
-      for (let tier = 1; tier <= 5; tier++) {
-        const rating = calculateCreatureRating(creature, expedition, level, biome)
-        const duration = calculateDuration(rating, expedition, tier)
-        const xpPerRun = calculateExpeditionXp(expedition, tier, 0, 1)
-        if (duration > 0 && xpPerRun > 0) {
-          const xpPerSec = xpPerRun / duration
-          if (xpPerSec > bestXpPerSec) bestXpPerSec = xpPerSec
-        }
-      }
-
-      return {
-        expedition,
-        score: Math.round(bestXpPerSec * 1000),
-        biomeName: biome?.name ?? expedition.biome,
-        traitMatch,
-        biomeStatus,
-        statAlignment: Math.round(statAlignment * 100),
-      }
-    })
-    .toSorted((a, b) => b.score - a.score)
-    .slice(0, limit)
+    }
+    return Math.round(bestXpPerSec * 1000)
+  })
 }
 
 export function getRecommendedCreatures(

--- a/src/views/AwakenView.vue
+++ b/src/views/AwakenView.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import { Coins, Sparkles } from 'lucide-vue-next'
-import { computed, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 
 import { useAwakenSimulation } from '@/composables/useAwakenSimulation'
 import { useGameConfig } from '@/composables/useGameConfig'
 import UpgradesContent from '@/data/upgrades'
 import type { Upgrade, UpgradeEffectData } from '@/data/upgrades'
-import { jobIcons, sourceIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { formatNumber } from '@/utils/format/format'
+import { jobIcons, sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -189,6 +191,38 @@ function tabLabel(id: TabId): string {
 
 
 const tab = ref<TabId>('gathering')
+
+
+// Deep-link highlight: a planner advisory can open ?tree=<skill>&node=<id> to flag
+// the relevant tree card + node for a few seconds.
+const route = useRoute()
+const highlightTree = ref<string | null>(null)
+const highlightNode = ref<string | null>(null)
+
+
+function tabForTree(id: string): TabId {
+  if (WORK_GROUPS.some((g) => g.id === id)) return 'workstations'
+  if (GOLD_GROUPS.some((g) => g.id === id)) return 'gold'
+  return 'gathering'
+}
+
+
+onMounted(() => {
+  const tree = typeof route.query.tree === 'string' ? route.query.tree : null
+  if (!tree) return
+  tab.value = tabForTree(tree)
+  highlightTree.value = tree
+  highlightNode.value = typeof route.query.node === 'string' ? route.query.node : null
+  nextTick(() => {
+    document
+      .getElementById(`awaken-card-${tree}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
+  window.setTimeout(() => {
+    highlightTree.value = null
+    highlightNode.value = null
+  }, 3500)
+})
 
 
 const { simAdded, simRemoved, savedIds, effectiveIds } = useAwakenSimulation()
@@ -688,7 +722,7 @@ function onNodeMouseLeave() {
 <template>
   <div class="space-y-6" @mousemove="onNodeMouseMove">
     <div>
-      <div class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+      <div class="text-2xs font-semibold uppercase tracking-widest text-muted-foreground">
         {{ t('awakenView.eyebrow') }}
       </div>
       <h1 class="mt-1 text-2xl font-bold">Awaken Tree</h1>
@@ -727,7 +761,7 @@ function onNodeMouseLeave() {
             v-if="savedUnallocated > 0"
             :class="
               unallocatedPoints < 0
-                ? 'rounded-full bg-red-500/15 px-2 py-0.5 font-medium text-red-600 dark:text-red-400'
+                ? 'rounded-full bg-danger/15 px-2 py-0.5 font-medium text-danger-strong'
                 : 'rounded-full bg-muted px-2 py-0.5 font-medium text-foreground'
             "
             :title="
@@ -740,13 +774,13 @@ function onNodeMouseLeave() {
           </span>
           <span
             v-if="totalSim > 0"
-            class="rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-amber-600 dark:text-amber-400"
+            class="rounded-full bg-warning/15 px-2 py-0.5 font-medium text-warning-strong"
           >
             +{{ totalSim }} {{ t('awakenView.simulated') }}
           </span>
           <span
             v-if="totalRemoved > 0"
-            class="rounded-full bg-red-500/15 px-2 py-0.5 font-medium text-red-600 dark:text-red-400"
+            class="rounded-full bg-danger/15 px-2 py-0.5 font-medium text-danger-strong"
           >
             −{{ totalRemoved }} {{ t('awakenView.removed') }}
           </span>
@@ -754,7 +788,7 @@ function onNodeMouseLeave() {
       </div>
       <div class="flex items-center gap-3">
         <button
-          class="rounded-full border border-border/60 bg-card/65 px-2.5 py-1 text-[11px] font-semibold text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
+          class="rounded-full border border-border/60 bg-card/65 px-2.5 py-1 text-2xs font-semibold text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
           :class="hasChanges ? '' : 'pointer-events-none invisible'"
           :aria-hidden="!hasChanges"
           @click="resetSimulation"
@@ -780,7 +814,7 @@ function onNodeMouseLeave() {
         {{ tabLabel(t) }}
         <span class="font-mono text-xs text-muted-foreground">({{ tabCount(t) }})</span>
       </button>
-      <div class="ml-auto flex items-center gap-3 pb-2 font-mono text-[10px] text-muted-foreground">
+      <div class="ml-auto flex items-center gap-3 pb-2 font-mono text-3xs text-muted-foreground">
         <span class="inline-flex items-center gap-1">
           <span
             class="inline-block size-2.5 rounded-sm"
@@ -823,8 +857,10 @@ function onNodeMouseLeave() {
     <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       <div
         v-for="card in activeCards"
+        :id="`awaken-card-${card.group.id}`"
         :key="card.group.id"
         class="rounded-xl border border-border bg-card p-3"
+        :class="{ 'attn-ring': highlightTree === card.group.id }"
         :style="{ background: `linear-gradient(${PALETTE[card.group.color].bgTint}, transparent)` }"
       >
         <div class="mb-2 flex items-center justify-between">
@@ -840,10 +876,12 @@ function onNodeMouseLeave() {
             <Coins v-else class="size-5" :style="{ color: PALETTE[card.group.color].stroke }" />
             <span class="text-sm font-semibold">{{ groupLabel(card.group) }}</span>
           </div>
-          <span class="font-mono text-[10px] text-muted-foreground">
+          <span class="font-mono text-3xs text-muted-foreground">
             {{ card.owned }}/{{ card.upgrades.length }}
-            <span v-if="card.sim > 0" class="ml-0.5 text-amber-500">+{{ card.sim }}</span>
-            <span v-if="card.removed > 0" class="ml-0.5 text-red-500">−{{ card.removed }}</span>
+            <span v-if="card.sim > 0" class="ml-0.5 text-warning-strong">+{{ card.sim }}</span>
+            <span v-if="card.removed > 0" class="ml-0.5 text-danger-strong"
+              >−{{ card.removed }}</span
+            >
           </span>
         </div>
         <svg
@@ -899,6 +937,19 @@ function onNodeMouseLeave() {
             @mouseenter="onNodeMouseEnter(u, $event)"
             @mouseleave="onNodeMouseLeave"
           >
+            <!-- Deep-link highlight ring -->
+            <rect
+              v-if="u.id === highlightNode"
+              :x="cardPos(card, u).cx - NODE_SIZE / 2 - 2.5"
+              :y="cardPos(card, u).cy - NODE_SIZE / 2 - 2.5"
+              :width="NODE_SIZE + 5"
+              :height="NODE_SIZE + 5"
+              rx="4"
+              fill="none"
+              stroke="hsl(48 96% 53%)"
+              class="attn-node"
+              style="pointer-events: none"
+            />
             <rect
               :x="cardPos(card, u).cx - NODE_SIZE / 2"
               :y="cardPos(card, u).cy - NODE_SIZE / 2"
@@ -980,12 +1031,12 @@ function onNodeMouseLeave() {
     >
       <div class="font-semibold text-foreground">{{ hovered.name }}</div>
       <div class="mt-0.5 text-muted-foreground">{{ describeEffect(hovered.effectData) }}</div>
-      <div class="mt-1 font-mono text-[10px]">
+      <div class="mt-1 font-mono text-3xs">
         <span v-if="effectiveIds.has(hovered.id)" class="text-green-500">{{
           t('awakenView.unlocked')
         }}</span>
         <span v-else class="inline-flex items-center gap-1">
-          <span class="inline-flex items-center gap-1 text-amber-500">
+          <span class="inline-flex items-center gap-1 text-warning-strong">
             <img
               v-if="awakenPointImage"
               :src="awakenPointImage"
@@ -994,7 +1045,7 @@ function onNodeMouseLeave() {
               style="image-rendering: pixelated"
               loading="lazy"
             />
-            {{ costToUnlock(hovered).toLocaleString() }}
+            {{ formatNumber(costToUnlock(hovered)) }}
           </span>
           <span v-if="!isPrereqMet(hovered)" class="text-muted-foreground">
             {{ t('awakenView.inclPrereqs') }}

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -14,8 +14,8 @@ import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
-import { toTitleCase, typeColor } from '@/utils/format'
-import { jobIcons } from '@/utils/icons'
+import { toTitleCase, typeColor } from '@/utils/format/format'
+import { jobIcons } from '@/utils/format/icons'
 
 const {
   filteredCreatures,

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -6,6 +6,7 @@ import { useI18n } from 'vue-i18n'
 
 import CreatureDetail from '@/components/beastiary/CreatureDetail.vue'
 import AssignmentZone from '@/components/configs/AssignmentZone.vue'
+import ExpeditionLadderSection from '@/components/configs/ExpeditionLadderSection.vue'
 import HeroStatsSection from '@/components/configs/HeroStatsSection.vue'
 import InventoryGridSection from '@/components/configs/InventoryGridSection.vue'
 import WorkstationQueuesSection from '@/components/configs/WorkstationQueuesSection.vue'
@@ -15,20 +16,11 @@ import SectionEyebrow from '@/components/shared/SectionEyebrow.vue'
 import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
+import { useExpeditionLadder } from '@/composables/useExpeditionLadder'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { clearSummoningPlannerSelection } from '@/composables/useSummoningPlanner'
-import expeditionsData from '@/data/expeditions.json'
 import { items as allItems } from '@/data/indexes'
-import type { Expedition } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { decryptSave } from '@/utils/decrypt'
-import {
-  getTotalCompletedExpeditions,
-  getMaxUnlockedTier,
-  TIER_UNLOCK_REQUIREMENTS,
-} from '@/utils/expeditionUnlocks'
-import { itemName } from '@/utils/format'
-import { levelFromXp, getPlayerLevel, SKILLING_IDS } from '@/utils/formulas'
+import { itemName } from '@/utils/format/format'
 import {
   sourceIcons,
   sanctuaryIcon,
@@ -36,17 +28,12 @@ import {
   machinesIcon,
   dungeonsIcon,
   jobIcons,
-  expeditionTierIcons,
-} from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
-import { extractSaveConfig, type SaveConfig } from '@/utils/parseSave'
-
-const allExpeditions = (expeditionsData as Expedition[]).toSorted((a, b) => {
-  const diff = a.requiredExpeditionCompletions - b.requiredExpeditionCompletions
-  if (diff !== 0) return diff
-  return a.baseRating - b.baseRating
-})
-
+} from '@/utils/format/icons'
+import { levelFromXp, getPlayerLevel, SKILLING_IDS } from '@/utils/formulas'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+import { getItemImage } from '@/utils/images/itemImages'
+import { decryptSave } from '@/utils/save/decrypt'
+import { extractSaveConfig, type SaveConfig } from '@/utils/save/parseSave'
 
 const { t } = useI18n()
 
@@ -60,49 +47,17 @@ const {
   machineCreatureIds,
   inventoryAmounts,
   collectedItems,
-  setCollectedItems,
-  resetCollectedItems,
   setGardenLayout,
   setGardenSaveSnapshot,
   resetGarden,
-  awakenGatherUpgrades,
-  awakenSpeedTiers,
-  setSanctuaryCreatures,
-  setHelperCreatures,
-  setMachineCreatures,
-  expeditionCompletions,
   expeditionParties,
-  setExpeditionCompletions,
-  setExpeditionToolXpBonus,
-  setToolLevels,
-  setToolSpeedModes,
-  resetToolLevels,
-  setMachineLevels,
-  setMachineRecipes,
-  resetMachines,
-  setFabricationAllocations,
-  resetFabrication,
-  setAwakenGoldLevel,
   skillLevels,
   playerLevel,
-  setSkillLevels,
-  resetSkillLevels,
   queuedAmounts,
   queuedTimes,
-  setQueuedAmounts,
-  setQueuedTimes,
-  resetQueuedAmounts,
-  setExpeditionParties,
-  setExpeditionTiers,
-  setExpeditionCreatureLevels,
-  setExpeditionLoopCounts,
-  resetExpeditionSetup,
   dungeonParty,
-  setDungeonParty,
-  resetDungeonParty,
-  applyDungeonStateFromSave,
-  resetDungeonStorage,
-  resetAwaken,
+  applySaveConfig,
+  resetAllConfig,
 } = useGameConfig()
 
 
@@ -117,6 +72,16 @@ const DUNGEON_MAX = 3
 const errorMessage = ref('')
 const isDragging = ref(false)
 const saveConfig = ref<SaveConfig | null>(null)
+
+
+const {
+  allExpeditions,
+  expeditionFrontiers,
+  expeditionLadderColumns,
+  expeditionDisplay,
+  expeditionPartiesList,
+  expeditionPartiesAssigned,
+} = useExpeditionLadder(saveConfig)
 
 
 // Save metadata (persisted so it survives reloads)
@@ -364,239 +329,6 @@ const idleCreatures = computed(() => {
 })
 
 
-// --- Expedition frontiers: what to unlock next ---
-const expeditionFrontiers = computed(() => {
-  const items = expeditionDisplay.value.items
-
-  // Next expedition to unlock (first locked one in the sorted list)
-  const nextExpItem = items.find((it) => !it.unlocked)
-  const totalRunsCompleted = (() => {
-    const completions = saveConfig.value
-      ? saveConfig.value.expeditionCompletions
-      : expeditionCompletions.value
-    return getTotalCompletedExpeditions(completions)
-  })()
-  const nextExp = nextExpItem
-    ? {
-        name: nextExpItem.expedition.name,
-        rewardItemId: nextExpItem.expedition.rewards[0]?.itemId,
-        have: totalRunsCompleted,
-        need: nextExpItem.expedition.requiredExpeditionCompletions,
-        remaining: Math.max(
-          0,
-          nextExpItem.expedition.requiredExpeditionCompletions - totalRunsCompleted,
-        ),
-        pct: Math.min(
-          100,
-          Math.round(
-            (totalRunsCompleted / nextExpItem.expedition.requiredExpeditionCompletions) * 100,
-          ),
-        ),
-      }
-    : null
-
-  // Tier-up frontiers: unlocked expeditions with a locked next tier, closest to ready
-  const completions = saveConfig.value
-    ? saveConfig.value.expeditionCompletions
-    : expeditionCompletions.value
-  const tierUps = items
-    .filter((it) => it.unlocked)
-    .map((it) => {
-      const lockedTier = it.tiers.find((t) => !t.unlocked)
-      if (!lockedTier) return null
-      const required = TIER_UNLOCK_REQUIREMENTS[lockedTier.tier] ?? 0
-      const prevTierCompletions = completions[it.expedition.id]?.[lockedTier.tier - 1] ?? 0
-      const have = prevTierCompletions
-      const need = required
-      const remaining = lockedTier.remaining
-      const pct = need ? Math.min(100, Math.round((have / need) * 100)) : 0
-      return {
-        name: it.expedition.name,
-        rewardItemId: it.expedition.rewards[0]?.itemId,
-        fromTier: lockedTier.tier - 1,
-        toTier: lockedTier.tier,
-        have,
-        need,
-        remaining,
-        pct,
-      }
-    })
-    .filter((x): x is NonNullable<typeof x> => x !== null)
-    .toSorted((a, b) => b.pct - a.pct)
-    .slice(0, 2)
-
-  return { nextExp, tierUps }
-})
-
-
-// --- Expedition ladder: compact per-row data for the mockup-faithful list ---
-interface ExpeditionLadderRow {
-  id: string
-  name: string
-  rewardItemId: string | undefined
-  requiredExpeditionCompletions: number
-  tiers: { tier: number; cleared: boolean; unlocked: boolean; completions: number }[]
-  maxTier: number
-  nextTier: number
-  pct: number
-  have: number
-  need: number
-  remaining: number
-  runs: number
-  locked: boolean
-  maxed: boolean
-}
-
-
-const expeditionLadder = computed<ExpeditionLadderRow[]>(() => {
-  const completions = saveConfig.value
-    ? saveConfig.value.expeditionCompletions
-    : expeditionCompletions.value
-  const totalRuns = getTotalCompletedExpeditions(completions)
-  return allExpeditions.map((e) => {
-    const unlocked = totalRuns >= e.requiredExpeditionCompletions
-    const expCompletions = completions[e.id] ?? {}
-    const tierEntries = [1, 2, 3, 4, 5].map((t) => {
-      const cleared = (expCompletions[t] ?? 0) > 0
-      const prevCompletions = expCompletions[t - 1] ?? 0
-      const tierUnlocked =
-        unlocked && (t === 1 || prevCompletions >= (TIER_UNLOCK_REQUIREMENTS[t] ?? 0))
-      return {
-        tier: t,
-        completions: expCompletions[t] ?? 0,
-        cleared,
-        unlocked: tierUnlocked,
-      }
-    })
-    // maxTier is the highest *unlocked* tier (not necessarily run yet) — once
-    // the threshold for the next tier is met, we conceptually move to it even
-    // before the player has done a single run there.
-    const maxTier = unlocked
-      ? Math.max(0, ...tierEntries.filter((t) => t.unlocked).map((t) => t.tier))
-      : 0
-    const nextTier = Math.min(5, maxTier + 1)
-    const need = maxTier > 0 && maxTier < 5 ? (TIER_UNLOCK_REQUIREMENTS[nextTier] ?? 0) : 0
-    const have = maxTier > 0 ? (expCompletions[maxTier] ?? 0) : 0
-    const remaining = Math.max(0, need - have)
-    const pct = need ? Math.min(100, Math.round((have / need) * 100)) : 0
-    const runs = tierEntries.reduce((s, t) => s + t.completions, 0)
-    const locked = !unlocked
-    const maxed = maxTier === 5
-    return {
-      id: e.id,
-      name: e.name,
-      rewardItemId: e.rewards[0]?.itemId,
-      requiredExpeditionCompletions: e.requiredExpeditionCompletions,
-      tiers: tierEntries,
-      maxTier,
-      nextTier,
-      pct,
-      have,
-      need,
-      remaining,
-      runs,
-      locked,
-      maxed,
-    }
-  })
-})
-
-
-const expeditionLadderColumns = computed(() => {
-  const rows = expeditionLadder.value
-  const mid = Math.ceil(rows.length / 2)
-  return [rows.slice(0, mid), rows.slice(mid)]
-})
-
-
-const expeditionPartiesAssigned = computed(() => {
-  // Match the source used by expeditionPartiesList so the slot counter stays
-  // in sync with the preview-vs-persisted behaviour.
-  let count = 0
-  for (const exp of expeditionPartiesList.value) {
-    for (const slot of exp.slots) {
-      if (slot) count += 1
-    }
-  }
-  return count
-})
-
-
-// Expeditions × creatures-on-party — for the Assignments card row.
-// Mirrors /expeditions' resolution pattern (creatures.find by id) so the same
-// localStorage state renders identically here.
-interface AssignmentExpeditionSlot {
-  id: string
-  name: string
-  image: string
-  tier: number
-}
-const expeditionPartiesList = computed(() => {
-  // Mirror the Sanctuary/Helpers/Machines swap: when a save is loaded and the
-  // expedition setup hasn't been applied yet, preview the save's party data so
-  // the user can see what `Apply` would set. Otherwise show the persisted ids.
-  const saveParties = saveConfig.value?.currentExpedition?.parties
-  const showSavePreview = !!saveConfig.value && !!saveParties && Object.keys(saveParties).length > 0
-  const parties = showSavePreview ? saveParties : (expeditionParties.value ?? {})
-  return allExpeditions.map((e) => {
-    const partyIds = (parties[e.id] ?? []) as string[]
-    const maxSlots = Math.max(3, e.maxPartySize ?? 3)
-    const slots: (AssignmentExpeditionSlot | null)[] = []
-    for (let i = 0; i < maxSlots; i++) {
-      const id = partyIds[i]
-      if (!id) {
-        slots.push(null)
-        continue
-      }
-      const meta = creatures.value.find((c) => c.id === id)
-      slots.push(
-        meta
-          ? { id: meta.id, name: meta.name, image: meta.image, tier: meta.tier }
-          : { id, name: id, image: '', tier: 0 },
-      )
-    }
-    return {
-      id: e.id,
-      name: e.name,
-      rewardItemId: e.rewards[0]?.itemId,
-      slots,
-    }
-  })
-})
-
-
-const expeditionDisplay = computed(() => {
-  const completions = saveConfig.value
-    ? saveConfig.value.expeditionCompletions
-    : expeditionCompletions.value
-  const totalCompletions = getTotalCompletedExpeditions(completions)
-  const unlockedCount = allExpeditions.filter(
-    (e) => totalCompletions >= e.requiredExpeditionCompletions,
-  ).length
-
-  const items = allExpeditions.map((expedition) => {
-    const unlocked = totalCompletions >= expedition.requiredExpeditionCompletions
-    const maxTier = unlocked ? getMaxUnlockedTier(expedition.id, completions) : 0
-    const expCompletions = completions[expedition.id]
-    const tiers = [1, 2, 3, 4, 5].map((t) => {
-      const isUnlocked = t <= maxTier
-      const prevTierCount = expCompletions?.[t - 1] ?? 0
-      const required = TIER_UNLOCK_REQUIREMENTS[t] ?? 0
-      const remaining = isUnlocked || t === 1 ? 0 : Math.max(0, required - prevTierCount)
-      return { tier: t, unlocked: isUnlocked || t === 1, remaining }
-    })
-    return { expedition, unlocked, tiers }
-  })
-
-  const totalTiersUnlocked = items.reduce(
-    (sum, item) => sum + (item.unlocked ? item.tiers.filter((t) => t.unlocked).length : 0),
-    0,
-  )
-
-  return { items, unlockedCount, totalTiersUnlocked }
-})
-
-
 // --- Inventory codex grid (full items.json order, placeholders for unowned) ---
 const itemPositionById = new Map(allItems.map((item, index) => [item.id, index]))
 
@@ -716,6 +448,7 @@ function applyAll() {
   const save = saveConfig.value
 
 
+  // Creature collection lives in its own composable (view-local concern).
   resetCollection()
   for (const c of previewCreatures.value) {
     setOwned(c.id, true)
@@ -724,50 +457,12 @@ function applyAll() {
   }
 
 
-  setSanctuaryCreatures(save.sanctuary)
-  setHelperCreatures(save.helpers)
-  setMachineCreatures(save.machines)
-  setDungeonParty(save.currentDungeon?.party ?? [])
+  // Config-owned setters run in their canonical order inside useGameConfig.
+  applySaveConfig(save)
 
 
-  inventoryAmounts.value = { ...save.inventory }
-  setCollectedItems([...save.collectedItems])
-
-
-  setQueuedAmounts({ ...save.queuedAmounts })
-  setQueuedTimes({ ...save.queuedTimes })
-
-
-  awakenGatherUpgrades.value = { ...save.awakenGatherUpgrades }
-  awakenSpeedTiers.value = { ...save.awakenSpeedTiers }
-  setAwakenGoldLevel(save.awakenGoldLevel)
-
-
-  setExpeditionToolXpBonus(((save.tools?.sword || 0) * 5) / 100 + 1)
-  setToolLevels({ ...save.toolLevels })
-  setToolSpeedModes({ ...save.toolSpeedModes })
-
-
-  setSkillLevels({ ...save.skillLevels })
-
-
-  setMachineLevels({ ...save.machineLevels })
-  setMachineRecipes({ ...save.machineRecipes })
-
-
-  setFabricationAllocations({ ...save.fabricationAllocations })
-
-
-  setExpeditionCompletions({ ...save.expeditionCompletions })
-
-
-  setExpeditionParties({ ...save.currentExpedition.parties })
-  setExpeditionCreatureLevels({ ...save.currentExpedition.levels })
-  setExpeditionTiers({ ...save.currentExpedition.tiers })
-  setExpeditionLoopCounts({ ...save.currentExpedition.loopCounts })
-
-
-  if (save.currentDungeon) applyDungeonStateFromSave(save.currentDungeon)
+  // A fresh save invalidates the old summon plan.
+  clearSummoningPlannerSelection()
 
 
   appliedSections.value = {
@@ -786,25 +481,12 @@ function applyAll() {
 
 
 function resetAll() {
-  setSanctuaryCreatures([])
-  setHelperCreatures([])
-  setMachineCreatures([])
-  inventoryAmounts.value = {}
-  resetCollectedItems()
-  resetQueuedAmounts()
-  resetAwaken()
-  setAwakenGoldLevel(0)
-  resetToolLevels()
-  setExpeditionToolXpBonus(1)
-  resetMachines()
-  resetFabrication()
-  expeditionCompletions.value = {}
-  resetExpeditionSetup()
-  resetSkillLevels()
+  // Config-owned state (sanctuary/helpers/machines, inventory, queues, awaken,
+  // tools, machines, fabrication, expeditions, skills, dungeon) resets inside
+  // useGameConfig. The remaining resets are view-local concerns.
+  resetAllConfig()
   resetCollection()
-  resetDungeonParty()
   resetGarden()
-  resetDungeonStorage()
   clearSummoningPlannerSelection()
   saveConfig.value = null
   saveFileName.value = ''
@@ -906,8 +588,8 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
         <div class="min-w-0">
           <SectionEyebrow class="flex flex-wrap items-center gap-x-2 gap-y-1">
             <template v-if="saveFileName">
-              <Check class="size-3.5 text-emerald-400" />
-              <span class="text-emerald-400">{{ t('configs.snapshot.saveSynced') }}</span>
+              <Check class="size-3.5 text-success-strong" />
+              <span class="text-success-strong">{{ t('configs.snapshot.saveSynced') }}</span>
               <span class="text-muted-foreground/60">·</span>
               <span class="font-mono normal-case tracking-normal text-muted-foreground/80">
                 {{ saveFileName }}
@@ -931,7 +613,7 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
         </div>
         <div class="flex shrink-0 items-center gap-2">
           <button
-            class="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-400 transition hover:bg-red-500/20"
+            class="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs font-semibold text-danger-strong transition hover:bg-danger/20"
             @click="resetAll"
           >
             <RotateCcw class="size-3.5" />
@@ -963,10 +645,10 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
 
       <div
         v-if="errorMessage"
-        class="flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2"
+        class="flex items-center gap-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2"
       >
-        <AlertCircle class="size-4 shrink-0 text-red-400" />
-        <p class="text-sm text-red-300">{{ errorMessage }}</p>
+        <AlertCircle class="size-4 shrink-0 text-danger-strong" />
+        <p class="text-sm text-danger-strong">{{ errorMessage }}</p>
       </div>
     </header>
 
@@ -1057,7 +739,7 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
               <img :src="sourceIcons.Expeditions" alt="" class="size-3.5" loading="lazy" />
               {{ t('configs.zones.expeditions') }}
             </SectionEyebrow>
-            <span class="font-mono text-[10px] text-muted-foreground">
+            <span class="font-mono text-3xs text-muted-foreground">
               {{
                 t('configs.assignments.slotsFilled', {
                   filled: expeditionPartiesAssigned,
@@ -1068,7 +750,7 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
           </div>
           <div
             v-if="expeditionPartiesAssigned === 0"
-            class="rounded-md border border-dashed border-border/50 px-3 py-2 text-[11px] text-muted-foreground"
+            class="rounded-md border border-dashed border-border/50 px-3 py-2 text-2xs text-muted-foreground"
           >
             <i18n-t keypath="configs.assignments.noExpeditionAssignments" tag="span">
               <template #link>
@@ -1095,7 +777,7 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
                   class="size-4 shrink-0 object-contain"
                   loading="lazy"
                 />
-                <span class="flex-1 truncate text-[11px] font-semibold">
+                <span class="flex-1 truncate text-2xs font-semibold">
                   {{ exp.name }}
                 </span>
               </div>
@@ -1116,14 +798,12 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
                       />
                       <div
                         v-else
-                        class="flex size-full items-center justify-center bg-muted text-[10px] font-bold uppercase"
+                        class="flex size-full items-center justify-center bg-muted text-3xs font-bold uppercase"
                       >
                         {{ slot.name.charAt(0) }}
                       </div>
                       <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-px">
-                        <p
-                          class="truncate text-center text-[9px] font-bold leading-tight text-white"
-                        >
+                        <p class="truncate text-center text-3xs font-bold leading-tight text-white">
                           {{ slot.name }}
                         </p>
                       </div>
@@ -1145,7 +825,7 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
             <SectionEyebrow as="h3" class="flex items-center gap-1.5">
               {{ t('configs.assignments.idleLabel') }}
             </SectionEyebrow>
-            <span class="font-mono text-[10px] text-muted-foreground">
+            <span class="font-mono text-3xs text-muted-foreground">
               {{ t('configs.assignments.unassigned', { n: idleCreatures.length }) }}
             </span>
           </div>
@@ -1171,7 +851,7 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
                   {{ c.name.charAt(0) }}
                 </div>
                 <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1 py-px">
-                  <p class="truncate text-center text-[9px] font-bold leading-tight text-white">
+                  <p class="truncate text-center text-3xs font-bold leading-tight text-white">
                     {{ c.name }}
                   </p>
                 </div>
@@ -1188,290 +868,12 @@ const dungeonSlots = computed<AssignmentSlot[]>(() =>
     <!-- Section: Planner snapshot cards -->
     <section class="space-y-4">
       <!-- Expeditions ladder (mockup order) -->
-      <!-- Expeditions -->
-      <div class="rounded-xl border border-border bg-card/50 p-4">
-        <div class="flex items-start justify-between gap-2">
-          <div>
-            <div class="flex items-center gap-1.5">
-              <h3 class="text-sm font-bold">{{ t('configs.zones.expeditions') }}</h3>
-              <AppTooltip :text="t('configs.expeditionsCard.tooltip')">
-                <Info class="size-3.5 text-muted-foreground/70 hover:text-foreground" />
-              </AppTooltip>
-            </div>
-          </div>
-          <div class="flex items-center gap-2">
-            <div class="flex flex-wrap gap-2 text-xs">
-              <span class="rounded-md bg-muted/50 px-2 py-1 font-medium">
-                {{
-                  t('configs.expeditions.unlocked', {
-                    count: expeditionDisplay.unlockedCount,
-                    total: allExpeditions.length,
-                  })
-                }}
-              </span>
-              <span class="rounded-md bg-muted/50 px-2 py-1 font-medium">
-                {{
-                  t('configs.expeditions.tiers', {
-                    count: expeditionDisplay.totalTiersUnlocked,
-                    total: allExpeditions.length * 5,
-                  })
-                }}
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-3 space-y-3">
-          <!-- Up Next frontier cards -->
-          <div
-            v-if="expeditionFrontiers.nextExp || expeditionFrontiers.tierUps.length"
-            class="space-y-2"
-          >
-            <div class="text-[10px] font-bold uppercase tracking-[0.18em] text-muted-foreground/80">
-              {{ t('configs.expeditionsCard.upNext') }}
-            </div>
-            <div class="grid gap-2 md:grid-cols-3">
-              <div
-                v-if="expeditionFrontiers.nextExp"
-                class="overflow-hidden rounded-xl border border-accent/35 bg-card/60 p-3.5"
-              >
-                <div class="flex items-stretch gap-3">
-                  <div
-                    class="flex size-14 shrink-0 items-center justify-center rounded-lg bg-amber-400/10"
-                  >
-                    <img
-                      v-if="
-                        expeditionFrontiers.nextExp.rewardItemId &&
-                        getItemImage({ id: expeditionFrontiers.nextExp.rewardItemId })
-                      "
-                      :src="getItemImage({ id: expeditionFrontiers.nextExp.rewardItemId })"
-                      :alt="expeditionFrontiers.nextExp.rewardItemId"
-                      class="size-9 object-contain"
-                      loading="lazy"
-                    />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <div class="mb-2 flex items-center gap-2">
-                      <span class="min-w-0 truncate text-sm font-semibold text-foreground">
-                        {{ expeditionFrontiers.nextExp.name }}
-                      </span>
-                      <span
-                        class="ml-auto shrink-0 text-[10px] font-bold uppercase tracking-[0.18em] text-amber-300"
-                      >
-                        {{ t('configs.expeditionsCard.next') }}
-                      </span>
-                    </div>
-                    <div class="h-1.5 overflow-hidden rounded-full bg-border/30">
-                      <div
-                        class="h-full rounded-full bg-amber-400 transition-all"
-                        :style="{ width: `${expeditionFrontiers.nextExp.pct}%` }"
-                      />
-                    </div>
-                    <div class="mt-1.5 flex items-baseline justify-between gap-2">
-                      <span class="font-mono text-xs font-semibold">
-                        <span class="text-[10px] font-normal text-muted-foreground/50"
-                          >{{ t('configs.expeditionsCard.have') }}
-                        </span>
-                        <span class="text-foreground">{{ expeditionFrontiers.nextExp.have }}</span>
-                        <span class="text-muted-foreground/50">
-                          / {{ expeditionFrontiers.nextExp.need }}
-                        </span>
-                        <span class="text-[10px] font-normal text-muted-foreground/50">
-                          {{ t('configs.expeditionsCard.total') }}
-                        </span>
-                      </span>
-                      <span
-                        class="font-mono text-xs font-semibold text-amber-700 dark:text-amber-400"
-                      >
-                        <span
-                          class="text-[10px] font-normal text-amber-700/70 dark:text-amber-400/60"
-                          >{{ t('configs.expeditionsCard.need') }}
-                        </span>
-                        {{ expeditionFrontiers.nextExp.remaining }}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div
-                v-for="f in expeditionFrontiers.tierUps"
-                :key="f.name"
-                class="overflow-hidden rounded-xl border border-border bg-card/60 p-3.5"
-              >
-                <div class="flex items-stretch gap-3">
-                  <div
-                    class="flex size-14 shrink-0 items-center justify-center rounded-lg bg-amber-400/10"
-                  >
-                    <img
-                      v-if="f.rewardItemId && getItemImage({ id: f.rewardItemId })"
-                      :src="getItemImage({ id: f.rewardItemId })"
-                      :alt="f.rewardItemId"
-                      class="size-9 object-contain"
-                      loading="lazy"
-                    />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <div class="mb-2 flex items-center gap-2">
-                      <span class="min-w-0 truncate text-sm font-semibold text-foreground">
-                        {{ f.name }}
-                      </span>
-                      <span
-                        class="ml-auto flex shrink-0 items-center gap-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-amber-300"
-                      >
-                        <img
-                          :src="expeditionTierIcons[f.fromTier]"
-                          :alt="`Tier ${f.fromTier}`"
-                          class="size-3.5 object-contain"
-                          loading="lazy"
-                        />
-                        <span>→</span>
-                        <img
-                          :src="expeditionTierIcons[f.toTier]"
-                          :alt="`Tier ${f.toTier}`"
-                          class="size-3.5 object-contain"
-                          loading="lazy"
-                        />
-                      </span>
-                    </div>
-                    <div class="h-1.5 overflow-hidden rounded-full bg-border/30">
-                      <div
-                        class="h-full rounded-full bg-amber-400 transition-all"
-                        :style="{ width: `${f.pct}%` }"
-                      />
-                    </div>
-                    <div class="mt-1.5 flex items-baseline justify-between gap-2">
-                      <span class="font-mono text-xs font-semibold">
-                        <span class="text-[10px] font-normal text-muted-foreground/50"
-                          >{{ t('configs.expeditionsCard.have') }}
-                        </span>
-                        <span class="text-foreground">{{ f.have }}</span>
-                        <span class="text-muted-foreground/50"> / {{ f.need }} </span>
-                        <span class="text-[10px] font-normal text-muted-foreground/50">
-                          {{ t('configs.expeditionsCard.loops') }}</span
-                        >
-                      </span>
-                      <span
-                        class="font-mono text-xs font-semibold text-amber-700 dark:text-amber-400"
-                      >
-                        <span
-                          class="text-[10px] font-normal text-amber-700/70 dark:text-amber-400/60"
-                          >{{ t('configs.expeditionsCard.need') }}
-                        </span>
-                        {{ f.remaining }}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Compact 2-col ladder -->
-          <div class="mt-2 grid grid-cols-1 gap-x-6 gap-y-0.5 md:grid-cols-2">
-            <div v-for="(col, ci) in expeditionLadderColumns" :key="ci" class="space-y-0.5">
-              <div class="grid grid-cols-[1fr_auto_auto_auto] items-end gap-3 px-2 pb-0.5">
-                <span />
-                <div class="flex gap-0.5">
-                  <span class="w-4 text-center font-mono text-[9px] text-muted-foreground/60" />
-                  <span
-                    v-for="t in [2, 3, 4, 5]"
-                    :key="t"
-                    class="w-4 text-center font-mono text-[9px] text-muted-foreground/60"
-                  >
-                    {{ TIER_UNLOCK_REQUIREMENTS[t] }}
-                  </span>
-                </div>
-                <span class="w-[92px]" />
-                <span class="w-16" />
-              </div>
-              <div
-                v-for="row in col"
-                :key="row.id"
-                class="grid grid-cols-[1fr_auto_auto_auto] items-center gap-3 rounded-md px-2 py-1.5"
-                :class="row.locked ? 'opacity-40' : ''"
-              >
-                <div class="flex min-w-0 items-center gap-1.5">
-                  <img
-                    v-if="row.rewardItemId && getItemImage({ id: row.rewardItemId })"
-                    :src="getItemImage({ id: row.rewardItemId })"
-                    :alt="itemName(row.rewardItemId)"
-                    class="size-4 shrink-0 object-contain"
-                    loading="lazy"
-                  />
-                  <span
-                    class="truncate text-[12px] font-semibold"
-                    :class="row.locked ? 'italic text-muted-foreground' : ''"
-                  >
-                    {{ row.name }}
-                    <span
-                      v-if="row.requiredExpeditionCompletions > 0"
-                      class="ml-0.5 font-mono text-[10px] font-normal text-muted-foreground/70"
-                    >
-                      ({{ row.requiredExpeditionCompletions }})
-                    </span>
-                  </span>
-                </div>
-                <div class="flex gap-0.5">
-                  <img
-                    v-for="t in row.tiers"
-                    :key="t.tier"
-                    :src="expeditionTierIcons[t.tier]"
-                    :alt="`Tier ${t.tier}`"
-                    class="size-4 object-contain"
-                    :class="t.cleared ? '' : t.unlocked ? 'opacity-70' : 'opacity-30 grayscale'"
-                    loading="lazy"
-                  />
-                </div>
-                <span
-                  class="flex w-[92px] items-center justify-end gap-1 font-mono text-[10px] font-bold"
-                  :class="
-                    row.maxed
-                      ? 'text-pink-400'
-                      : row.locked
-                        ? 'text-muted-foreground/40'
-                        : 'text-muted-foreground'
-                  "
-                >
-                  <template v-if="row.locked">{{ t('configs.ladder.locked') }}</template>
-                  <template v-else-if="row.maxed">
-                    <img
-                      :src="expeditionTierIcons[5]"
-                      alt="Tier 5"
-                      class="size-3.5 object-contain"
-                      loading="lazy"
-                    />
-                    <span>{{ t('configs.ladder.maxed') }}</span>
-                  </template>
-                  <template v-else>
-                    <img
-                      :src="expeditionTierIcons[row.maxTier]"
-                      :alt="`Tier ${row.maxTier}`"
-                      class="size-3.5 object-contain"
-                      loading="lazy"
-                    />
-                    <span>{{ row.have }}/{{ row.need }}</span>
-                    <span>→</span>
-                    <img
-                      :src="expeditionTierIcons[row.nextTier]"
-                      :alt="`Tier ${row.nextTier}`"
-                      class="size-3.5 object-contain"
-                      loading="lazy"
-                    />
-                  </template>
-                </span>
-                <span
-                  class="w-16 text-right font-mono text-[10px] tabular-nums text-muted-foreground/70"
-                >
-                  <template v-if="row.runs > 0">{{
-                    t('configs.ladder.runs', { n: row.runs }, row.runs)
-                  }}</template>
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <ExpeditionLadderSection
+        :all-expeditions="allExpeditions"
+        :expedition-display="expeditionDisplay"
+        :expedition-frontiers="expeditionFrontiers"
+        :expedition-ladder-columns="expeditionLadderColumns"
+      />
 
       <!-- Workstation Queues: pipeline visualization -->
       <WorkstationQueuesSection

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import { ChevronDown, Info, Minus, Plus, Swords, X } from 'lucide-vue-next'
+import { CheckCircle2, ChevronDown, Info, Lock, Minus, Plus, Swords, X } from 'lucide-vue-next'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -15,13 +15,18 @@ import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useCreatures } from '@/composables/useCreatures'
 import { useDungeons } from '@/composables/useDungeons'
 import { useGameConfig } from '@/composables/useGameConfig'
-import { activeLocale } from '@/i18n'
 import type { Creature, ElementType, ExpeditionStatKey, GatheringSubFocus } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { itemName, toTitleCase, typeColor } from '@/utils/format'
+import { formatNumber, itemName, toTitleCase, typeColor } from '@/utils/format/format'
+import {
+  sanctuaryIcon,
+  helpersIcon,
+  machinesIcon,
+  expeditionsIcon,
+  jobIcons,
+} from '@/utils/format/icons'
 import { statAbbreviations, statLabels } from '@/utils/formulas'
-import { sanctuaryIcon, helpersIcon, machinesIcon, expeditionsIcon, jobIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -32,8 +37,14 @@ const isDesktop = useMediaQuery('(min-width: 1024px)')
 
 
 const { creatures } = useCreatures()
-const { sanctuaryCreatureIds, helperCreatureIds, machineCreatureIds, expeditionCreatureIds } =
-  useGameConfig()
+const {
+  sanctuaryCreatureIds,
+  helperCreatureIds,
+  machineCreatureIds,
+  expeditionCreatureIds,
+  playerLevel,
+  skillLevels,
+} = useGameConfig()
 const { isOwned, isAwakened, collectionLevels } = useCreatureCollection()
 const {
   selectedCreature: inspectedCreature,
@@ -333,10 +344,31 @@ function toggleCreatureTier(tier: number) {
 }
 
 
-const tierLevelReq = computed(() => {
+// Level the tier requirement is checked against: the average player level for
+// combat dungeons, the specific gathering skill level for gathering dungeons.
+const relevantLevel = computed(() =>
+  selectedFocus.value === 'combat'
+    ? playerLevel.value
+    : (skillLevels.value[selectedSubFocus.value] ?? 1),
+)
+
+
+function tierRequirement(tier: number): number {
   const reqs = config.tierLevelRequirements[selectedFocus.value]
-  return reqs?.[String(selectedTier.value)] ?? 0
-})
+  return reqs?.[String(tier)] ?? 0
+}
+
+
+function meetsTierRequirement(tier: number): boolean {
+  return relevantLevel.value >= tierRequirement(tier)
+}
+
+
+const tierLevelReq = computed(() => tierRequirement(selectedTier.value))
+const meetsSelectedTier = computed(() => meetsTierRequirement(selectedTier.value))
+const requirementLabel = computed(() =>
+  selectedFocus.value === 'combat' ? t('dungeons.player') : selectedSubFocus.value,
+)
 </script>
 
 <template>
@@ -464,24 +496,34 @@ const tierLevelReq = computed(() => {
               {{ t('dungeons.tier') }}
               <span
                 v-if="tierLevelReq > 0"
-                class="text-[11px] font-semibold normal-case tracking-normal text-muted-foreground/70"
+                class="inline-flex items-center gap-1 text-2xs font-semibold normal-case tracking-normal"
+                :class="meetsSelectedTier ? 'text-success-strong' : 'text-danger-strong'"
               >
-                {{ t('dungeons.tierRequiresLevel', { n: tierLevelReq }) }}
+                <CheckCircle2 v-if="meetsSelectedTier" class="size-3" />
+                <Lock v-else class="size-3" />
+                {{ t('dungeons.tierRequiresLevel', { label: requirementLabel, n: tierLevelReq }) }}
               </span>
             </h4>
             <div class="inline-flex rounded-lg border border-border bg-muted/45 p-1">
               <button
-                v-for="t_val in 5"
-                :key="t_val"
-                class="focus-ring rounded-md px-3 py-1.5 text-xs font-semibold transition"
-                :class="
-                  selectedTier === t_val
+                v-for="t in 5"
+                :key="t"
+                class="focus-ring inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold transition"
+                :class="[
+                  selectedTier === t
                     ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                  !meetsTierRequirement(t) && selectedTier !== t ? 'opacity-50' : '',
+                ]"
+                :title="
+                  meetsTierRequirement(t)
+                    ? undefined
+                    : `Requires ${requirementLabel} LVL ${tierRequirement(t)}`
                 "
-                @click="selectedTier = t_val"
+                @click="selectedTier = t"
               >
-                {{ TIER_LABELS[t_val - 1] }}
+                {{ TIER_LABELS[t - 1] }}
+                <Lock v-if="!meetsTierRequirement(t)" class="size-2.5 shrink-0" />
               </button>
             </div>
           </div>
@@ -538,10 +580,10 @@ const tierLevelReq = computed(() => {
                   >
                     <td class="px-3 py-1.5 font-semibold">{{ TIER_LABELS[tier.tier - 1] }}</td>
                     <td class="px-3 py-1.5 text-right font-mono">
-                      {{ tier.baseRating.toLocaleString(activeLocale()) }}
+                      {{ formatNumber(tier.baseRating) }}
                     </td>
                     <td class="px-3 py-1.5 text-right font-mono">
-                      {{ tier.xpReward.toLocaleString(activeLocale()) }}
+                      {{ formatNumber(tier.xpReward) }}
                     </td>
                   </tr>
                 </tbody>
@@ -585,11 +627,7 @@ const tierLevelReq = computed(() => {
                       </span>
                     </td>
                     <td class="px-3 py-1.5 text-right font-mono">
-                      {{
-                        Math.floor(grade.minRatio * currentTierConfig.baseRating).toLocaleString(
-                          activeLocale(),
-                        )
-                      }}
+                      {{ formatNumber(Math.floor(grade.minRatio * currentTierConfig.baseRating)) }}
                     </td>
                     <td class="px-3 py-1.5 text-right font-mono">{{ grade.multiplier }}x</td>
                   </tr>
@@ -600,7 +638,7 @@ const tierLevelReq = computed(() => {
 
           <!-- Requirements -->
           <div class="rounded-lg border border-border bg-muted/30 p-3">
-            <p class="text-[11px] text-muted-foreground">
+            <p class="text-2xs text-muted-foreground">
               {{
                 t('dungeons.requiresNote', {
                   item: itemName(config.requiresItem),
@@ -627,7 +665,7 @@ const tierLevelReq = computed(() => {
           <!-- Current Config Summary -->
           <div class="grid grid-cols-2 gap-2 text-sm">
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('dungeons.focus') }}
               </p>
               <p class="font-semibold">
@@ -638,27 +676,26 @@ const tierLevelReq = computed(() => {
               </p>
             </div>
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('dungeons.tier') }}
               </p>
               <p class="font-semibold">
                 {{ TIER_LABELS[selectedTier - 1] }}
                 <span class="text-xs text-muted-foreground">
-                  ({{ currentTierConfig.baseRating.toLocaleString(activeLocale()) }}
-                  {{ t('dungeons.rating') }})
+                  ({{ formatNumber(currentTierConfig.baseRating) }} {{ t('dungeons.rating') }})
                 </span>
               </p>
             </div>
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('dungeons.xpPerCreature') }}
               </p>
               <p class="font-mono font-semibold">
-                {{ predictedXP ? predictedXP.toLocaleString(activeLocale()) : '—' }}
+                {{ predictedXP ? formatNumber(predictedXP) : '—' }}
               </p>
             </div>
             <div class="rounded-lg border border-border bg-muted/35 px-3 py-2">
-              <p class="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <p class="text-2xs uppercase tracking-wide text-muted-foreground">
                 {{ t('dungeons.entryCost') }}
               </p>
               <p class="flex items-center gap-1.5 font-semibold">
@@ -737,12 +774,12 @@ const tierLevelReq = computed(() => {
                         loading="lazy"
                       />
                       <span
-                        class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-cyan-300"
+                        class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-3xs font-semibold text-cyan-300"
                       >
                         {{ getCreatureSlotScore(slot) }}
                       </span>
                       <div class="absolute inset-x-0 bottom-0 select-none bg-black/75 px-1.5 py-1">
-                        <p class="truncate text-center text-[10px] font-semibold text-white">
+                        <p class="truncate text-center text-3xs font-semibold text-white">
                           {{ slot.name }}
                         </p>
                       </div>
@@ -757,7 +794,7 @@ const tierLevelReq = computed(() => {
                   <template v-else>
                     <div class="flex size-full flex-col items-center justify-center gap-1">
                       <Plus class="size-4 text-muted-foreground/50" />
-                      <span v-if="activeSlotIndex === index" class="text-[9px] text-primary">{{
+                      <span v-if="activeSlotIndex === index" class="text-3xs text-primary">{{
                         t('common.select')
                       }}</span>
                     </div>
@@ -765,7 +802,7 @@ const tierLevelReq = computed(() => {
                 </div>
                 <span
                   v-if="slot"
-                  class="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-semibold text-foreground"
+                  class="rounded-full bg-muted/40 px-2 py-0.5 text-3xs font-semibold text-foreground"
                 >
                   LVL {{ effectiveLevels[slot.id] || 1 }}
                 </span>
@@ -785,13 +822,13 @@ const tierLevelReq = computed(() => {
               <div class="rounded-md bg-card px-2 py-2">
                 <p class="text-muted-foreground">{{ t('dungeons.partyScore') }}</p>
                 <p class="font-mono text-sm font-semibold text-primary">
-                  {{ partyScore.toLocaleString(activeLocale()) }}
+                  {{ formatNumber(partyScore) }}
                 </p>
               </div>
               <div class="rounded-md bg-card px-2 py-2">
                 <p class="text-muted-foreground">{{ t('dungeons.baseRating') }}</p>
                 <p class="font-mono text-sm font-semibold">
-                  {{ currentTierConfig.baseRating.toLocaleString(activeLocale()) }}
+                  {{ formatNumber(currentTierConfig.baseRating) }}
                 </p>
               </div>
               <div class="rounded-md bg-card px-2 py-2">
@@ -799,9 +836,7 @@ const tierLevelReq = computed(() => {
                 <p
                   class="font-mono text-sm font-semibold"
                   :class="
-                    scoreRatio && scoreRatio >= 1
-                      ? 'text-emerald-700 dark:text-emerald-400'
-                      : 'text-amber-700 dark:text-amber-400'
+                    scoreRatio && scoreRatio >= 1 ? 'text-success-strong' : 'text-warning-strong'
                   "
                 >
                   {{ scoreRatio ? scoreRatio.toFixed(2) : '—' }}
@@ -844,7 +879,7 @@ const tierLevelReq = computed(() => {
                 <span
                   v-for="grade in config.grades.filter((g) => g.minRatio > 0)"
                   :key="grade.grade"
-                  class="absolute -translate-x-1/2 text-[9px] font-bold"
+                  class="absolute -translate-x-1/2 text-3xs font-bold"
                   :class="GRADE_COLORS[grade.grade].text"
                   :style="{ left: `${(grade.minRatio / 2) * 100}%` }"
                 >
@@ -981,7 +1016,7 @@ const tierLevelReq = computed(() => {
 
           <div class="flex items-start gap-2 rounded-lg bg-muted/30 px-3 py-2">
             <Info class="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-            <p class="text-[11px] text-muted-foreground">
+            <p class="text-2xs text-muted-foreground">
               {{ t('dungeons.levelHint') }}
             </p>
           </div>
@@ -1013,28 +1048,28 @@ const tierLevelReq = computed(() => {
                     v-if="sanctuaryCreatureIds.includes(creature.id)"
                     :src="sanctuaryIcon"
                     alt="Sanctuary"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                   <img
                     v-else-if="helperCreatureIds.includes(creature.id)"
                     :src="helpersIcon"
                     alt="Helper"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                   <img
                     v-else-if="machineCreatureIds.includes(creature.id)"
                     :src="machinesIcon"
                     alt="Machine"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                   <img
                     v-else-if="expeditionCreatureIds.has(creature.id)"
                     :src="expeditionsIcon"
                     alt="Expedition"
-                    class="absolute -bottom-1 -right-1 size-5 rounded-full border border-background bg-background"
+                    class="absolute -left-1 -top-1 size-5 rounded-full border border-background bg-background"
                     loading="lazy"
                   />
                 </div>
@@ -1057,7 +1092,7 @@ const tierLevelReq = computed(() => {
                       :class="
                         isAwakened(creature.id)
                           ? 'text-pink-600 dark:text-pink-400'
-                          : 'text-amber-700 dark:text-amber-400'
+                          : 'text-warning-strong'
                       "
                       >★</span
                     >
@@ -1078,17 +1113,13 @@ const tierLevelReq = computed(() => {
 
               <div class="text-right" @click.stop>
                 <p
-                  class="mb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+                  class="mb-1 text-3xs font-semibold uppercase tracking-[0.16em] text-muted-foreground"
                 >
                   {{ t('common.lvl') }}
                   <span
                     v-if="suggestedLevel != null"
                     class="ml-1 normal-case tracking-normal"
-                    :class="
-                      level >= suggestedLevel
-                        ? 'text-emerald-700 dark:text-emerald-400'
-                        : 'text-amber-700 dark:text-amber-400'
-                    "
+                    :class="level >= suggestedLevel ? 'text-success-strong' : 'text-warning-strong'"
                   >
                     {{ t('common.suggested', { n: suggestedLevel }) }}
                   </span>
@@ -1132,7 +1163,7 @@ const tierLevelReq = computed(() => {
                 :key="key"
                 class="grid grid-cols-[28px_minmax(0,1fr)] items-center gap-2"
               >
-                <span class="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">{{
+                <span class="text-3xs font-bold uppercase tracking-wide text-muted-foreground">{{
                   statAbbreviations[key]
                 }}</span>
                 <div class="h-1.5 rounded-full bg-muted">

--- a/src/views/ExpeditionsView.vue
+++ b/src/views/ExpeditionsView.vue
@@ -1,18 +1,7 @@
 <script setup lang="ts">
 import { useMediaQuery } from '@vueuse/core'
-import {
-  Check,
-  ClipboardPaste,
-  Copy,
-  Download,
-  FileDown,
-  FileUp,
-  FolderOpen,
-  RotateCcw,
-  RotateCw,
-  X,
-} from 'lucide-vue-next'
-import { computed, nextTick, onMounted, ref, watch, watchEffect } from 'vue'
+import { RotateCcw, RotateCw } from 'lucide-vue-next'
+import { computed, onMounted, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -26,11 +15,11 @@ import { useCreatures } from '@/composables/useCreatures'
 import { useExpeditions } from '@/composables/useExpeditions'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, ExpeditionStatWeights } from '@/types'
-import { getCreatureImage } from '@/utils/creatureImages'
-import { formatDecimal, formatDuration, itemName, toTitleCase } from '@/utils/format'
+import { formatDecimal, formatDuration, itemName, toTitleCase } from '@/utils/format/format'
+import { expeditionTierIcons, toolIcons } from '@/utils/format/icons'
 import { getLoopXpBonus, getRecommendedCreatures } from '@/utils/formulas'
-import { expeditionTierIcons, toolIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { getCreatureImage } from '@/utils/images/creatureImages'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -74,8 +63,6 @@ const {
   expeditionEvaluations,
   totalXpPerSecond,
   resetAllExpeditions,
-  exportSetup,
-  importSetup,
   expeditionTiers,
   expeditionParties,
   expeditionLoopCounts,
@@ -84,122 +71,6 @@ const {
 
 
 const { collectionLevels } = useCreatureCollection()
-
-
-const modalMode = ref<'import' | 'export' | null>(null)
-const modalText = ref('')
-const importError = ref('')
-const copied = ref(false)
-const importTextarea = ref<HTMLTextAreaElement | null>(null)
-const exportTextarea = ref<HTMLTextAreaElement | null>(null)
-
-
-function autoResizeTextarea(el: HTMLTextAreaElement | null) {
-  if (!el) return
-  el.style.height = 'auto'
-  el.style.height = `${el.scrollHeight}px`
-}
-
-
-watch(modalText, () => {
-  nextTick(() => {
-    if (modalMode.value === 'import') autoResizeTextarea(importTextarea.value)
-    if (modalMode.value === 'export') autoResizeTextarea(exportTextarea.value)
-  })
-})
-
-
-watch(modalMode, () => {
-  nextTick(() => {
-    autoResizeTextarea(importTextarea.value)
-    autoResizeTextarea(exportTextarea.value)
-  })
-})
-
-
-function openExportModal() {
-  const raw = exportSetup()
-  try {
-    modalText.value = JSON.stringify(JSON.parse(raw), null, 2)
-  } catch {
-    modalText.value = raw
-  }
-  importError.value = ''
-  copied.value = false
-  modalMode.value = 'export'
-}
-
-
-function openImportModal() {
-  modalText.value = ''
-  importError.value = ''
-  modalMode.value = 'import'
-}
-
-
-function handleImport() {
-  const success = importSetup(modalText.value)
-  if (success) {
-    modalMode.value = null
-  } else {
-    importError.value = t('expeditions.invalidJson')
-  }
-}
-
-
-function copyExport() {
-  navigator.clipboard.writeText(modalText.value)
-  copied.value = true
-  setTimeout(() => {
-    copied.value = false
-  }, 2000)
-}
-
-
-function downloadExport() {
-  const blob = new Blob([modalText.value], { type: 'application/json' })
-  const url = URL.createObjectURL(blob)
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `expedition-setup-${timestamp}.json`
-  a.click()
-  URL.revokeObjectURL(url)
-}
-
-
-async function pasteFromClipboard() {
-  try {
-    const text = await navigator.clipboard.readText()
-    try {
-      modalText.value = JSON.stringify(JSON.parse(text), null, 2)
-    } catch {
-      modalText.value = text
-    }
-    importError.value = ''
-  } catch {
-    importError.value = t('expeditions.unableClipboard')
-  }
-}
-
-
-function handleFileUpload(event: Event) {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0]
-  if (!file) return
-  const reader = new FileReader()
-  reader.addEventListener('load', () => {
-    const text = reader.result as string
-    try {
-      modalText.value = JSON.stringify(JSON.parse(text), null, 2)
-    } catch {
-      modalText.value = text
-    }
-    importError.value = ''
-  })
-  reader.readAsText(file)
-  input.value = ''
-}
 
 
 function handleReset() {
@@ -409,13 +280,13 @@ function rowSelected(id: string): boolean {
             <h2 class="text-base font-bold">{{ t('expeditions.title') }}</h2>
             <span
               v-if="totalXpPerSecond > 0"
-              class="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+              class="rounded-full bg-success/10 px-2 py-0.5 text-xs font-semibold text-success-strong dark:bg-success/15 dark:text-success-strong"
             >
               {{ formatDecimal(totalXpPerSecond) }} {{ t('expeditions.xpPerSecondSuffix') }}
             </span>
             <span
               v-if="expeditionToolXpBonus > 1"
-              class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-400"
+              class="inline-flex items-center gap-1 rounded-full bg-warning/10 px-2 py-0.5 text-xs font-semibold text-warning-strong dark:bg-warning/15 dark:text-warning-strong"
             >
               <img :src="toolIcons.sword" alt="" class="size-3.5" loading="lazy" />
               {{
@@ -427,22 +298,8 @@ function rowSelected(id: string): boolean {
           </div>
           <div class="flex shrink-0 items-center gap-2">
             <button
-              class="focus-ring rounded-lg p-1.5 text-muted-foreground transition hover:text-foreground"
-              :title="t('expeditions.import')"
-              @click="openImportModal"
-            >
-              <FileUp class="size-5" />
-            </button>
-            <button
-              class="focus-ring rounded-lg p-1.5 text-muted-foreground transition hover:text-foreground"
-              :title="t('expeditions.export')"
-              @click="openExportModal"
-            >
-              <FileDown class="size-5" />
-            </button>
-            <button
               class="focus-ring rounded-lg p-1.5 text-muted-foreground transition hover:text-destructive"
-              :title="t('expeditions.resetAll')"
+              title="Reset All"
               @click="handleReset"
             >
               <RotateCcw class="size-5" />
@@ -483,8 +340,8 @@ function rowSelected(id: string): boolean {
                   class="text-xs font-semibold"
                   :class="
                     expeditionEvaluations[expedition.id]!.scoreRatio >= 1
-                      ? 'text-emerald-700 dark:text-emerald-400'
-                      : 'text-amber-700 dark:text-amber-400'
+                      ? 'text-success-strong'
+                      : 'text-warning-strong'
                   "
                 >
                   {{ formatDuration(expeditionEvaluations[expedition.id]!.duration) }}
@@ -507,7 +364,7 @@ function rowSelected(id: string): boolean {
               }}</span>
               <span
                 v-if="(expeditionLoopCounts[expedition.id] ?? 0) > 0"
-                class="ml-auto inline-flex items-center gap-0.5 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400"
+                class="ml-auto inline-flex items-center gap-0.5 rounded-full bg-success/10 px-1.5 py-0.5 text-3xs font-semibold text-success-strong dark:bg-success/15 dark:text-success-strong"
               >
                 <RotateCw class="size-2.5" />
                 +{{ Math.round(getLoopXpBonus(expeditionLoopCounts[expedition.id] ?? 0) * 100) }}%
@@ -536,7 +393,7 @@ function rowSelected(id: string): boolean {
                           loading="lazy"
                         />
                       </div>
-                      <span class="text-[10px] font-semibold text-foreground">{{
+                      <span class="text-3xs font-semibold text-foreground">{{
                         creature.name
                       }}</span>
                     </div>
@@ -550,8 +407,8 @@ function rowSelected(id: string): boolean {
                     class="font-mono font-semibold"
                     :class="
                       expeditionEvaluations[expedition.id]!.scoreRatio >= 1
-                        ? 'text-emerald-700 dark:text-emerald-400'
-                        : 'text-amber-700 dark:text-amber-400'
+                        ? 'text-success-strong'
+                        : 'text-warning-strong'
                     "
                   >
                     {{ formatDecimal(expeditionEvaluations[expedition.id]!.partyXpPerSecond) }}
@@ -623,100 +480,6 @@ function rowSelected(id: string): boolean {
         @normalize-level="normalizeLevelOnBlur"
       />
     </div>
-
-    <Teleport to="body">
-      <Transition name="fade">
-        <div
-          v-if="modalMode"
-          class="fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-sm"
-          @click.self="modalMode = null"
-        >
-          <div class="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-2xl">
-            <div class="mb-4 flex items-center justify-between">
-              <h3 class="text-lg font-bold">
-                {{
-                  modalMode === 'export'
-                    ? t('expeditions.exportSetup')
-                    : t('expeditions.importSetup')
-                }}
-              </h3>
-              <button
-                class="focus-ring rounded-lg p-1.5 text-muted-foreground hover:text-foreground"
-                @click="modalMode = null"
-              >
-                <X class="size-4" />
-              </button>
-            </div>
-
-            <!-- Export modal -->
-            <template v-if="modalMode === 'export'">
-              <textarea
-                :value="modalText"
-                readonly
-                ref="exportTextarea"
-                class="focus-ring max-h-[70vh] min-h-[20rem] w-full resize-none overflow-y-auto rounded-lg border border-input bg-background/70 p-3 font-mono text-xs"
-              />
-              <div class="mt-3 flex justify-end gap-2">
-                <button
-                  class="focus-ring inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/35 px-3 py-2 text-xs font-semibold text-muted-foreground transition hover:border-accent/50 hover:text-foreground"
-                  @click="copyExport"
-                >
-                  <Check v-if="copied" class="size-3 text-emerald-700 dark:text-emerald-400" />
-                  <Copy v-else class="size-3" />
-                  {{ copied ? t('expeditions.copied') : t('expeditions.copy') }}
-                </button>
-                <button
-                  class="focus-ring inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90"
-                  @click="downloadExport"
-                >
-                  <Download class="size-3" />
-                  {{ t('expeditions.download') }}
-                </button>
-              </div>
-            </template>
-
-            <!-- Import modal -->
-            <template v-else>
-              <textarea
-                v-model="modalText"
-                ref="importTextarea"
-                class="focus-ring max-h-[70vh] min-h-[20rem] w-full resize-none overflow-y-auto rounded-lg border border-input bg-background/70 p-3 font-mono text-xs"
-                :placeholder="t('expeditions.pastePlaceholder')"
-              />
-              <p v-if="importError" class="mt-1 text-xs text-destructive">{{ importError }}</p>
-              <div class="mt-3 flex justify-end gap-2">
-                <button
-                  class="focus-ring inline-flex items-center gap-1.5 rounded-lg border border-border bg-muted/35 px-3 py-2 text-xs font-semibold text-muted-foreground transition hover:border-accent/50 hover:text-foreground"
-                  @click="pasteFromClipboard"
-                >
-                  <ClipboardPaste class="size-4" />
-                  {{ t('expeditions.paste') }}
-                </button>
-                <label
-                  class="focus-ring inline-flex cursor-pointer items-center gap-1.5 rounded-lg border border-border bg-muted/35 px-3 py-2 text-xs font-semibold text-muted-foreground transition hover:border-accent/50 hover:text-foreground"
-                >
-                  <FolderOpen class="size-4" />
-                  {{ t('expeditions.openFile') }}
-                  <input
-                    type="file"
-                    accept=".json,application/json"
-                    class="hidden"
-                    @change="handleFileUpload"
-                  />
-                </label>
-                <button
-                  class="focus-ring inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90"
-                  @click="handleImport"
-                >
-                  <Check class="size-4" />
-                  {{ t('expeditions.import') }}
-                </button>
-              </div>
-            </template>
-          </div>
-        </div>
-      </Transition>
-    </Teleport>
 
     <CreatureDetail
       :creature="inspectedCreature"

--- a/src/views/FabricationView.vue
+++ b/src/views/FabricationView.vue
@@ -7,9 +7,9 @@ import { RouterLink } from 'vue-router'
 
 import { useGameConfig } from '@/composables/useGameConfig'
 import { items, jobActivityIndex } from '@/data/indexes'
-import { toTitleCase } from '@/utils/format'
-import { sourceIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { toTitleCase } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -193,7 +193,7 @@ const prestigeImage = computed(() => getItemImage({ id: 'prestige-points' }))
             v-if="savedUnallocated > 0"
             :class="
               unallocatedPoints < 0
-                ? 'rounded-full bg-red-500/15 px-2 py-0.5 font-medium text-red-600 dark:text-red-400'
+                ? 'rounded-full bg-danger/15 px-2 py-0.5 font-medium text-danger-strong'
                 : 'rounded-full bg-muted px-2 py-0.5 font-medium text-foreground'
             "
             :title="
@@ -206,13 +206,13 @@ const prestigeImage = computed(() => getItemImage({ id: 'prestige-points' }))
           </span>
           <span
             v-if="addedPoints > 0"
-            class="rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-amber-600 dark:text-amber-400"
+            class="rounded-full bg-warning/15 px-2 py-0.5 font-medium text-warning-strong"
           >
             +{{ addedPoints }} {{ t('fabricationView.simulated') }}
           </span>
           <span
             v-if="removedPoints > 0"
-            class="rounded-full bg-red-500/15 px-2 py-0.5 font-medium text-red-600 dark:text-red-400"
+            class="rounded-full bg-danger/15 px-2 py-0.5 font-medium text-danger-strong"
           >
             -{{ removedPoints }} {{ t('fabricationView.removed') }}
           </span>
@@ -220,7 +220,7 @@ const prestigeImage = computed(() => getItemImage({ id: 'prestige-points' }))
       </div>
       <div class="flex items-center gap-2">
         <button
-          class="rounded-full border border-border/60 bg-card/65 px-2.5 py-1 text-[11px] font-semibold text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
+          class="rounded-full border border-border/60 bg-card/65 px-2.5 py-1 text-2xs font-semibold text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
           :class="{ 'pointer-events-none invisible': !hasSimulatedChanges }"
           @click="resetToSave"
         >
@@ -256,9 +256,9 @@ const prestigeImage = computed(() => getItemImage({ id: 'prestige-points' }))
             class="flex items-center gap-2 rounded-lg border px-2 py-1.5 transition-colors"
             :class="
               getCardState(item.id) === 'simulated'
-                ? 'border-amber-500/40 bg-amber-500/5'
+                ? 'border-warning/40 bg-warning/5'
                 : getCardState(item.id) === 'removed'
-                  ? 'border-red-500/40 bg-red-500/5'
+                  ? 'border-danger/40 bg-danger/5'
                   : getPoints(item.id) > 0
                     ? 'border-primary/40 bg-primary/5'
                     : 'border-border bg-card'
@@ -272,8 +272,8 @@ const prestigeImage = computed(() => getItemImage({ id: 'prestige-points' }))
                 class="h-1.5 w-3 rounded-sm transition-colors"
                 :class="{
                   'bg-primary': getDotState(item.id, dot) === 'save',
-                  'bg-amber-500': getDotState(item.id, dot) === 'simulated',
-                  'bg-red-500/50': getDotState(item.id, dot) === 'removed',
+                  'bg-warning': getDotState(item.id, dot) === 'simulated',
+                  'bg-danger/50': getDotState(item.id, dot) === 'removed',
                   'bg-muted': getDotState(item.id, dot) === 'empty',
                 }"
               />
@@ -292,10 +292,10 @@ const prestigeImage = computed(() => getItemImage({ id: 'prestige-points' }))
             <div class="min-w-0 flex-1">
               <div class="truncate text-xs font-medium">{{ item.name }}</div>
               <div
-                class="text-[10px]"
+                class="text-3xs"
                 :class="{
-                  'text-amber-600 dark:text-amber-400': getCardState(item.id) === 'simulated',
-                  'text-red-600 dark:text-red-400': getCardState(item.id) === 'removed',
+                  'text-warning-strong': getCardState(item.id) === 'simulated',
+                  'text-danger-strong': getCardState(item.id) === 'removed',
                   'text-muted-foreground': getCardState(item.id) === 'normal',
                 }"
               >

--- a/src/views/GardenView.vue
+++ b/src/views/GardenView.vue
@@ -6,8 +6,9 @@ import { useI18n } from 'vue-i18n'
 import AppTooltip from '@/components/shared/AppTooltip.vue'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { GardenCell } from '@/types'
-import { gardenIcon } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { formatNumber } from '@/utils/format/format'
+import { gardenIcon } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const {
   gardenLayout,
@@ -348,13 +349,13 @@ watch(
           </span>
           <span
             v-if="diffCounts.added > 0"
-            class="rounded-full bg-amber-500/15 px-2 py-0.5 font-medium text-amber-600 dark:text-amber-400"
+            class="rounded-full bg-warning/15 px-2 py-0.5 font-medium text-warning-strong"
           >
             {{ t('gardenView.simulated', { n: diffCounts.added }) }}
           </span>
           <span
             v-if="diffCounts.removed > 0"
-            class="rounded-full bg-red-500/15 px-2 py-0.5 font-medium text-red-600 dark:text-red-400"
+            class="rounded-full bg-danger/15 px-2 py-0.5 font-medium text-danger-strong"
           >
             {{ t('gardenView.removed', { n: diffCounts.removed }) }}
           </span>
@@ -362,7 +363,7 @@ watch(
       </div>
       <div class="flex items-center gap-3">
         <button
-          class="inline-flex items-center gap-1 rounded-full border border-border/60 bg-card/65 px-2.5 py-1 text-[11px] font-semibold text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
+          class="inline-flex items-center gap-1 rounded-full border border-border/60 bg-card/65 px-2.5 py-1 text-2xs font-semibold text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
           :class="{ 'pointer-events-none invisible': !hasGardenChanges }"
           :title="
             hasGardenSaveSnapshot ? t('gardenView.revertTitle') : t('gardenView.clearBedTitle')
@@ -373,7 +374,7 @@ watch(
         </button>
         <span
           v-if="totalPlantedCount > 0 || fertilizerToReachCurrent > 0"
-          class="inline-flex items-center gap-2 font-mono text-[11px] text-primary"
+          class="inline-flex items-center gap-2 font-mono text-2xs text-primary"
         >
           {{ t('gardenView.total') }}
           <AppTooltip
@@ -384,7 +385,7 @@ watch(
                   totalPlantedCount === 1
                     ? t('gardenView.flowerCount', { n: totalPlantedCount })
                     : t('gardenView.flowersCount', { n: totalPlantedCount }),
-                cost: FLOWER_BUY_VALUE.toLocaleString(),
+                cost: formatNumber(FLOWER_BUY_VALUE),
               })
             "
           >
@@ -398,7 +399,7 @@ watch(
                 class="size-3.5 object-contain"
                 loading="lazy"
               />
-              {{ (totalPlantedCount * FLOWER_BUY_VALUE).toLocaleString() }}
+              {{ formatNumber(totalPlantedCount * FLOWER_BUY_VALUE) }}
             </span>
           </AppTooltip>
           <AppTooltip
@@ -429,14 +430,14 @@ watch(
     <div class="grid items-start gap-6 lg:grid-cols-[minmax(0,460px)_1fr]">
       <!-- Left column: grid + selection panel -->
       <div class="space-y-4">
-        <div class="rounded-2xl border border-border bg-card/50 p-4">
+        <div class="rounded-xl border border-border bg-card/50 p-4">
           <div class="mb-3 flex items-center justify-between">
             <div class="flex items-center gap-2">
               <img :src="gardenIcon" alt="Garden" class="size-4 object-contain" loading="lazy" />
               <h2 class="text-sm font-extrabold">{{ t('gardenView.gardenBed') }}</h2>
             </div>
             <span
-              class="inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground"
+              class="inline-flex items-center gap-1 font-mono text-3xs uppercase tracking-[0.18em] text-muted-foreground"
             >
               <img
                 :src="getItemImage({ id: ROCK_ITEM_ID })"
@@ -461,7 +462,7 @@ watch(
                         class="font-mono font-semibold"
                         :style="{ color: `hsl(${FLOWERS[4].color})` }"
                       >
-                        {{ fullBedClearCost.toLocaleString() }}
+                        {{ formatNumber(fullBedClearCost) }}
                       </span>
                     </span>
                     {{ t('gardenView.clearBedCostFirstRock') }}
@@ -476,7 +477,7 @@ watch(
                         class="font-mono font-semibold"
                         :style="{ color: `hsl(${FLOWERS[4].color})` }"
                       >
-                        {{ rockCostAt(0).toLocaleString() }}
+                        {{ formatNumber(rockCostAt(0)) }}
                       </span> </span
                     >{{ t('gardenView.clearBedCostLastRock') }}
                     <span class="inline-flex items-center gap-1 align-middle">
@@ -490,7 +491,7 @@ watch(
                         class="font-mono font-semibold"
                         :style="{ color: `hsl(${FLOWERS[4].color})` }"
                       >
-                        {{ rockCostAt(GRID_SIZE - 1).toLocaleString() }}
+                        {{ formatNumber(rockCostAt(GRID_SIZE - 1)) }}
                       </span> </span
                     >{{ t('gardenView.clearBedCostEnd') }}
                   </span>
@@ -508,7 +509,7 @@ watch(
                 class="garden-cell focus-ring relative aspect-square overflow-hidden rounded-md border transition"
                 :class="
                   selectedIndex === i
-                    ? 'garden-cell-selected ring-2 ring-amber-500 dark:ring-amber-300'
+                    ? 'garden-cell-selected ring-2 ring-warning dark:ring-warning'
                     : ''
                 "
                 :style="{
@@ -529,7 +530,7 @@ watch(
                   loading="lazy"
                 />
                 <span
-                  class="garden-cell-level absolute bottom-0 right-0 py-0.5 pl-1.5 pr-1 font-mono text-[9px] font-bold tabular-nums leading-none"
+                  class="garden-cell-level absolute bottom-0 right-0 py-0.5 pl-1.5 pr-1 font-mono text-3xs font-bold tabular-nums leading-none"
                   style="clip-path: polygon(5px 0, 100% 0, 100% 100%, 0 100%, 0 5px)"
                 >
                   {{ t('gardenView.levelBadge', { n: v.cell.level }) }}
@@ -550,7 +551,7 @@ watch(
         </div>
 
         <!-- Selection panel -->
-        <div class="min-h-[15rem] rounded-2xl border border-border bg-card/50 p-4">
+        <div class="min-h-[15rem] rounded-xl border border-border bg-card/50 p-4">
           <div
             v-if="!selectedVisualCell"
             class="flex h-full min-h-[13rem] items-center justify-center text-center text-sm text-muted-foreground"
@@ -564,7 +565,7 @@ watch(
               <div
                 class="garden-thumb-empty flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-dashed"
               >
-                <span class="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">
+                <span class="font-mono text-3xs uppercase tracking-wider text-muted-foreground">
                   {{ t('gardenView.empty') }}
                 </span>
               </div>
@@ -572,13 +573,13 @@ watch(
                 <div class="text-sm font-extrabold leading-tight">
                   {{ t('gardenView.plantAFlower') }}
                 </div>
-                <div class="font-mono text-[10px] text-muted-foreground">
+                <div class="font-mono text-3xs text-muted-foreground">
                   {{ t('gardenView.pickFlowerBelow') }}
                 </div>
               </div>
             </div>
             <div
-              class="flex h-9 items-center justify-center gap-1 rounded-lg border border-border bg-muted/60 px-3 font-mono text-[10px] text-muted-foreground dark:border-border/60 dark:bg-muted/20"
+              class="flex h-9 items-center justify-center gap-1 rounded-lg border border-border bg-muted/60 px-3 font-mono text-3xs text-muted-foreground dark:border-border/60 dark:bg-muted/20"
             >
               <span>{{ t('gardenView.merchantCostLead') }}</span>
               <span class="inline-flex items-center gap-1 align-middle">
@@ -592,7 +593,7 @@ watch(
                   class="font-mono font-semibold"
                   :style="{ color: `hsl(${FLOWERS[4].color})` }"
                 >
-                  {{ FLOWER_BUY_VALUE.toLocaleString() }}
+                  {{ formatNumber(FLOWER_BUY_VALUE) }}
                 </span>
               </span>
               <span>{{ t('gardenView.perFlower') }}</span>
@@ -636,7 +637,7 @@ watch(
                 <div class="text-sm font-extrabold leading-tight">
                   {{ t('gardenView.flowerName', { name: selectedFlowerMeta?.name }) }}
                 </div>
-                <div class="flex items-center gap-1 font-mono text-[10px] text-muted-foreground">
+                <div class="flex items-center gap-1 font-mono text-3xs text-muted-foreground">
                   <span>
                     {{
                       t('gardenView.levelOf', {
@@ -666,7 +667,7 @@ watch(
                   <Trash2 class="size-4" />
                 </button>
                 <template #content>
-                  <span class="block max-w-[16rem] text-[11px] font-medium leading-snug">
+                  <span class="block max-w-[16rem] text-2xs font-medium leading-snug">
                     {{ t('gardenView.removeTooltip') }}
                   </span>
                 </template>
@@ -746,7 +747,7 @@ watch(
 
       <!-- Right column: flower summary -->
       <div class="space-y-4">
-        <div class="rounded-2xl border border-border bg-card/50 p-4">
+        <div class="rounded-xl border border-border bg-card/50 p-4">
           <div class="mb-3 flex items-center">
             <h2 class="text-sm font-extrabold">{{ t('gardenView.flowersHeading') }}</h2>
           </div>
@@ -757,7 +758,7 @@ watch(
               class="rounded-xl border bg-card/50 p-3 transition-all duration-500"
               :class="
                 recentlyChangedFlowers.has(flower.id)
-                  ? 'border-amber-400/70 bg-amber-400/10 shadow-[0_0_0_3px_rgba(251,191,36,0.18)]'
+                  ? 'border-warning/70 bg-warning/10 shadow-[0_0_0_3px_oklch(var(--warning)_/_0.18)]'
                   : 'border-border'
               "
             >
@@ -776,11 +777,11 @@ watch(
                   />
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="text-[13px] font-extrabold leading-tight">
+                  <div class="text-xs font-extrabold leading-tight">
                     {{ t('gardenView.flowerName', { name: flower.name }) }}
                   </div>
                   <div
-                    class="mt-0.5 flex items-center gap-1 font-mono text-[10px] text-muted-foreground"
+                    class="mt-0.5 flex items-center gap-1 font-mono text-3xs text-muted-foreground"
                   >
                     <span class="tabular-nums text-foreground/80">{{ flower.count }}</span>
                     <span>{{ t('gardenView.plantedLabel') }}</span>
@@ -794,9 +795,7 @@ watch(
                   </div>
                 </div>
                 <div class="min-w-[112px] shrink-0 text-right">
-                  <div
-                    class="font-mono text-[9px] uppercase tracking-[0.18em] text-muted-foreground"
-                  >
+                  <div class="font-mono text-3xs uppercase tracking-[0.18em] text-muted-foreground">
                     {{ flower.unit }}{{ t('common.perMin') }}
                   </div>
                   <div

--- a/src/views/ItemsView.vue
+++ b/src/views/ItemsView.vue
@@ -9,13 +9,14 @@ import ItemCard from '@/components/items/ItemCard.vue'
 import ItemDetail from '@/components/items/ItemDetail.vue'
 import ItemsToolbar from '@/components/items/ItemsToolbar.vue'
 import type { ActiveFilter } from '@/components/shared/ActiveFilters.vue'
+import SortableHeader from '@/components/shared/SortableHeader.vue'
 import { useCreatureDrawer } from '@/composables/useCreatureDrawer'
 import { useItems } from '@/composables/useItems'
 import { summoningIndex } from '@/data/indexes'
 import type { Item } from '@/types'
-import { itemTypeColor, sourceLabel } from '@/utils/format'
-import { sourceIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { itemTypeColor, sourceLabel } from '@/utils/format/format'
+import { sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const {
   filteredItems,
@@ -259,7 +260,7 @@ onMounted(() => {
         <!-- Empty state -->
         <div
           v-if="filteredItems.length === 0"
-          class="flex flex-col items-center justify-center rounded-2xl border border-border/60 bg-card/50 px-6 py-16 text-center"
+          class="flex flex-col items-center justify-center rounded-xl border border-border/60 bg-card/50 px-6 py-16 text-center"
         >
           <p class="text-lg font-semibold text-foreground">{{ t('items.view.emptyTitle') }}</p>
           <p class="mt-1 text-sm text-muted-foreground">
@@ -294,46 +295,25 @@ onMounted(() => {
             <table class="min-w-full text-sm" role="grid">
               <thead class="bg-muted/50">
                 <tr>
-                  <th
-                    class="px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-                    :aria-sort="
-                      tableSortKey === 'name'
-                        ? tableSortDirection === 'asc'
-                          ? 'ascending'
-                          : 'descending'
-                        : 'none'
-                    "
-                  >
-                    <button
-                      class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                      @click="sortBy('name')"
-                    >
-                      {{ t('items.view.name') }}
-                      <span :class="tableSortKey === 'name' ? 'text-primary' : 'opacity-30'">{{
-                        tableSortDirection === 'asc' ? '▲' : '▼'
-                      }}</span>
-                    </button>
-                  </th>
-                  <th
-                    class="whitespace-nowrap px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-                    :aria-sort="
-                      tableSortKey === 'type'
-                        ? tableSortDirection === 'asc'
-                          ? 'ascending'
-                          : 'descending'
-                        : 'none'
-                    "
-                  >
-                    <button
-                      class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                      @click="sortBy('type')"
-                    >
-                      {{ t('items.view.type') }}
-                      <span :class="tableSortKey === 'type' ? 'text-primary' : 'opacity-30'">{{
-                        tableSortDirection === 'asc' ? '▲' : '▼'
-                      }}</span>
-                    </button>
-                  </th>
+                  <SortableHeader
+                    sort-key="name"
+                    :active-key="tableSortKey"
+                    :direction="tableSortDirection"
+                    :label="t('items.view.name')"
+                    align="left"
+                    inactive-arrow-class="opacity-30"
+                    @sort="sortBy"
+                  />
+                  <SortableHeader
+                    sort-key="type"
+                    :active-key="tableSortKey"
+                    :direction="tableSortDirection"
+                    :label="t('items.view.type')"
+                    align="left"
+                    inactive-arrow-class="opacity-30"
+                    th-class="whitespace-nowrap"
+                    @sort="sortBy"
+                  />
                   <th
                     class="whitespace-nowrap px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
                   >
@@ -378,48 +358,26 @@ onMounted(() => {
                       </button>
                     </span>
                   </th>
-                  <th
-                    class="whitespace-nowrap px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-                    :aria-sort="
-                      tableSortKey === 'recipeCount'
-                        ? tableSortDirection === 'asc'
-                          ? 'ascending'
-                          : 'descending'
-                        : 'none'
-                    "
-                  >
-                    <button
-                      class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                      @click="sortBy('recipeCount')"
-                    >
-                      {{ t('items.view.recipes') }}
-                      <span
-                        :class="tableSortKey === 'recipeCount' ? 'text-primary' : 'opacity-30'"
-                        >{{ tableSortDirection === 'asc' ? '▲' : '▼' }}</span
-                      >
-                    </button>
-                  </th>
-                  <th
-                    class="whitespace-nowrap px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
-                    :aria-sort="
-                      tableSortKey === 'usedInCount'
-                        ? tableSortDirection === 'asc'
-                          ? 'ascending'
-                          : 'descending'
-                        : 'none'
-                    "
-                  >
-                    <button
-                      class="focus-ring inline-flex items-center gap-1 transition hover:text-foreground"
-                      @click="sortBy('usedInCount')"
-                    >
-                      {{ t('items.view.usedIn') }}
-                      <span
-                        :class="tableSortKey === 'usedInCount' ? 'text-primary' : 'opacity-30'"
-                        >{{ tableSortDirection === 'asc' ? '▲' : '▼' }}</span
-                      >
-                    </button>
-                  </th>
+                  <SortableHeader
+                    sort-key="recipeCount"
+                    :active-key="tableSortKey"
+                    :direction="tableSortDirection"
+                    :label="t('items.view.recipes')"
+                    align="left"
+                    inactive-arrow-class="opacity-30"
+                    th-class="whitespace-nowrap"
+                    @sort="sortBy"
+                  />
+                  <SortableHeader
+                    sort-key="usedInCount"
+                    :active-key="tableSortKey"
+                    :direction="tableSortDirection"
+                    :label="t('items.view.usedIn')"
+                    align="left"
+                    inactive-arrow-class="opacity-30"
+                    th-class="whitespace-nowrap"
+                    @sort="sortBy"
+                  />
                   <th
                     v-if="anySummons"
                     class="whitespace-nowrap px-2 py-3 text-left text-xs font-bold uppercase tracking-[0.1em] text-muted-foreground"
@@ -503,9 +461,7 @@ onMounted(() => {
                       >
                     </div>
                   </td>
-                  <td
-                    class="whitespace-nowrap px-2 py-2.5 font-mono text-sm text-yellow-700 dark:text-yellow-400"
-                  >
+                  <td class="whitespace-nowrap px-2 py-2.5 font-mono text-sm text-gold-strong">
                     {{ item.buyValue ?? '—' }} / {{ item.sellValue ?? '—' }}
                   </td>
                   <td class="px-2 py-2.5 text-sm text-foreground">
@@ -574,7 +530,7 @@ onMounted(() => {
             leave-to-class="opacity-0 translate-y-4"
           >
             <div
-              class="mx-auto max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-2xl border border-border bg-card shadow-card"
+              class="mx-auto max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-xl border border-border bg-card shadow-card"
             >
               <ItemDetail
                 :item="selectedItem"

--- a/src/views/MachinesView.vue
+++ b/src/views/MachinesView.vue
@@ -6,10 +6,9 @@ import { useI18n } from 'vue-i18n'
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useMachines } from '@/composables/useMachines'
 import { itemById } from '@/data/indexes'
-import { activeLocale } from '@/i18n'
-import { itemName, typeColor } from '@/utils/format'
-import { getItemImage } from '@/utils/itemImages'
-import { getMachineImage } from '@/utils/machineImages'
+import { formatNumber, itemName, typeColor } from '@/utils/format/format'
+import { getItemImage } from '@/utils/images/itemImages'
+import { getMachineImage } from '@/utils/images/machineImages'
 
 const { t } = useI18n()
 
@@ -40,7 +39,7 @@ function formatInterval(seconds: number): string {
 
 
 function formatGold(amount: number): string {
-  return amount.toLocaleString(activeLocale())
+  return formatNumber(amount)
 }
 
 
@@ -88,7 +87,7 @@ const hasSaveData = computed(() => Object.keys(machineLevels.value).length > 0)
               <div class="flex items-center justify-between">
                 <h3 class="font-semibold">{{ machine.name }}</h3>
                 <span
-                  class="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-400"
+                  class="rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success-strong"
                 >
                   {{ t('machines.generator') }}
                 </span>
@@ -187,7 +186,7 @@ const hasSaveData = computed(() => Object.keys(machineLevels.value).length > 0)
                     {{ t('machines.creatureAny') }}
                   </span>
                   <span
-                    class="rounded-full bg-violet-500/15 px-2 py-0.5 text-xs font-medium text-violet-400"
+                    class="rounded-full bg-reserved/15 px-2 py-0.5 text-xs font-medium text-reserved-strong"
                   >
                     {{ t('machines.processor') }}
                   </span>

--- a/src/views/ToolsView.vue
+++ b/src/views/ToolsView.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 
 import { useGameConfig } from '@/composables/useGameConfig'
 import { useTools } from '@/composables/useTools'
 import { itemById } from '@/data/indexes'
-import { itemName } from '@/utils/format'
-import { toolIcons, sourceIcons } from '@/utils/icons'
-import { getItemImage } from '@/utils/itemImages'
+import { itemName } from '@/utils/format/format'
+import { toolIcons, sourceIcons } from '@/utils/format/icons'
+import { getItemImage } from '@/utils/images/itemImages'
 
 const { t } = useI18n()
 
@@ -41,6 +42,26 @@ const toolGroups = computed(() => [
   { label: t('toolsView.workstation'), tools: workstationTools.value },
   { label: t('toolsView.other'), tools: otherTools.value },
 ])
+
+
+// Deep-link highlight: a planner advisory can open ?tool=<id> to flag that tool.
+const route = useRoute()
+const highlightTool = ref<string | null>(null)
+
+
+onMounted(() => {
+  const tool = typeof route.query.tool === 'string' ? route.query.tool : null
+  if (!tool) return
+  highlightTool.value = tool
+  nextTick(() => {
+    document
+      .getElementById(`tool-card-${tool}`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  })
+  window.setTimeout(() => {
+    highlightTool.value = null
+  }, 3500)
+})
 </script>
 
 <template>
@@ -73,8 +94,10 @@ const toolGroups = computed(() => [
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <div
           v-for="tool in group.tools"
+          :id="`tool-card-${tool.id}`"
           :key="tool.id"
           class="overflow-hidden rounded-xl border border-border bg-card"
+          :class="{ 'attn-ring': highlightTool === tool.id }"
         >
           <div class="flex items-center gap-3 border-b border-border/50 bg-muted/30 px-4 py-3">
             <img
@@ -123,7 +146,7 @@ const toolGroups = computed(() => [
                   <span
                     class="font-semibold"
                     :class="
-                      toolSpeedModes[tool.skillId] ? 'text-emerald-400' : 'text-muted-foreground'
+                      toolSpeedModes[tool.skillId] ? 'text-success-strong' : 'text-muted-foreground'
                     "
                   >
                     {{


### PR DESCRIPTION
## Description

Seventh PR in the Planner v2 stacked rebuild (targets `planner-v2`). Rebuilds the item-detail page around dedicated source/recipe/loot components, adds the driver.js product tour, and aligns the remaining page views and supporting composables with the v2 components.

## Summary
- Rebuild item detail: new `ItemRecipeList`, `ItemJobSources`, `ItemExpeditions`, `ItemSummoning`, `ItemLootTable` plus `ItemCard`/`ItemDetail`/`ItemsToolbar` updates
- Align beastiary and expedition components (creature card/detail/grid/table, expedition list/detail/selector) with the v2 design
- Add the driver.js product tour (`usePlannerTour`, `plannerTourDemo`)
- Update supporting composables (`useGameConfig`, `useRecommendations`, `useExpeditions`, `useDungeons`, `useGoldIncome`, `useExpeditionTierSelections`) and `formulas`
- Align the remaining page views (Items, Beastiary, Dungeons, Expeditions, Awaken, Configs, Fabrication, Garden, Machines, Tools)