### PR TITLE
Add recommended tier to creature Best Expeditions list

### DIFF
--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -12,7 +12,7 @@ import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type { Creature, CreatureStats, Jobs } from '@/types'
 import { itemName, toTitleCase, typeColor, typeColorVar } from '@/utils/format/format'
-import { jobIcons } from '@/utils/format/icons'
+import { expeditionTierIcons, jobIcons } from '@/utils/format/icons'
 import {
   getBestExpeditionsForCreature,
   jobColors,
@@ -87,7 +87,7 @@ const selectedCreatureStats = computed<CreatureStats | undefined>(() => {
 
 const bestExpeditions = computed(() => {
   if (!props.creature) return []
-  return getBestExpeditionsForCreature(props.creature)
+  return getBestExpeditionsForCreature(props.creature, 5, getLevel(props.creature.id))
 })
 
 
@@ -401,6 +401,12 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                 <div
                   class="mt-0.5 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground"
                 >
+                  <img
+                    :src="expeditionTierIcons[entry.tier]"
+                    :alt="`Tier ${entry.tier}`"
+                    class="size-4 shrink-0 object-contain"
+                    loading="lazy"
+                  />
                   <span>{{ entry.biomeName }}</span>
                   <span v-if="entry.traitMatch" class="text-primary">{{
                     t('beastiary.detail.traitMatch')

--- a/src/utils/__tests__/formulas.test.ts
+++ b/src/utils/__tests__/formulas.test.ts
@@ -361,6 +361,7 @@ describe('getBestExpeditionsForCreature', () => {
     expect(entry).toHaveProperty('traitMatch')
     expect(entry).toHaveProperty('biomeStatus')
     expect(entry).toHaveProperty('statAlignment')
+    expect(entry).toHaveProperty('tier')
   })
 
   test('scores are non-negative', () => {
@@ -368,6 +369,31 @@ describe('getBestExpeditionsForCreature', () => {
     for (const entry of results) {
       expect(entry.score).toBeGreaterThanOrEqual(0)
     }
+  })
+
+  test('recommended tier is an integer in 1..5', () => {
+    const results = getBestExpeditionsForCreature(creature, 20, 30)
+    for (const entry of results) {
+      expect(Number.isInteger(entry.tier)).toBe(true)
+      expect(entry.tier).toBeGreaterThanOrEqual(1)
+      expect(entry.tier).toBeLessThanOrEqual(5)
+    }
+  })
+
+  test('recommended tier adapts to creature level', () => {
+    // A creature too weak to clear a hard expedition should be steered to the
+    // highest-XP tier (run time is pinned at the max either way); once strong
+    // enough to clear it quickly, the best XP/sec lands on a lower, faster tier.
+    const strong = makeCreature({ stats: { ...zeroStats, power: 100 }, types: [] })
+    const hardId = 'expedition-type-20' // Battle for Koltera (baseRating 6000)
+    const tierAt = (level: number) =>
+      getBestExpeditionsForCreature(strong, 100, level).find((e) => e.expedition.id === hardId)
+        ?.tier
+
+    const weak = tierAt(1)
+    const leveled = tierAt(120)
+    expect(weak).toBe(5)
+    expect(leveled).toBeLessThan(weak!)
   })
 })
 
@@ -401,6 +427,7 @@ describe('getBestExpeditionsForLeveling', () => {
     expect(entry).toHaveProperty('traitMatch')
     expect(entry).toHaveProperty('biomeStatus')
     expect(entry).toHaveProperty('statAlignment')
+    expect(entry).toHaveProperty('tier')
   })
 
   test('higher level creatures produce valid results', () => {

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -213,6 +213,38 @@ interface BestExpeditionEntry {
   traitMatch: boolean
   biomeStatus: 'advantage' | 'disadvantage' | 'neutral'
   statAlignment: number
+  /** Recommended run-tier (1–5): the tier that maximizes XP/sec for this creature at `level`. */
+  tier: number
+}
+
+/**
+ * The run-tier (1–5) a creature should farm an expedition at: the one maximizing XP/sec.
+ * Higher tiers grant more XP but raise the difficulty rating (longer duration), so the best
+ * tier is the highest the creature's rating can still clear quickly. Mirrors the best-rate
+ * loop in scripts/generate-tables.ts (which builds the precomputed tables) and the leveling
+ * scorer below.
+ */
+function bestTierByRate(
+  creature: Creature,
+  expedition: Expedition,
+  level: number,
+  biome: Biome | undefined,
+): number {
+  const rating = calculateCreatureRating(creature, expedition, level, biome)
+  let bestTier = 1
+  let bestXpPerSec = -1
+  for (let tier = 1; tier <= 5; tier++) {
+    const duration = calculateDuration(rating, expedition, tier)
+    const xpPerRun = calculateExpeditionXp(expedition, tier, 0, 1)
+    if (duration > 0 && xpPerRun > 0) {
+      const xpPerSec = xpPerRun / duration
+      if (xpPerSec > bestXpPerSec) {
+        bestXpPerSec = xpPerSec
+        bestTier = tier
+      }
+    }
+  }
+  return bestTier
 }
 
 /**
@@ -236,6 +268,7 @@ function statAlignmentScore(creature: Creature, expedition: Expedition): number 
  */
 function rankExpeditions(
   creature: Creature,
+  level: number,
   limit: number,
   scoreFn: (
     expedition: Expedition,
@@ -265,6 +298,7 @@ function rankExpeditions(
         traitMatch,
         biomeStatus,
         statAlignment: Math.round(statAlignment * 100),
+        tier: bestTierByRate(creature, expedition, level, biome),
       }
     })
     .toSorted((a, b) => b.score - a.score)
@@ -274,13 +308,19 @@ function rankExpeditions(
 export function getBestExpeditionsForCreature(
   creature: Creature,
   limit: number = 5,
+  level: number = 1,
 ): BestExpeditionEntry[] {
-  return rankExpeditions(creature, limit, (_expedition, biome, statAlignment, traitMatch) => {
-    const biomeScore = biome ? biomeMultiplier(creature, biome) : 1.0
-    // Combined score: stat alignment * biome * trait
-    const score = statAlignment * biomeScore * (traitMatch ? 1.5 : 1.0)
-    return Math.round(score * 100)
-  })
+  return rankExpeditions(
+    creature,
+    level,
+    limit,
+    (_expedition, biome, statAlignment, traitMatch) => {
+      const biomeScore = biome ? biomeMultiplier(creature, biome) : 1.0
+      // Combined score: stat alignment * biome * trait
+      const score = statAlignment * biomeScore * (traitMatch ? 1.5 : 1.0)
+      return Math.round(score * 100)
+    },
+  )
 }
 
 export function getBestExpeditionsForLeveling(
@@ -288,7 +328,7 @@ export function getBestExpeditionsForLeveling(
   level: number,
   limit: number = 5,
 ): BestExpeditionEntry[] {
-  return rankExpeditions(creature, limit, (expedition, biome) => {
+  return rankExpeditions(creature, level, limit, (expedition, biome) => {
     // Score by best XP/sec across all tiers
     let bestXpPerSec = 0
     for (let tier = 1; tier <= 5; tier++) {

--- a/src/utils/formulas.ts
+++ b/src/utils/formulas.ts
@@ -330,9 +330,9 @@ export function getBestExpeditionsForLeveling(
 ): BestExpeditionEntry[] {
   return rankExpeditions(creature, level, limit, (expedition, biome) => {
     // Score by best XP/sec across all tiers
+    const rating = calculateCreatureRating(creature, expedition, level, biome)
     let bestXpPerSec = 0
     for (let tier = 1; tier <= 5; tier++) {
-      const rating = calculateCreatureRating(creature, expedition, level, biome)
       const duration = calculateDuration(rating, expedition, tier)
       const xpPerRun = calculateExpeditionXp(expedition, tier, 0, 1)
       if (duration > 0 && xpPerRun > 0) {


### PR DESCRIPTION
## Description

The Best Expeditions list in the creature detail drawer ranked expeditions by stat alignment, biome, and trait but never surfaced a tier. Because several expeditions share a biome and trait (e.g. Defend Koltera Outpost and Battle for Koltera, both plains + hard-shell), those pairs rendered as visually identical rows with nothing to tell them apart. This adds a recommended run-tier per row so the look-alike entries are distinguishable.

## Summary
- Add a `tier` field to each `BestExpeditionEntry`, computed by a new `bestTierByRate` helper as the run-tier (1–5) maximizing XP/sec for that creature at its level
- Thread a `level` argument through `rankExpeditions`; `getBestExpeditionsForCreature` gains an optional `level` (the ranking score and sort order are unchanged — the tier is purely additive)
- Render the recommended tier in `CreatureDetail.vue` as a difficulty skull icon via the shared `expeditionTierIcons` map, reactive to the creature's level
- Hoist a loop-invariant `calculateCreatureRating` out of the per-tier loop in `getBestExpeditionsForLeveling`
- Add unit tests covering the tier's 1–5 range and its adaptation to creature level

Closes #41.