### PR TITLE
Finish semantic color palette migration and enforce it

### DIFF
--- a/src/assets/styles/__tests__/no-raw-tailwind-colors.test.ts
+++ b/src/assets/styles/__tests__/no-raw-tailwind-colors.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Enforcement guard for the semantic color palette (issue #61). Fails if any
+ * raw Tailwind color utility (e.g. `text-emerald-600`, `bg-pink-500/10`) appears
+ * in source — all colors must go through the semantic tokens defined in
+ * `global.css` (success/warning/danger/info/reserved/gold and the method-kind /
+ * state tokens awakened/garden/buy/machine/tool, each with a `-strong` ramp).
+ *
+ * Element-type colors intentionally use the `--type-*` tokens via the
+ * `typeColorVar()` helper and inline `hsl(var(--type-*))`, not raw classes, so
+ * they don't trip this guard.
+ *
+ * Scope: this guard matches the Tailwind utility-class form only
+ * (`<prefix>-<color>-<shade>`). It deliberately does NOT scan inline `style`
+ * color literals (`rgb()`/`hsl()`/hex) or arbitrary-value classes
+ * (`text-[#...]`). Those forms remain in decorative gradients, SVG/canvas
+ * fills, and themed surfaces that were never part of the #61 class migration —
+ * flagging them here would be out of scope. Guard those by review, not regex.
+ */
+
+const SRC = resolve(process.cwd(), 'src')
+
+// Tailwind's default color scales — the palette we've migrated away from.
+const RAW_COLOR = String.raw`(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)`
+// Utility prefix + color + numeric shade, e.g. `text-emerald-600`, `dark:bg-pink-500`.
+const RAW_COLOR_CLASS = new RegExp(
+  String.raw`\b(?:text|bg|border|ring|from|to|via|fill|stroke|divide|outline|decoration|shadow|ring-offset|placeholder|caret|accent)-${RAW_COLOR}-\d`,
+)
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name)
+    // Skip test dirs — they reference raw-color patterns as fixtures/examples.
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') out.push(...sourceFiles(full))
+    } else if (/\.(vue|ts|tsx)$/.test(entry.name)) out.push(full)
+  }
+  return out
+}
+
+describe('no raw Tailwind color classes in source', () => {
+  it('every color goes through a semantic token', () => {
+    const offenders: string[] = []
+    for (const file of sourceFiles(SRC)) {
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (RAW_COLOR_CLASS.test(line)) {
+          offenders.push(`${file.replace(SRC, 'src')}:${i + 1}  ${line.trim()}`)
+        }
+      })
+    }
+    expect(
+      offenders,
+      `Raw Tailwind color classes found — migrate to a semantic token:\n${offenders.join('\n')}`,
+    ).toEqual([])
+  })
+})

--- a/src/assets/styles/__tests__/palette-contrast.test.ts
+++ b/src/assets/styles/__tests__/palette-contrast.test.ts
@@ -41,7 +41,20 @@ const BUTTON_PAIRS: [label: string, fg: string, bg: string][] = [
 // Status chips: opaque `text-X-strong` over a translucent `bg-X/<alpha>` fill
 // that itself sits on the card or page background. Alphas span the real chip
 // range used across the app (bg-X/10 … bg-X/25).
-const SEMANTIC_COLORS = ['success', 'warning', 'danger', 'info', 'reserved', 'gold'] as const
+const SEMANTIC_COLORS = [
+  'success',
+  'warning',
+  'danger',
+  'info',
+  'reserved',
+  'gold',
+  // Method-kind + state colors share the chip recipe (text-X-strong on bg-X/alpha).
+  'awakened',
+  'garden',
+  'buy',
+  'machine',
+  'tool',
+] as const
 const CHIP_ALPHAS = [0.1, 0.25]
 const CHIP_BASES = ['card', 'background'] as const
 

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -42,6 +42,19 @@
     --info-strong: 0.45 0.13 230;
     --reserved-strong: 0.45 0.18 285;
     --gold-strong: 0.5 0.12 85;
+
+    /* Method-kind + state colors — kept distinct from the status palette above so
+       they can diverge independently (a "garden" chip is not a "success"). */
+    --awakened: 0.6 0.2 350; /* pink   — awakened creature state   */
+    --garden: 0.72 0.18 128; /* lime   — garden / farming method   */
+    --buy: 0.62 0.24 322; /* fuchsia — shop / purchase method    */
+    --machine: 0.68 0.16 55; /* orange — machine / infra method    */
+    --tool: 0.62 0.1 195; /* teal   — tool-speed modifier chip  */
+    --awakened-strong: 0.47 0.2 350;
+    --garden-strong: 0.46 0.14 128;
+    --buy-strong: 0.48 0.22 322;
+    --machine-strong: 0.47 0.13 55;
+    --tool-strong: 0.44 0.09 195;
   }
 
   .dark {
@@ -79,6 +92,18 @@
     --info-strong: 0.78 0.13 230;
     --reserved-strong: 0.78 0.16 285;
     --gold-strong: 0.82 0.14 85;
+
+    /* Method-kind + state colors — dark-tuned. */
+    --awakened: 0.68 0.2 350;
+    --garden: 0.8 0.2 128;
+    --buy: 0.7 0.24 322;
+    --machine: 0.75 0.16 55;
+    --tool: 0.72 0.12 195;
+    --awakened-strong: 0.8 0.18 350;
+    --garden-strong: 0.85 0.18 128;
+    --buy-strong: 0.82 0.2 322;
+    --machine-strong: 0.82 0.13 55;
+    --tool-strong: 0.82 0.1 195;
   }
 
   * {

--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -238,7 +238,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                   role="switch"
                   :aria-checked="isAwakened(creature.id)"
                   class="focus-ring relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors"
-                  :class="isAwakened(creature.id) ? 'bg-pink-500' : 'bg-muted'"
+                  :class="isAwakened(creature.id) ? 'bg-awakened' : 'bg-muted'"
                   @click="setAwakened(creature.id, !isAwakened(creature.id))"
                 >
                   <span
@@ -411,7 +411,7 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
                   <span v-if="entry.traitMatch" class="text-primary">{{
                     t('beastiary.detail.traitMatch')
                   }}</span>
-                  <span v-if="entry.biomeStatus === 'advantage'" class="text-green-500">{{
+                  <span v-if="entry.biomeStatus === 'advantage'" class="text-success-strong">{{
                     t('beastiary.detail.advantage')
                   }}</span>
                   <span v-if="entry.biomeStatus === 'disadvantage'" class="text-destructive">{{

--- a/src/components/beastiary/CreatureGrid.vue
+++ b/src/components/beastiary/CreatureGrid.vue
@@ -54,7 +54,7 @@ const { isOwned, isAwakened, getLevel, setLevel, setAwakened, stepLevel, normali
               ? 'border-accent opacity-100 ring-2 ring-accent'
               : isOwned(creature.id)
                 ? isAwakened(creature.id)
-                  ? 'border-pink-500/40 ring-1 ring-pink-500/20'
+                  ? 'border-awakened/40 ring-1 ring-awakened/20'
                   : 'border-primary/40 ring-1 ring-primary/20'
                 : 'border-border/60 opacity-55',
             selectedCreatureId === creature.id
@@ -144,11 +144,7 @@ const { isOwned, isAwakened, getLevel, setLevel, setAwakened, stepLevel, normali
             <div class="text-center">
               <p
                 class="truncate text-lg font-extrabold"
-                :class="
-                  isAwakened(creature.id)
-                    ? 'text-pink-600 dark:text-pink-400'
-                    : 'text-foreground/80'
-                "
+                :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-foreground/80'"
               >
                 {{ creature.name }}
               </p>
@@ -210,7 +206,7 @@ const { isOwned, isAwakened, getLevel, setLevel, setAwakened, stepLevel, normali
                 class="flex w-full items-center justify-center gap-1.5 rounded-md border px-2 py-1 text-3xs font-semibold transition"
                 :class="
                   isAwakened(creature.id)
-                    ? 'border-pink-500/40 bg-pink-500/10 text-pink-400'
+                    ? 'border-awakened/40 bg-awakened/10 text-awakened-strong'
                     : 'border-border/60 bg-muted/20 text-muted-foreground hover:text-foreground'
                 "
                 @click="setAwakened(creature.id, !isAwakened(creature.id))"

--- a/src/components/beastiary/CreaturesTable.vue
+++ b/src/components/beastiary/CreaturesTable.vue
@@ -245,17 +245,15 @@ const sortedCreatures = computed(() => {
                 <div class="flex items-center gap-0.5">
                   <span
                     class="font-semibold"
-                    :class="
-                      isAwakened(creature.id)
-                        ? 'text-pink-600 dark:text-pink-400'
-                        : 'text-foreground/80'
-                    "
+                    :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-foreground/80'"
                     >{{ creature.name }}</span
                   >
                   <span
                     v-if="isOwned(creature.id)"
                     class="text-xs"
-                    :class="isAwakened(creature.id) ? 'text-pink-400' : 'text-warning-strong'"
+                    :class="
+                      isAwakened(creature.id) ? 'text-awakened-strong' : 'text-warning-strong'
+                    "
                     >★</span
                   >
                 </div>

--- a/src/components/configs/ExpeditionLadderSection.vue
+++ b/src/components/configs/ExpeditionLadderSection.vue
@@ -299,7 +299,7 @@ const { t } = useI18n()
               class="flex w-[92px] items-center justify-end gap-1 font-mono text-3xs font-bold"
               :class="
                 row.maxed
-                  ? 'text-pink-400'
+                  ? 'text-awakened-strong'
                   : row.locked
                     ? 'text-muted-foreground/40'
                     : 'text-muted-foreground'

--- a/src/components/configs/HeroStatsSection.vue
+++ b/src/components/configs/HeroStatsSection.vue
@@ -52,7 +52,10 @@ defineProps<{
             {{ collectionSummary.owned
             }}<span class="text-3xl text-muted-foreground/60">/{{ collectionSummary.total }}</span>
           </span>
-          <span v-if="collectionSummary.awakened" class="text-sm font-semibold text-pink-400">
+          <span
+            v-if="collectionSummary.awakened"
+            class="text-sm font-semibold text-awakened-strong"
+          >
             ★ {{ t('configs.hero.awakenedCount', { n: collectionSummary.awakened }) }}
           </span>
         </div>
@@ -74,7 +77,7 @@ defineProps<{
                 class="h-2.5 flex-1 rounded-sm"
                 :class="
                   i <= tierBucket.awakened
-                    ? 'bg-pink-400'
+                    ? 'bg-awakened'
                     : i <= tierBucket.owned
                       ? 'bg-accent'
                       : 'bg-muted/40'

--- a/src/components/craft-planner/DungeonSourceCallout.vue
+++ b/src/components/craft-planner/DungeonSourceCallout.vue
@@ -25,23 +25,23 @@ const isDungeonReward = computed(() => dungeonCombatRewardIds.has(props.itemId))
   <RouterLink
     v-if="isDungeonReward"
     :to="{ name: 'dungeons' }"
-    class="group/dungeon mt-2.5 flex items-center gap-2.5 rounded-lg border border-rose-500/30 bg-rose-500/10 px-2.5 py-2 transition hover:border-rose-500/50 hover:bg-rose-500/15 dark:border-rose-400/25 dark:bg-rose-400/10"
+    class="group/dungeon mt-2.5 flex items-center gap-2.5 rounded-lg border border-danger/30 bg-danger/10 px-2.5 py-2 transition hover:border-danger/50 hover:bg-danger/15 dark:border-danger/25 dark:bg-danger/10"
   >
     <span
-      class="flex size-7 shrink-0 items-center justify-center rounded-md bg-rose-500/15 text-rose-600 dark:bg-rose-400/15 dark:text-rose-300"
+      class="flex size-7 shrink-0 items-center justify-center rounded-md bg-danger/15 text-danger-strong"
     >
       <Swords class="size-4" />
     </span>
     <span class="flex flex-col leading-tight">
-      <span class="text-xs font-semibold text-rose-700 dark:text-rose-300">
+      <span class="text-xs font-semibold text-danger-strong">
         {{ t('planner.dungeonCallout.title') }}
       </span>
-      <span class="text-3xs font-medium text-rose-600/70 dark:text-rose-400/70">
+      <span class="text-3xs font-medium text-danger-strong/70">
         {{ t('planner.dungeonCallout.subtitle') }}
       </span>
     </span>
     <span
-      class="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-rose-600 transition group-hover/dungeon:translate-x-0.5 group-hover/dungeon:bg-rose-500/15 dark:text-rose-300"
+      class="ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-danger-strong transition group-hover/dungeon:translate-x-0.5 group-hover/dungeon:bg-danger/15"
     >
       <ArrowUpRight class="size-4" />
     </span>

--- a/src/components/expeditions/CreatureSelector.vue
+++ b/src/components/expeditions/CreatureSelector.vue
@@ -375,20 +375,14 @@ const activeCreatureFilters = computed<ActiveFilter[]>(() => {
               <div class="flex items-center gap-1">
                 <p
                   class="truncate font-semibold"
-                  :class="
-                    isAwakened(creature.id) ? 'text-pink-600 dark:text-pink-400' : 'text-foreground'
-                  "
+                  :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-foreground'"
                 >
                   {{ creature.name }}
                 </p>
                 <span
                   v-if="isOwned(creature.id)"
                   class="text-xs"
-                  :class="
-                    isAwakened(creature.id)
-                      ? 'text-pink-600 dark:text-pink-400'
-                      : 'text-warning-strong'
-                  "
+                  :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-warning-strong'"
                   >★</span
                 >
               </div>

--- a/src/components/expeditions/ExpeditionDetail.vue
+++ b/src/components/expeditions/ExpeditionDetail.vue
@@ -341,7 +341,7 @@ function normalizeLoopCountOnBlur(event: FocusEvent) {
                     loading="lazy"
                   />
                   <span
-                    class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-3xs font-semibold text-cyan-300"
+                    class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-3xs font-semibold text-info-strong"
                   >
                     {{ getCreatureSlotRating(slot) }}
                   </span>

--- a/src/components/level-planner/AwakenRushPlanner.vue
+++ b/src/components/level-planner/AwakenRushPlanner.vue
@@ -596,7 +596,7 @@ defineExpose({ awakenQueueCreatures })
                 {{ b.level }}
               </span>
               <button
-                class="focus-ring absolute -right-1.5 -top-1.5 grid size-4 place-items-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition hover:border-rose-400/60 hover:bg-rose-500/10 hover:text-rose-400"
+                class="focus-ring absolute -right-1.5 -top-1.5 grid size-4 place-items-center rounded-full border border-border bg-card text-muted-foreground shadow-sm transition hover:border-danger/60 hover:bg-danger/10 hover:text-danger-strong"
                 :title="t('levelPlanner.awaken.removeBooster', { name: b.name })"
                 @click="toggleAwakenBooster(b.id)"
               >

--- a/src/components/level-planner/LevelPlannerCreaturePicker.vue
+++ b/src/components/level-planner/LevelPlannerCreaturePicker.vue
@@ -133,14 +133,14 @@ function close() {
           <div class="flex items-center gap-1.5">
             <p
               class="truncate text-base font-semibold"
-              :class="isAwakened(selected.id) ? 'text-pink-400' : 'text-foreground'"
+              :class="isAwakened(selected.id) ? 'text-awakened-strong' : 'text-foreground'"
             >
               {{ selected.name }}
             </p>
             <span
               v-if="ownedCreatureIds.has(selected.id)"
               class="text-xs"
-              :class="isAwakened(selected.id) ? 'text-pink-400' : 'text-warning-strong'"
+              :class="isAwakened(selected.id) ? 'text-awakened-strong' : 'text-warning-strong'"
               >★</span
             >
             <span
@@ -152,7 +152,7 @@ function close() {
           </div>
           <p class="text-xs text-muted-foreground/80">
             LVL {{ getLevel(selected.id)
-            }}<span v-if="isAwakened(selected.id)" class="ml-1 text-pink-400">★</span>
+            }}<span v-if="isAwakened(selected.id)" class="ml-1 text-awakened-strong">★</span>
           </p>
         </div>
       </template>
@@ -229,21 +229,21 @@ function close() {
               <div class="flex items-center gap-1">
                 <p
                   class="truncate text-sm font-semibold"
-                  :class="isAwakened(creature.id) ? 'text-pink-400' : 'text-foreground'"
+                  :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-foreground'"
                 >
                   {{ creature.name }}
                 </p>
                 <span
                   v-if="ownedCreatureIds.has(creature.id)"
                   class="text-xs"
-                  :class="isAwakened(creature.id) ? 'text-pink-400' : 'text-warning-strong'"
+                  :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-warning-strong'"
                   >★</span
                 >
               </div>
               <div class="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span v-if="ownedCreatureIds.has(creature.id)">
                   LVL {{ getLevel(creature.id)
-                  }}<span v-if="isAwakened(creature.id)" class="ml-1 text-pink-400">★</span>
+                  }}<span v-if="isAwakened(creature.id)" class="ml-1 text-awakened-strong">★</span>
                 </span>
                 <span v-else class="italic">{{
                   t('levelPlannerComponents.creaturePicker.notSummoned')

--- a/src/components/level-planner/LevelPlannerSummary.vue
+++ b/src/components/level-planner/LevelPlannerSummary.vue
@@ -111,7 +111,7 @@ function segmentColor(status: 'advantage' | 'disadvantage' | 'neutral'): string 
         {{ formatNumber(plan.totalRuns) }}
         {{ t('levelPlannerComponents.summary.runs') }}
       </span>
-      <span class="inline-flex items-center gap-1.5 text-purple-400">
+      <span class="inline-flex items-center gap-1.5 text-reserved-strong">
         <Zap class="size-3.5" />
         {{ Math.round(plan.xpPerMinute) }} {{ t('levelPlannerComponents.summary.xpPerMin') }}
       </span>

--- a/src/components/level-planner/LevelPlannerTimelineStep.vue
+++ b/src/components/level-planner/LevelPlannerTimelineStep.vue
@@ -93,8 +93,8 @@ function formatDelta(value: number): string {
         <div class="sticky top-[calc(var(--header-height)+0.75rem)] z-10 flex justify-center">
           <div
             v-if="step.kind === 'awaken'"
-            class="flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-pink-500 text-xs font-bold sm:size-8"
-            style="background-color: hsl(var(--card)); color: rgb(236 72 153)"
+            class="flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-awakened text-xs font-bold sm:size-8"
+            style="background-color: hsl(var(--card)); color: oklch(var(--awakened))"
           >
             <img :src="awakenedSummonedIcon" alt="" class="size-4" loading="lazy" />
           </div>
@@ -116,7 +116,7 @@ function formatDelta(value: number): string {
     <!-- Awakening step card -->
     <div v-if="step.kind === 'awaken'" class="mb-2 min-w-0 flex-1 pb-1">
       <div
-        class="surface-card w-full overflow-hidden border-pink-500/30 bg-gradient-to-r from-pink-500/10 to-warning/10"
+        class="surface-card w-full overflow-hidden border-awakened/30 bg-gradient-to-r from-awakened/10 to-warning/10"
       >
         <div class="flex items-center gap-3 px-3 py-2.5 sm:px-4 sm:py-3">
           <RightClickHint
@@ -126,7 +126,7 @@ function formatDelta(value: number): string {
             <img
               :src="getCreatureImage(partyMembers[0].creature)"
               :alt="creatureName"
-              class="size-10 shrink-0 rounded-lg border border-pink-500/30 object-cover transition hover:ring-1 hover:ring-pink-500/50 sm:size-12"
+              class="size-10 shrink-0 rounded-lg border border-awakened/30 object-cover transition hover:ring-1 hover:ring-awakened/50 sm:size-12"
               loading="lazy"
             />
           </RightClickHint>
@@ -139,7 +139,7 @@ function formatDelta(value: number): string {
                   class="size-5 shrink-0 object-contain"
                   loading="lazy"
                 />
-                <p class="text-sm font-semibold text-pink-400">
+                <p class="text-sm font-semibold text-awakened-strong">
                   {{
                     step.fromLevel > 70
                       ? t('levelPlannerComponents.timelineStep.prestigeCreature')
@@ -148,7 +148,7 @@ function formatDelta(value: number): string {
                 </p>
               </div>
               <span
-                class="shrink-0 rounded-full bg-pink-500/15 px-2 py-0.5 text-xs font-semibold text-pink-400"
+                class="shrink-0 rounded-full bg-awakened/15 px-2 py-0.5 text-xs font-semibold text-awakened-strong"
               >
                 LVL {{ step.fromLevel }}&rarr;{{ step.toLevel }}
               </span>
@@ -330,7 +330,7 @@ function formatDelta(value: number): string {
                   class="inline-flex items-center gap-1 text-xs font-semibold"
                   :class="
                     scoreRatioMet === undefined
-                      ? 'text-purple-400'
+                      ? 'text-reserved-strong'
                       : scoreRatioMet
                         ? 'text-success-strong'
                         : 'text-warning-strong'

--- a/src/components/level-planner/PartyCreatureTile.vue
+++ b/src/components/level-planner/PartyCreatureTile.vue
@@ -67,7 +67,7 @@ function tileBorderClass(): string {
   if (props.chipState === 'excluded') return 'border-border/40 opacity-40 grayscale'
   if (props.chipState === 'selected') return 'border-primary/60 ring-2 ring-primary/40'
   if (props.chipState === 'force-included') return 'border-primary/60 ring-1 ring-primary/30'
-  if (props.awakened) return 'border-pink-500/40 ring-1 ring-pink-500/20 hover:border-pink-500/60'
+  if (props.awakened) return 'border-awakened/40 ring-1 ring-awakened/20 hover:border-awakened/60'
   return 'border-border bg-card/50 hover:border-primary/50'
 }
 
@@ -76,7 +76,7 @@ function nameClass(): string {
   if (props.chipState === 'excluded') return 'text-white/60 line-through'
   if (props.chipState === 'selected') return 'text-primary'
   if (props.chipState === 'force-included') return 'text-primary'
-  if (props.awakened) return 'text-pink-400'
+  if (props.awakened) return 'text-awakened-strong'
   return 'text-white'
 }
 
@@ -85,7 +85,7 @@ function levelBadgeClass(): string {
   if (props.chipState === 'excluded') return 'text-muted-foreground'
   if (props.chipState === 'selected') return 'text-primary'
   if (props.chipState === 'force-included') return 'text-primary'
-  if (props.awakened) return 'text-pink-400'
+  if (props.awakened) return 'text-awakened-strong'
   return 'text-foreground'
 }
 </script>

--- a/src/components/level-planner/PartyPlannerGantt.vue
+++ b/src/components/level-planner/PartyPlannerGantt.vue
@@ -290,8 +290,8 @@ function closeAwakenPopover() {
             @click.stop="toggleAwakenPopover(marker, $event)"
           >
             <div
-              class="size-7 overflow-hidden rounded-full border-2 border-pink-500 bg-card shadow-md shadow-pink-500/20 transition-transform hover:scale-110"
-              :class="activeAwakenMarker === marker ? 'ring-2 ring-pink-400/60' : ''"
+              class="size-7 overflow-hidden rounded-full border-2 border-awakened bg-card shadow-md shadow-awakened/20 transition-transform hover:scale-110"
+              :class="activeAwakenMarker === marker ? 'ring-2 ring-awakened/60' : ''"
             >
               <RightClickHint
                 v-if="marker.creature"
@@ -328,7 +328,7 @@ function closeAwakenPopover() {
           <div
             v-for="(marker, mi) in awakenMarkers"
             :key="`awaken-${mi}`"
-            class="pointer-events-none absolute inset-y-0 w-0.5 bg-pink-500/40"
+            class="pointer-events-none absolute inset-y-0 w-0.5 bg-awakened/40"
             :style="{ left: `${marker.pct}%`, transform: 'translateX(-50%)' }"
           />
           <div
@@ -500,7 +500,7 @@ function closeAwakenPopover() {
       :is-open="markerPop.isOpen"
       :el-ref="markerPop.setPanelEl"
       :style="markerPop.style"
-      class="z-50 w-60 rounded-xl border border-pink-500/30 bg-card shadow-xl shadow-black/30"
+      class="z-50 w-60 rounded-xl border border-awakened/30 bg-card shadow-xl shadow-black/30"
       @click.stop
     >
       <template v-if="activeAwakenMarker">
@@ -511,7 +511,7 @@ function closeAwakenPopover() {
               @contextmenu="ganttToggleCreature(activeAwakenMarker.creature)"
             >
               <div
-                class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-pink-500 bg-card transition hover:ring-1 hover:ring-pink-500/50"
+                class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-awakened bg-card transition hover:ring-1 hover:ring-awakened/50"
               >
                 <img
                   :src="getCreatureImage(activeAwakenMarker.creature)"
@@ -523,7 +523,7 @@ function closeAwakenPopover() {
             </RightClickHint>
             <div
               v-else
-              class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-pink-500 bg-card"
+              class="size-10 shrink-0 overflow-hidden rounded-full border-2 border-awakened bg-card"
             />
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-1.5">
@@ -533,7 +533,7 @@ function closeAwakenPopover() {
                   class="size-4 shrink-0 object-contain"
                   loading="lazy"
                 />
-                <p class="text-sm font-bold text-pink-400">
+                <p class="text-sm font-bold text-awakened-strong">
                   {{ t('levelPlannerComponents.partyGantt.manuallyAwaken') }}
                 </p>
               </div>

--- a/src/components/level-planner/PartyPlannerResults.vue
+++ b/src/components/level-planner/PartyPlannerResults.vue
@@ -521,8 +521,8 @@ const stepsByWave = computed(() => {
           <div class="sticky top-[calc(var(--header-height)+0.75rem)] z-10 flex justify-center">
             <div
               v-if="wave.isAwakening"
-              class="flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-pink-500 text-xs font-bold sm:size-8"
-              style="background-color: hsl(var(--card)); color: rgb(236 72 153)"
+              class="flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-awakened text-xs font-bold sm:size-8"
+              style="background-color: hsl(var(--card)); color: oklch(var(--awakened))"
             >
               <img :src="awakenedSummonedIcon" alt="" class="size-4" loading="lazy" />
             </div>

--- a/src/components/level-planner/PartyPlannerSummary.vue
+++ b/src/components/level-planner/PartyPlannerSummary.vue
@@ -59,7 +59,7 @@ const swapCount = computed(
           })
         }}
       </span>
-      <span class="inline-flex items-center gap-1.5 text-purple-400">
+      <span class="inline-flex items-center gap-1.5 text-reserved-strong">
         <Flag class="size-4" />
         {{
           t('levelPlannerComponents.partySummary.expeditions', {
@@ -68,7 +68,7 @@ const swapCount = computed(
         }}
       </span>
       <span
-        class="inline-flex cursor-help items-center gap-1.5 text-rose-400"
+        class="inline-flex cursor-help items-center gap-1.5 text-danger-strong"
         :title="t('levelPlannerComponents.partySummary.swapsTooltip')"
       >
         <ArrowRightLeft class="size-4" />

--- a/src/components/level-planner/PlannerLoadingProgress.vue
+++ b/src/components/level-planner/PlannerLoadingProgress.vue
@@ -72,18 +72,14 @@ function formatElapsedMs(ms: number): string {
           </div>
           <div
             v-if="bestCompleteTime !== null"
-            class="col-span-2 flex items-center gap-2 rounded-lg bg-green-500/10 px-3 py-2 sm:col-span-1"
+            class="col-span-2 flex items-center gap-2 rounded-lg bg-success/10 px-3 py-2 sm:col-span-1"
           >
-            <CheckCircle2 class="size-4 shrink-0 text-green-500" />
+            <CheckCircle2 class="size-4 shrink-0 text-success-strong" />
             <div class="min-w-0">
-              <p
-                class="text-3xs font-medium uppercase tracking-wider text-green-600 dark:text-green-400"
-              >
+              <p class="text-3xs font-medium uppercase tracking-wider text-success-strong">
                 {{ t('levelPlannerComponents.loadingProgress.bestTime') }}
               </p>
-              <p
-                class="truncate text-sm font-semibold tabular-nums text-green-700 dark:text-green-300"
-              >
+              <p class="truncate text-sm font-semibold tabular-nums text-success-strong">
                 {{ formatDuration(bestCompleteTime) }}
               </p>
             </div>

--- a/src/components/level-planner/PrestigeCardLevelChart.vue
+++ b/src/components/level-planner/PrestigeCardLevelChart.vue
@@ -33,8 +33,8 @@ const PALETTE = [
   'text-reserved-strong',
   'text-success-strong',
   'text-warning-strong',
-  'text-rose-500',
-  'text-cyan-500',
+  'text-danger-strong',
+  'text-tool-strong',
 ]
 
 

--- a/src/components/level-planner/PrestigeLoopResults.vue
+++ b/src/components/level-planner/PrestigeLoopResults.vue
@@ -53,7 +53,7 @@ const ROLE_LABEL: Record<MemberRole, string> = {
 const ROLE_CLASS: Record<MemberRole, string> = {
   climber: 'bg-primary/15 text-primary',
   booster: 'bg-warning/15 text-warning-strong',
-  anchor: 'bg-slate-500/15 text-slate-600 dark:text-slate-300',
+  anchor: 'bg-muted-foreground/15 text-muted-foreground',
 }
 
 

--- a/src/components/level-planner/PrestigeRosterRail.vue
+++ b/src/components/level-planner/PrestigeRosterRail.vue
@@ -47,7 +47,7 @@ const ROLE_LABEL: Record<MemberRole, string> = {
 const ROLE_CLASS: Record<MemberRole, string> = {
   climber: 'bg-primary/15 text-primary',
   booster: 'bg-warning/15 text-warning-strong',
-  anchor: 'bg-slate-500/15 text-slate-600 dark:text-slate-300',
+  anchor: 'bg-muted-foreground/15 text-muted-foreground',
 }
 
 

--- a/src/components/skill-planner/CreatureDiffTile.vue
+++ b/src/components/skill-planner/CreatureDiffTile.vue
@@ -37,7 +37,7 @@ defineEmits<{
 
 
 const VARIANT = {
-  remove: 'border-rose-500/40',
+  remove: 'border-danger/40',
   add: 'border-success/40',
   keep: 'border-border',
   neutral: 'border-border',

--- a/src/components/skill-planner/SanctuaryPartyDiff.vue
+++ b/src/components/skill-planner/SanctuaryPartyDiff.vue
@@ -87,10 +87,8 @@ const tierChanges = computed(() =>
 
     <!-- Remove ▸ Add, side by side and filling the full width on wider screens -->
     <div class="grid gap-2.5 sm:grid-cols-2">
-      <div class="rounded-xl border border-rose-500/25 bg-rose-500/[0.04] p-2.5">
-        <p
-          class="mb-2 text-2xs font-semibold uppercase tracking-wide text-rose-600 dark:text-rose-400"
-        >
+      <div class="rounded-xl border border-danger/25 bg-danger/[0.04] p-2.5">
+        <p class="mb-2 text-2xs font-semibold uppercase tracking-wide text-danger-strong">
           {{ t('skillPlanner.sanctuary.remove') }}
           <span class="text-muted-foreground">({{ diff.swapOut.length }})</span>
         </p>
@@ -182,7 +180,7 @@ const tierChanges = computed(() =>
             <span class="text-2xs tabular-nums text-muted-foreground">{{ d.from }}</span>
             <span
               class="text-3xs"
-              :class="d.to < d.from ? 'text-rose-500 dark:text-rose-400' : 'text-success-strong'"
+              :class="d.to < d.from ? 'text-danger-strong' : 'text-success-strong'"
             >
               {{ d.to < d.from ? '▼' : '▲' }}
             </span>
@@ -216,10 +214,7 @@ const tierChanges = computed(() =>
                   <span class="text-2xs text-muted-foreground">{{ b.label }}</span>
                   <span class="flex items-center gap-1 text-2xs tabular-nums">
                     <span class="text-foreground/80">{{ b.before }}</span>
-                    <span
-                      :class="
-                        b.improved ? 'text-success-strong' : 'text-rose-500 dark:text-rose-400'
-                      "
+                    <span :class="b.improved ? 'text-success-strong' : 'text-danger-strong'"
                       >→</span
                     >
                     <span class="font-semibold text-foreground">{{ b.after }}</span>

--- a/src/composables/useDungeons.ts
+++ b/src/composables/useDungeons.ts
@@ -39,9 +39,9 @@ const GRADE_COLORS: Record<DungeonGradeLetter, { text: string; bg: string; borde
     border: 'border-info/30 dark:border-info/40',
   },
   C: {
-    text: 'text-orange-700 dark:text-orange-400',
-    bg: 'bg-orange-100 dark:bg-orange-500/15',
-    border: 'border-orange-300 dark:border-orange-500/40',
+    text: 'text-machine-strong',
+    bg: 'bg-machine/10 dark:bg-machine/15',
+    border: 'border-machine/30 dark:border-machine/40',
   },
   F: {
     text: 'text-danger-strong',

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -184,9 +184,9 @@ describe('methodKindLabel', () => {
 })
 
 describe('methodKindClasses', () => {
-  test('machine kind includes orange classes', () => {
+  test('machine kind includes the machine token classes', () => {
     const classes = methodKindClasses('machine')
-    expect(classes).toContain('orange')
+    expect(classes).toContain('machine')
   })
 
   test('fabrication kind includes reserved (violet) token classes', () => {
@@ -196,12 +196,12 @@ describe('methodKindClasses', () => {
 })
 
 describe('methodKindColor', () => {
-  test('machine kind returns orange color', () => {
-    expect(methodKindColor('machine')).toBe('rgb(251, 146, 60)')
+  test('machine kind returns the machine token color', () => {
+    expect(methodKindColor('machine')).toBe('oklch(var(--machine))')
   })
 
-  test('fabrication kind returns violet color', () => {
-    expect(methodKindColor('fabrication')).toBe('rgb(167, 139, 250)')
+  test('fabrication kind returns the reserved (violet) token color', () => {
+    expect(methodKindColor('fabrication')).toBe('oklch(var(--reserved))')
   })
 })
 

--- a/src/utils/format/format.ts
+++ b/src/utils/format/format.ts
@@ -110,31 +110,34 @@ export function methodKindClasses(kind: PlannerMethodKind): string {
   if (kind === 'gather')
     return 'border-success/35 bg-success/10 text-success-strong dark:border-success/40 dark:bg-success/20 dark:text-success-strong'
   if (kind === 'garden')
-    return 'border-lime-600/35 bg-lime-100 text-lime-800 dark:border-lime-400/40 dark:bg-lime-400/20 dark:text-lime-100'
+    return 'border-garden/35 bg-garden/10 text-garden-strong dark:border-garden/40 dark:bg-garden/20 dark:text-garden-strong'
   if (kind === 'container')
     return 'border-gold/35 bg-gold/10 text-gold-strong dark:border-gold/40 dark:bg-gold/20 dark:text-gold-strong'
   if (kind === 'expedition')
     return 'border-info/35 bg-info/10 text-info-strong dark:border-info/40 dark:bg-info/20 dark:text-info-strong'
   if (kind === 'buy')
-    return 'border-fuchsia-600/35 bg-fuchsia-100 text-fuchsia-800 dark:border-fuchsia-400/40 dark:bg-fuchsia-400/20 dark:text-fuchsia-100'
+    return 'border-buy/35 bg-buy/10 text-buy-strong dark:border-buy/40 dark:bg-buy/20 dark:text-buy-strong'
   if (kind === 'machine')
-    return 'border-orange-600/35 bg-orange-100 text-orange-800 dark:border-orange-400/40 dark:bg-orange-400/20 dark:text-orange-100'
+    return 'border-machine/35 bg-machine/10 text-machine-strong dark:border-machine/40 dark:bg-machine/20 dark:text-machine-strong'
   if (kind === 'fabrication')
     return 'border-reserved/35 bg-reserved/10 text-reserved-strong dark:border-reserved/40 dark:bg-reserved/20 dark:text-reserved-strong'
   return 'border-destructive/40 bg-destructive/10 text-destructive-foreground'
 }
 
+// Returns a CSS color for inline `:style` bindings (e.g. gantt bar borders).
+// Inline styles resolve `var()`, so these track the theme automatically — no
+// canvas/getComputedStyle plumbing needed.
 export function methodKindColor(kind: PlannerMethodKind): string {
   if (kind === 'craft') return 'hsl(var(--primary))'
-  if (kind === 'gather') return 'rgb(52, 211, 153)'
-  if (kind === 'garden') return 'rgb(163, 230, 53)'
-  if (kind === 'container') return 'rgb(250, 204, 21)'
-  if (kind === 'expedition') return 'rgb(56, 189, 248)'
-  if (kind === 'buy') return 'rgb(232, 121, 249)'
+  if (kind === 'gather') return 'oklch(var(--success))'
+  if (kind === 'garden') return 'oklch(var(--garden))'
+  if (kind === 'container') return 'oklch(var(--gold))'
+  if (kind === 'expedition') return 'oklch(var(--info))'
+  if (kind === 'buy') return 'oklch(var(--buy))'
   if (kind === 'cycle') return 'hsl(var(--destructive))'
-  if (kind === 'stocked') return 'rgb(52, 211, 153)'
-  if (kind === 'machine') return 'rgb(251, 146, 60)'
-  if (kind === 'fabrication') return 'rgb(167, 139, 250)'
+  if (kind === 'stocked') return 'oklch(var(--success))'
+  if (kind === 'machine') return 'oklch(var(--machine))'
+  if (kind === 'fabrication') return 'oklch(var(--reserved))'
   return 'hsl(var(--muted-foreground))'
 }
 

--- a/src/utils/planner/modifierChips.ts
+++ b/src/utils/planner/modifierChips.ts
@@ -64,8 +64,8 @@ export function extractModifierChips(
         value: row.value,
         icon: upgradesIcon,
         color:
-          'border-cyan-600/35 bg-cyan-100 text-cyan-800 dark:border-cyan-400/40 dark:bg-cyan-400/20 dark:text-cyan-100',
-        accentColor: 'bg-cyan-500',
+          'border-info/35 bg-info/10 text-info-strong dark:border-info/40 dark:bg-info/20 dark:text-info-strong',
+        accentColor: 'bg-info',
         subtitle: t('modifiers.skillTreeBonuses'),
         stats: parseStats(row.value),
       })
@@ -90,8 +90,8 @@ export function extractModifierChips(
         value: row.value,
         icon: sourceIcons[machineName] ?? machinesIcon,
         color:
-          'border-orange-600/35 bg-orange-100 text-orange-800 dark:border-orange-400/40 dark:bg-orange-400/20 dark:text-orange-100',
-        accentColor: 'bg-orange-500',
+          'border-machine/35 bg-machine/10 text-machine-strong dark:border-machine/40 dark:bg-machine/20 dark:text-machine-strong',
+        accentColor: 'bg-machine',
         subtitle: t('modifiers.passiveMachineProduction'),
         stats: [localizeModifierValue(row.value)],
       })
@@ -124,8 +124,8 @@ export function extractModifierChips(
         value: row.value,
         icon: toolId ? toolIcons[toolId] : upgradesIcon,
         color:
-          'border-teal-600/35 bg-teal-100 text-teal-800 dark:border-teal-400/40 dark:bg-teal-400/20 dark:text-teal-100',
-        accentColor: 'bg-teal-500',
+          'border-tool/35 bg-tool/10 text-tool-strong dark:border-tool/40 dark:bg-tool/20 dark:text-tool-strong',
+        accentColor: 'bg-tool',
         subtitle: t('modifiers.toolSpeedModeBonus'),
         stats: [localizeModifierValue(row.value)],
       })

--- a/src/views/AwakenView.vue
+++ b/src/views/AwakenView.vue
@@ -1032,7 +1032,7 @@ function onNodeMouseLeave() {
       <div class="font-semibold text-foreground">{{ hovered.name }}</div>
       <div class="mt-0.5 text-muted-foreground">{{ describeEffect(hovered.effectData) }}</div>
       <div class="mt-1 font-mono text-3xs">
-        <span v-if="effectiveIds.has(hovered.id)" class="text-green-500">{{
+        <span v-if="effectiveIds.has(hovered.id)" class="text-success-strong">{{
           t('awakenView.unlocked')
         }}</span>
         <span v-else class="inline-flex items-center gap-1">

--- a/src/views/BeastiaryView.vue
+++ b/src/views/BeastiaryView.vue
@@ -339,7 +339,7 @@ const { t } = useI18n()
 
           <!-- Awakening -->
           <button
-            class="focus-ring inline-flex items-center justify-center gap-1.5 rounded-xl border border-border bg-card px-3 py-2 text-sm font-semibold text-muted-foreground transition hover:border-pink-500/50 hover:text-pink-400 disabled:cursor-not-allowed disabled:opacity-40"
+            class="focus-ring inline-flex items-center justify-center gap-1.5 rounded-xl border border-border bg-card px-3 py-2 text-sm font-semibold text-muted-foreground transition hover:border-awakened/50 hover:text-awakened-strong disabled:cursor-not-allowed disabled:opacity-40"
             :disabled="!selectedIds.size"
             @click="bulkSetAwakened(true)"
           >

--- a/src/views/DungeonsView.vue
+++ b/src/views/DungeonsView.vue
@@ -774,7 +774,7 @@ const requirementLabel = computed(() =>
                         loading="lazy"
                       />
                       <span
-                        class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-3xs font-semibold text-cyan-300"
+                        class="absolute left-0.5 top-0.5 rounded-full bg-black/60 px-1.5 py-0.5 font-mono text-3xs font-semibold text-info-strong"
                       >
                         {{ getCreatureSlotScore(slot) }}
                       </span>
@@ -1078,11 +1078,7 @@ const requirementLabel = computed(() =>
                   <div class="flex items-center gap-1">
                     <p
                       class="truncate font-semibold"
-                      :class="
-                        isAwakened(creature.id)
-                          ? 'text-pink-600 dark:text-pink-400'
-                          : 'text-foreground'
-                      "
+                      :class="isAwakened(creature.id) ? 'text-awakened-strong' : 'text-foreground'"
                     >
                       {{ creature.name }}
                     </p>
@@ -1090,9 +1086,7 @@ const requirementLabel = computed(() =>
                       v-if="isOwned(creature.id)"
                       class="text-xs"
                       :class="
-                        isAwakened(creature.id)
-                          ? 'text-pink-600 dark:text-pink-400'
-                          : 'text-warning-strong'
+                        isAwakened(creature.id) ? 'text-awakened-strong' : 'text-warning-strong'
                       "
                       >★</span
                     >

--- a/src/views/GardenView.vue
+++ b/src/views/GardenView.vue
@@ -411,9 +411,7 @@ watch(
             "
             :disabled="fertilizerToMaxAll === 0"
           >
-            <span
-              class="inline-flex items-center gap-1 font-semibold text-fuchsia-700 dark:text-fuchsia-300"
-            >
+            <span class="inline-flex items-center gap-1 font-semibold text-buy-strong">
               <img
                 :src="getItemImage({ id: FERTILIZER_ITEM_ID })"
                 alt="Fertilizer"

--- a/src/views/SanctuaryView.vue
+++ b/src/views/SanctuaryView.vue
@@ -969,9 +969,7 @@ function chooseCreature(creature: Creature) {
                     <span
                       class="truncate text-sm font-semibold"
                       :class="
-                        isAwakened(creature.id)
-                          ? 'text-pink-600 dark:text-pink-400'
-                          : 'text-foreground/80'
+                        isAwakened(creature.id) ? 'text-awakened-strong' : 'text-foreground/80'
                       "
                       >{{ creature.name }}</span
                     >
@@ -979,9 +977,7 @@ function chooseCreature(creature: Creature) {
                       v-if="isOwned(creature.id)"
                       class="shrink-0 text-xs"
                       :class="
-                        isAwakened(creature.id)
-                          ? 'text-pink-500 dark:text-pink-400'
-                          : 'text-warning-strong'
+                        isAwakened(creature.id) ? 'text-awakened-strong' : 'text-warning-strong'
                       "
                       >★</span
                     >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,6 +45,17 @@ export default {
         'info-strong': 'oklch(var(--info-strong) / <alpha-value>)',
         'reserved-strong': 'oklch(var(--reserved-strong) / <alpha-value>)',
         'gold-strong': 'oklch(var(--gold-strong) / <alpha-value>)',
+        // Method-kind + state colors — distinct from the status palette.
+        awakened: 'oklch(var(--awakened) / <alpha-value>)',
+        garden: 'oklch(var(--garden) / <alpha-value>)',
+        buy: 'oklch(var(--buy) / <alpha-value>)',
+        machine: 'oklch(var(--machine) / <alpha-value>)',
+        tool: 'oklch(var(--tool) / <alpha-value>)',
+        'awakened-strong': 'oklch(var(--awakened-strong) / <alpha-value>)',
+        'garden-strong': 'oklch(var(--garden-strong) / <alpha-value>)',
+        'buy-strong': 'oklch(var(--buy-strong) / <alpha-value>)',
+        'machine-strong': 'oklch(var(--machine-strong) / <alpha-value>)',
+        'tool-strong': 'oklch(var(--tool-strong) / <alpha-value>)',
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Description

This finishes issue #61 by migrating the remaining raw Tailwind color classes onto the semantic palette and adding automated guards so they can't creep back. PR #136 added the contrast-testing foundation and the core tokens; this PR closes the gap — defining the last method-kind/state tokens, routing every component through them, and locking the migration in with an enforcement test.

## Summary
- Add OKLCH tokens for the `awakened`, `garden`, `buy`, `machine`, and `tool` accents (each with a `-strong` text ramp) in `global.css` (`:root` + `.dark`) and map them in `tailwind.config.ts`. Every token is contrast-tuned so chips and `-strong` text clear WCAG AA.
- Route all remaining raw Tailwind color utilities through the semantic palette across the beastiary, expedition, dungeon, level/skill/craft planner, and config surfaces: text uses the theme-aware `-strong` ramp (collapsing redundant `dark:` pairs), while fills/borders/rings keep their `/alpha` on the base token.
- Tokenize `format.ts` (`methodKindColor`/`methodKindClasses`), `modifierChips.ts`, and `useDungeons` grade colors so they emit tokens instead of `rgb()` literals.
- Fix two issues this sweep surfaced: the Prestige card-level chart palette had two slots collapse to the same color, and two awaken markers kept an inline `rgb()` pink that bypassed the `awakened` token in dark mode.
- Extend the palette-contrast suite to assert WCAG AA for the new tokens, and add a `no-raw-tailwind-colors` guard that fails if any raw Tailwind color utility reappears in source. The guard documents its scope: it matches utility-class forms only, not inline `style` color literals (used in decorative gradients, SVG, and canvas).

Closes #61