### PR TITLE
Bump version to 5.4 and hide creature descriptions

### DIFF
--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -186,13 +186,6 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
         </div>
 
         <div class="space-y-5 px-5 pb-5">
-          <!-- Description -->
-          <div class="detail-section">
-            <p class="text-sm leading-relaxed text-muted-foreground">
-              {{ creature.description }}
-            </p>
-          </div>
-
           <!-- Collection & Actions -->
           <div class="detail-section space-y-4 rounded-lg border border-border/60 bg-muted/10 p-4">
             <h3 class="section-title">{{ t('beastiary.detail.collection') }}</h3>

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,4 +1,4 @@
 {
-  "gameVersion": "5.3",
-  "latestGameVersion": "5.3"
+  "gameVersion": "5.4",
+  "latestGameVersion": "5.4"
 }


### PR DESCRIPTION
## Description

Bumps the game and wiki version to 5.4 and removes the flavor-text description from the creature detail panel. The two changes are unrelated but small, so they ship together.

## Summary
- Bump `gameVersion` and `latestGameVersion` in `src/data/meta.json` from 5.3 to 5.4; the sidebar version badge reads both fields and updates automatically
- Remove the description block from `CreatureDetail.vue` so summoned creatures no longer render flavor text; the `description` field stays in the data and is still used elsewhere (e.g. item search)

