### PR TITLE
Modernize README with current features and live site URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,71 @@
 # K2 Wiki
 
-A fan-made wiki for [Koltera 2](https://store.steampowered.com/app/2834700/Koltera_2/).
+A fan-made companion app for [Koltera 2](https://store.steampowered.com/app/2834700/Koltera_2/) — browse the game's creatures, items, and dungeons, and plan your progression with a set of interactive planners.
 
-**[Live Site](https://ardelato.github.io/k2-wiki/)**
+**[Live Site](https://k2-wiki.pages.dev/)** · Game data current to Koltera 2 **v5.4**
+
+> Mirror: [ardelato.github.io/k2-wiki/app](https://ardelato.github.io/k2-wiki/app/) — for anyone whose ISP blocks Cloudflare Pages.
 
 ## Features
 
-- **Beastiary** — Browse all 120 creatures with stats, proficiencies, and radar charts
-- **Expedition Planner** — Build parties and plan expeditions with a creature selector
+**Reference**
+
+- **Beastiary** — All 120 creatures with stats, proficiencies, biomes, and radar charts
+- **Items** — 192 items with recipes, sources, and where to find them
+- **Expeditions** — 20 expeditions with requirements and drops
+- **Machines**, **Tools**, **Fabrication**, **Sanctuary**, **Garden** — the game's crafting and production systems
+
+**Planners**
+
+- **Creature Planner** — Summon, Awaken, and Prestige Loop tabs for planning a creature's growth
+- **Crafting & Skills Planner** — Work out craft chains and skill progression
+- **Expedition Planner** — Auto-build parties from your collection, scored against each expedition (runs off the main thread in a web worker)
+- **Dungeon Planner** — Rate a party for combat and gathering runs across 5 tiers, with S–F grade thresholds and reward multipliers
 
 ## Tech Stack
 
-Vue 3 · TypeScript · Vite · Tailwind CSS · Vue Router
+Vue 3 · TypeScript · Vite · Tailwind CSS · Vue Router · vue-i18n
+
+- **i18n** — UI localized in 6 languages (English, German, Spanish, French, Turkish, Traditional Chinese). Game terms stay in English by design so the wiki cross-references the in-game text — see [`src/locales/README.md`](./src/locales/README.md).
+- **Web workers** — Party planning and prestige-loop simulation run off the main thread.
+- **Generated data** — Everything in `src/data/*.json` is generated from the game source via `npm run generate-tables`.
+- **Semantic color palette** — Tokenized theme with automated WCAG contrast tests.
 
 ## Development
+
+Requires **Node 24+**.
 
 ```bash
 npm install
 npm run dev
 ```
 
-To build for production:
+Build for production:
 
 ```bash
 npm run build
 npm run preview
 ```
+
+## Scripts
+
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Start the Vite dev server |
+| `npm run build` | Type-check and build for production |
+| `npm run lint` | Lint with oxlint |
+| `npm run format` | Format with oxfmt |
+| `npm test` | Run unit tests (Vitest) |
+| `npm run test:e2e` | Run end-to-end tests (Playwright) |
+| `npm run knip` | Find unused files, exports, and dependencies |
+| `npm run generate-tables` | Regenerate game data in `src/data/` |
+| `npm run i18n:check` | Check locale files for missing/stale keys |
+
+Git hooks are managed by [lefthook](https://github.com/evilmartians/lefthook) and installed automatically on `npm install`.
+
+## Continuous Integration
+
+Every pull request runs knip, lint, format, unit tests, a production build, and a sharded Playwright e2e suite via GitHub Actions. Merges to `main` deploy the site to GitHub Pages.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Description

The README still described K2 Wiki as a two-feature app (Beastiary + expedition planner) from when the repo was first created. Since then the app has grown to 14 views, 6 UI languages, worker-backed planners, generated game data, and a full CI/deploy pipeline — none of it documented. This rewrites the README to reflect what the project actually is today and corrects the live site URLs.

## Summary

- Rewrote the feature list into **Reference** (Beastiary, Items, Expeditions, Machines, Tools, Fabrication, Sanctuary, Garden) and **Planners** (Creature, Crafting/Skills, Expedition, Dungeon), with counts read from the current data (120 creatures, 192 items, 20 expeditions) and game version v5.4.
- Reframed **Dungeons** as the tiered dungeon-rating planner it actually is (combat and gathering runs across 5 tiers with S–F grade thresholds and reward multipliers), rather than a list of named dungeons.
- Made **k2-wiki.pages.dev** (Cloudflare Pages) the primary live site and listed `ardelato.github.io/k2-wiki/app/` as a mirror for users whose ISPs block Cloudflare Pages.
- Documented the real toolchain: Node 24+ requirement, a scripts table (oxlint, oxfmt, knip, Vitest, Playwright, `generate-tables`, i18n checks), and lefthook-managed git hooks.
- Added tech-stack callouts for i18n (with the "keep game terms in English" rule linking `src/locales/README.md`), web workers, generated data, and the semantic color palette with WCAG contrast tests.
- Added a Continuous Integration section describing the PR gates and the GitHub Pages deploy on merge to `main`.