### PR TITLE
Fix awaken scheduling, config reset, and prestige roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ npm run preview
 
 ## Scripts
 
-| Command | What it does |
-| --- | --- |
-| `npm run dev` | Start the Vite dev server |
-| `npm run build` | Type-check and build for production |
-| `npm run lint` | Lint with oxlint |
-| `npm run format` | Format with oxfmt |
-| `npm test` | Run unit tests (Vitest) |
-| `npm run test:e2e` | Run end-to-end tests (Playwright) |
-| `npm run knip` | Find unused files, exports, and dependencies |
-| `npm run generate-tables` | Regenerate game data in `src/data/` |
-| `npm run i18n:check` | Check locale files for missing/stale keys |
+| Command                   | What it does                                 |
+| ------------------------- | -------------------------------------------- |
+| `npm run dev`             | Start the Vite dev server                    |
+| `npm run build`           | Type-check and build for production          |
+| `npm run lint`            | Lint with oxlint                             |
+| `npm run format`          | Format with oxfmt                            |
+| `npm test`                | Run unit tests (Vitest)                      |
+| `npm run test:e2e`        | Run end-to-end tests (Playwright)            |
+| `npm run knip`            | Find unused files, exports, and dependencies |
+| `npm run generate-tables` | Regenerate game data in `src/data/`          |
+| `npm run i18n:check`      | Check locale files for missing/stale keys    |
 
 Git hooks are managed by [lefthook](https://github.com/evilmartians/lefthook) and installed automatically on `npm install`.
 

--- a/src/components/level-planner/PrestigeLoopPlanner.vue
+++ b/src/components/level-planner/PrestigeLoopPlanner.vue
@@ -22,7 +22,6 @@ const props = defineProps<{
   creatureMap: Map<string, Creature>
   overrideableCreatures: Creature[]
   excludedCreatureIds: Set<string>
-  sanctuaryCreatureIds: string[]
   getLevel: (id: string) => number
   isAwakened: (id: string) => boolean
   // Shared session override set (parent-owned, shared with custom-party)
@@ -63,26 +62,13 @@ const prestigeBoosterCount = ref(3)
 const cadencePresets = COMPARISON_CADENCE_HOURS
 
 
-// The prestige loop reassigns creatures across expeditions, so a Sanctuary-seated creature
-// is still a valid candidate — drop Sanctuary members from the auto-excluded basis (other
-// deployments stay excluded, surfaced via the picker's busy toggle).
-const prestigeExcludedBasis = computed(() => {
-  const set = new Set(props.excludedCreatureIds)
-  for (const id of props.sanctuaryCreatureIds) set.delete(id)
-  return set
-})
-// Same include/exclude semantics as the shared handlers, but keyed off the prestige basis
-// so toggling a Sanctuary creature excludes it (rather than force-including an already-in one).
-const togglePrestigeCreature = (id: string) =>
-  props.toggleCreatureOverride(id, prestigeExcludedBasis.value)
-const togglePrestigeTier = (ids: string[], include: boolean) =>
-  props.toggleTierOverride(ids, include, prestigeExcludedBasis.value)
-
-
 const effectiveExpeditionTierSelections = computed(() => props.effectiveExpeditionTierSelections)
-const prestigeExcludedBasisRef = computed(() => prestigeExcludedBasis.value)
 
 
+// Sanctuary-seated creatures are treated like every other deployment: busy, and so
+// excluded from the auto-roster (running the loop would pull them out of their seat and
+// forfeit the job-tier bonus). They stay toggleable in via the picker's busy filter, using
+// the shared override handlers with their default basis — no prestige-specific carve-out.
 const {
   plan: prestigePlan,
   lastInput: prestigeLastInput,
@@ -97,7 +83,6 @@ const {
   prestigeBoosterCount,
   props.creatureOverrides,
   effectiveExpeditionTierSelections,
-  prestigeExcludedBasisRef,
 )
 
 
@@ -196,8 +181,8 @@ defineExpose({ prestigeCalculate, prestigeRecalculate })
     :selected-ids="prestigeSelectedIds"
     :get-level="getLevel"
     :is-awakened="isAwakened"
-    @toggle="togglePrestigeCreature"
-    @toggle-tier="togglePrestigeTier"
+    @toggle="toggleCreatureOverride"
+    @toggle-tier="toggleTierOverride"
     @reset="resetCreatureOverrides"
     @close="prestigeRosterPickerOpen = false"
   />

--- a/src/composables/__tests__/useAwakenHandsFree.test.ts
+++ b/src/composables/__tests__/useAwakenHandsFree.test.ts
@@ -1,0 +1,113 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
+
+import creaturesData from '@/data/creatures.json'
+import type { Creature } from '@/types'
+import type { LevelingPlan } from '@/utils/planner/levelPlanner'
+
+// Real roster from the reported save: Echo L66, Zibby L64, Wiggle L62 — all
+// unawakened and heading to 70. Left alone, each solo plan picks the same single
+// best expedition, so they used to stack overlapping runs on one lane.
+const ROSTER = creaturesData.filter((c) => ['echo', 'zibby', 'wiggle'].includes(c.id)) as Creature[]
+const LEVELS: Record<string, number> = { echo: 66, zibby: 64, wiggle: 62 }
+
+vi.mock('@/composables/useCreatures', () => ({
+  useCreatures: () => ({ creatures: ref(ROSTER) }),
+}))
+
+vi.mock('@/composables/useCreatureCollection', () => ({
+  useCreatureCollection: () => ({
+    ownedCreatureIds: ref(new Set(ROSTER.map((c) => c.id))),
+    getLevel: (id: string) => LEVELS[id] ?? 1,
+    isAwakened: () => false,
+  }),
+}))
+
+vi.mock('@/composables/useGameConfig', () => ({
+  useGameConfig: () => ({ expeditionToolXpBonus: ref(1) }),
+}))
+
+import { dominantExpeditionId, useAwakenHandsFree } from '@/composables/useAwakenHandsFree'
+
+type Api = ReturnType<typeof useAwakenHandsFree>
+
+function harness(queue: string[]) {
+  const queueIds = ref(queue)
+  const targetLevel = ref(70)
+  let api: Api | null = null
+  const Host = defineComponent({
+    setup() {
+      api = useAwakenHandsFree(queueIds, targetLevel)
+      return () => null
+    },
+  })
+  mount(Host)
+  return api!
+}
+
+const dominant = dominantExpeditionId
+
+describe('useAwakenHandsFree spread pass', () => {
+  beforeEach(() => {
+    if (typeof localStorage !== 'undefined') localStorage.clear()
+  })
+
+  it('gives each queued creature a distinct primary expedition', () => {
+    const api = harness(['echo', 'zibby', 'wiggle'])
+    api.calculate()
+
+    const plans = api.plansById.value
+    expect(plans.size).toBe(3)
+
+    const lanes = [...plans.values()].map(dominant)
+    expect(lanes.every((l) => l != null)).toBe(true)
+    // The core fix: no two creatures share their dominant expedition lane.
+    expect(new Set(lanes).size).toBe(3)
+  })
+
+  it('keeps the bottleneck (lowest-level) creature on the single best expedition', () => {
+    // Wiggle (L62) is furthest from 70, so it should keep the globally-best expedition.
+    const api = harness(['echo', 'zibby', 'wiggle'])
+    api.calculate()
+
+    const wigglePlan = api.plansById.value.get('wiggle')!
+    // Solo-best expedition for this roster/level band is expedition-type-3 (from analysis).
+    expect(dominant(wigglePlan)).toBe('expedition-type-3')
+  })
+
+  it('leaves a single-creature queue on its unrestricted best expedition', () => {
+    const api = harness(['wiggle'])
+    api.calculate()
+    expect(dominant(api.plansById.value.get('wiggle')!)).toBe('expedition-type-3')
+  })
+
+  it('preserves the last-finish (makespan) at the parallel-solo optimum', () => {
+    // Spreading is free here: the bottleneck keeps the best expedition and faster
+    // creatures finish inside its window, so makespan matches the ideal 20100s.
+    const api = harness(['echo', 'zibby', 'wiggle'])
+    api.calculate()
+    expect(api.lastFinishSeconds.value).toBe(20100)
+  })
+})
+
+describe('dominantExpeditionId', () => {
+  const runStep = (expId: string, timeSeconds: number) =>
+    ({
+      kind: 'run',
+      expedition: { id: expId },
+      timeSeconds,
+    }) as unknown as LevelingPlan['steps'][number]
+  const planOf = (...steps: LevelingPlan['steps']): LevelingPlan =>
+    ({ steps, totalTimeSeconds: 0, totalRuns: 0, xpPerMinute: 0 }) as LevelingPlan
+
+  it('picks the expedition with the greatest TOTAL time, not the single longest step', () => {
+    // exp-A: two short revisits (300 + 300 = 600) beat exp-B's one long step (500).
+    const plan = planOf(runStep('exp-A', 300), runStep('exp-B', 500), runStep('exp-A', 300))
+    expect(dominantExpeditionId(plan)).toBe('exp-A')
+  })
+
+  it('returns null for a plan with no run steps', () => {
+    expect(dominantExpeditionId(planOf())).toBeNull()
+  })
+})

--- a/src/composables/__tests__/useGameConfig.test.ts
+++ b/src/composables/__tests__/useGameConfig.test.ts
@@ -385,11 +385,17 @@ describe('useGameConfig', () => {
     expect(localStorage.getItem('dungeon-sub-focus')).toBe('Mining')
   })
 
-  test('resetDungeonStorage clears dungeon-creature-levels', () => {
+  test('resetDungeonStorage clears every imported-dungeon key', () => {
     localStorage.setItem('dungeon-creature-levels', JSON.stringify({ pudge: 10 }))
+    localStorage.setItem('dungeon-tier', '5')
+    localStorage.setItem('dungeon-focus', 'gathering')
+    localStorage.setItem('dungeon-sub-focus', 'Fishing')
     const { resetDungeonStorage } = useGameConfig()
     resetDungeonStorage()
     expect(localStorage.getItem('dungeon-creature-levels')).toBeNull()
+    expect(localStorage.getItem('dungeon-tier')).toBeNull()
+    expect(localStorage.getItem('dungeon-focus')).toBeNull()
+    expect(localStorage.getItem('dungeon-sub-focus')).toBeNull()
   })
 
   test('applyDungeonStateFromSave notifies same-tab useLocalStorage consumers', async () => {

--- a/src/composables/useAwakenHandsFree.ts
+++ b/src/composables/useAwakenHandsFree.ts
@@ -5,6 +5,7 @@ import { useCreatureCollection } from '@/composables/useCreatureCollection'
 import { useCreatures } from '@/composables/useCreatures'
 import { useGameConfig } from '@/composables/useGameConfig'
 import type {
+  Creature,
   CreatureLevelingSummary,
   PartyLevelingPlan,
   PartyPlanMember,
@@ -24,6 +25,49 @@ import {
  * per creature — no cross-creature coordination — which suits the walk-away flow.
  */
 const HANDS_FREE_SWAP_THRESHOLD = 0.4
+
+/** The expedition a plan spends the most time on — its lane on the timeline. Sums time
+ * per expedition (a plan can revisit one across non-consecutive or multi-tier steps), so
+ * the true bottleneck lane wins over a single long runner-up step. */
+export function dominantExpeditionId(plan: LevelingPlan): string | null {
+  const timeByExpedition = new Map<string, number>()
+  for (const step of plan.steps) {
+    if (step.kind !== 'run') continue
+    timeByExpedition.set(
+      step.expedition.id,
+      (timeByExpedition.get(step.expedition.id) ?? 0) + step.timeSeconds,
+    )
+  }
+  let bestId: string | null = null
+  let bestTime = -1
+  for (const [id, time] of timeByExpedition) {
+    if (time > bestTime) {
+      bestTime = time
+      bestId = id
+    }
+  }
+  return bestId
+}
+
+/**
+ * Layer expedition exclusions on top of the user's tier selections: each reserved
+ * expedition is pinned to an empty tier list so `planLevelingPath` skips it. Missing
+ * keys still default to all tiers, so only the reserved expeditions drop out.
+ */
+function reserveExpeditions(
+  base: Record<string, number[]> | undefined,
+  taken: Set<string>,
+): Record<string, number[]> | undefined {
+  if (taken.size === 0) return base
+  const out: Record<string, number[]> = { ...base }
+  for (const expId of taken) out[expId] = []
+  return out
+}
+
+/** True when a plan has at least one runnable step (vs. an empty, all-excluded plan). */
+function hasRunStep(plan: LevelingPlan): boolean {
+  return plan.steps.some((s) => s.kind === 'run')
+}
 
 export function useAwakenHandsFree(
   queueIds: Ref<string[]>,
@@ -88,32 +132,80 @@ export function useAwakenHandsFree(
   const plansById = computed<Map<string, LevelingPlan>>(() => {
     const map = new Map<string, LevelingPlan>()
     if (!hasCalculated.value) return map
+
+    // Resolve the queue to creatures still below target (others are already done).
+    const queued = queueIds.value
+      .map((id) => {
+        const creature = creatures.value.find((c) => c.id === id)
+        if (!creature) return null
+        const startLevel = startLevelFor(id)
+        if (startLevel >= targetLevel.value) return null
+        return { id, creature, startLevel }
+      })
+      .filter((x): x is { id: string; creature: Creature; startLevel: number } => x != null)
+
+    // Spread across distinct expeditions. The game runs ONE party per expedition at a
+    // time, so three creatures each planned solo would otherwise stack invalid, overlapping
+    // runs on the single best expedition. Instead each creature reserves the expedition it
+    // spends the most time on, and later creatures re-plan with the taken ones excluded — so
+    // every creature graduates on its own expedition, running truly in parallel.
+    //
+    // Order matters: the lowest-level creature (furthest from target, the makespan
+    // bottleneck) picks first and keeps the single best expedition; faster creatures have
+    // slack and absorb a runner-up expedition at little or no cost to the overall finish.
+    const order = queued.toSorted((a, b) => a.startLevel - b.startLevel)
+
     // Creatures run in parallel, so a booster can only help ONE of them. Allocate
     // exclusively: each creature plans against the remaining pool, then the boosters
     // it actually used are reserved so no later creature double-books them.
     let remaining = boosterPool.value
-    for (const id of queueIds.value) {
-      const creature = creatures.value.find((c) => c.id === id)
-      if (!creature) continue
-      const startLevel = startLevelFor(id)
-      if (startLevel >= targetLevel.value) continue
-      const plan = planLevelingPath({
-        creature,
-        startLevel,
-        targetLevel: targetLevel.value,
-        isAwakened: isAwakened(id),
-        swordXpMultiplier: expeditionToolXpBonus.value,
-        expeditionTierSelections: expeditionTierSelections?.value,
-        boosterCandidates: remaining.length > 0 ? remaining : undefined,
-        swapThreshold: HANDS_FREE_SWAP_THRESHOLD,
-      })
+    const takenExpeditions = new Set<string>()
+    const planFor = new Map<string, LevelingPlan>()
+
+    for (const { id, creature, startLevel } of order) {
+      const planWith = (tierSelections: Record<string, number[]> | undefined) =>
+        planLevelingPath({
+          creature,
+          startLevel,
+          targetLevel: targetLevel.value,
+          isAwakened: isAwakened(id),
+          swordXpMultiplier: expeditionToolXpBonus.value,
+          expeditionTierSelections: tierSelections,
+          boosterCandidates: remaining.length > 0 ? remaining : undefined,
+          swapThreshold: HANDS_FREE_SWAP_THRESHOLD,
+        })
+
+      let plan = planWith(reserveExpeditions(expeditionTierSelections?.value, takenExpeditions))
+      // If reserving the taken expeditions left nothing runnable, fall back to the
+      // unrestricted plan — a stacked-but-complete plan beats an empty one.
+      let sharedFallback = false
+      if (!hasRunStep(plan)) {
+        plan = planWith(expeditionTierSelections?.value)
+        sharedFallback = true
+      }
+
+      // Reserve this creature's lane only when it planned around the taken ones. A fallback
+      // plan is already sharing a lane, so reserving its expedition would needlessly push a
+      // later, genuinely-distinct creature off a lane it could still use.
+      if (!sharedFallback) {
+        const primary = dominantExpeditionId(plan)
+        if (primary) takenExpeditions.add(primary)
+      }
+
       const used = new Set<string>()
       for (const step of plan.steps) {
         if (step.kind !== 'run') continue
         for (const b of step.boosters ?? []) used.add(b.creature.id)
       }
       if (used.size > 0) remaining = remaining.filter((b) => !used.has(b.creature.id))
-      map.set(id, plan)
+      planFor.set(id, plan)
+    }
+
+    // Emit in queue order so downstream consumers (rail, summaries) stay stable regardless
+    // of the internal bottleneck-first planning order.
+    for (const id of queueIds.value) {
+      const plan = planFor.get(id)
+      if (plan) map.set(id, plan)
     }
     return map
   })

--- a/src/composables/useGameConfig.ts
+++ b/src/composables/useGameConfig.ts
@@ -10,6 +10,7 @@ import {
 import type { GardenCell, GardenFlowerEntry, AwakenGatherUpgrade } from '@/types'
 import { getPlayerLevel } from '@/utils/formulas'
 import { calculateJobTiersFromSanctuary, type SaveConfig } from '@/utils/save/parseSave'
+import { writeStorageKey } from '@/utils/save/writeStorageKey'
 
 const sanctuaryCreatureIds = useLocalStorage<string[]>('config-sanctuary-creatures', [])
 const helperCreatureIds = useLocalStorage<string[]>('config-helper-creatures', [])
@@ -121,17 +122,10 @@ const queuedTimes = useLocalStorage<Record<string, number>>('config-queued-times
 const awakenGoldLevel = useLocalStorage<number>('config-awaken-gold-level', 0)
 const skillLevels = useLocalStorage<Record<string, number>>('config-skill-levels', {})
 
-// Dungeon state lives across multiple localStorage keys read by useDungeons.
-// Writes go through this helper so the `storage` event fires in the same
-// tab — useLocalStorage refs in useDungeons listen for it and stay in sync.
-function writeDungeonKey(key: string, value: string | null) {
-  const oldValue = localStorage.getItem(key)
-  if (value === null) localStorage.removeItem(key)
-  else localStorage.setItem(key, value)
-  window.dispatchEvent(
-    new StorageEvent('storage', { key, oldValue, newValue: value, storageArea: localStorage }),
-  )
-}
+// Dungeon state lives across multiple localStorage keys read by useDungeons. Writes go
+// through writeStorageKey so the `storage` event fires in the same tab — useLocalStorage
+// refs in useDungeons listen for it and stay in sync.
+const writeDungeonKey = writeStorageKey
 
 export function useGameConfig() {
   const playerLevel = computed(() => getPlayerLevel(skillLevels.value))
@@ -452,7 +446,13 @@ export function useGameConfig() {
   }
 
   function resetDungeonStorage() {
+    // Null every imported-dungeon key so useDungeons reverts to its defaults (tier 1,
+    // Combat focus, Mining sub-focus). Previously only creature-levels was cleared, so a
+    // reset left the old dungeon's focus/tier behind.
     writeDungeonKey('dungeon-creature-levels', null)
+    writeDungeonKey('dungeon-tier', null)
+    writeDungeonKey('dungeon-focus', null)
+    writeDungeonKey('dungeon-sub-focus', null)
   }
 
   // Apply the config-owned portion of an imported save. Preserves the exact

--- a/src/composables/usePrestigeLoopPlanner.ts
+++ b/src/composables/usePrestigeLoopPlanner.ts
@@ -35,20 +35,15 @@ export function usePrestigeLoopPlanner(
     plannerIncluded: { value: Set<string> }
   },
   expeditionTierSelections?: { value: Record<string, number[]> },
-  /**
-   * Overrides the auto-excluded roster basis. Prestige passes a set that omits
-   * Sanctuary-seated creatures (the loop reassigns them, so they stay eligible),
-   * unlike the default `excludedCreatureIds` which excludes every deployed creature.
-   */
-  globalExcludedIds?: { value: Set<string> },
 ) {
   const { creatures } = useCreatures()
   const { ownedCreatureIds, getLevel, isAwakened } = useCreatureCollection()
   const { excludedCreatureIds } = useGameConfig()
 
-  /** Owned, awakened (prestige-capable), override-aware roster. */
+  /** Owned, awakened (prestige-capable), override-aware roster. Every deployed creature —
+   * Sanctuary included — is excluded by default; the picker can opt any of them back in. */
   const eligibleEntries = computed<PrestigeLoopRosterEntry[]>(() => {
-    const globalExcluded = globalExcludedIds?.value ?? excludedCreatureIds.value
+    const globalExcluded = excludedCreatureIds.value
     const plannerExcluded = creatureOverrides?.plannerExcluded.value ?? new Set<string>()
     const plannerIncluded = creatureOverrides?.plannerIncluded.value ?? new Set<string>()
 

--- a/src/utils/__tests__/resetPlannerState.test.ts
+++ b/src/utils/__tests__/resetPlannerState.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetPlannerState } from '@/utils/save/resetPlannerState'
+
+// Every save-scoped planner key "Reset all" must clear (see resetPlannerState). These
+// live outside useGameConfig, so they used to survive a reset and point at a gone save.
+const PLANNER_KEYS = [
+  'awaken-planner-queue',
+  'awaken-planner-boosters-excluded',
+  'awaken-planner-boosters-included',
+  'awaken-hands-free-fingerprint',
+  'awaken-sim-added',
+  'awaken-sim-removed',
+  'sanctuary-target-tiers',
+  'fabrication-simulated',
+  'planner-expedition-tier-selections',
+  'planner-include-all-expeditions',
+]
+
+// This sandbox's Node has no localStorage; install a minimal shim so the util has
+// something to clear. (In the browser/happy-dom this is a no-op.)
+beforeEach(() => {
+  if (typeof globalThis.localStorage === 'undefined') {
+    const store = new Map<string, string>()
+    // @ts-expect-error minimal Storage shim for the test environment
+    globalThis.localStorage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size
+      },
+    }
+  }
+  localStorage.clear()
+})
+
+describe('resetPlannerState', () => {
+  it('removes every save-scoped planner key', () => {
+    for (const key of PLANNER_KEYS) localStorage.setItem(key, '["stale"]')
+    // An unrelated key must be left untouched.
+    localStorage.setItem('sidebar-collapsed', 'true')
+
+    resetPlannerState()
+
+    for (const key of PLANNER_KEYS) expect(localStorage.getItem(key)).toBeNull()
+    expect(localStorage.getItem('sidebar-collapsed')).toBe('true')
+  })
+
+  it('dispatches a StorageEvent per cleared key so mounted refs revert', () => {
+    localStorage.setItem('awaken-planner-queue', '["echo"]')
+    const seen: (string | null)[] = []
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'awaken-planner-queue') seen.push(e.newValue)
+    }
+    window.addEventListener('storage', handler)
+    resetPlannerState()
+    window.removeEventListener('storage', handler)
+
+    expect(seen).toEqual([null])
+  })
+
+  it('is a no-op for keys that are already absent', () => {
+    // No keys set → nothing to remove, no throw.
+    expect(() => resetPlannerState()).not.toThrow()
+    for (const key of PLANNER_KEYS) expect(localStorage.getItem(key)).toBeNull()
+  })
+})

--- a/src/utils/save/resetPlannerState.ts
+++ b/src/utils/save/resetPlannerState.ts
@@ -1,0 +1,28 @@
+import { writeStorageKey } from '@/utils/save/writeStorageKey'
+
+// Planner and simulation state that each planner persists to its OWN localStorage
+// key, independent of useGameConfig. "Reset all" on the Configs page must wipe these
+// alongside the imported save — otherwise stale queues, targets, and scopes keep
+// pointing at a save that no longer exists (the awaken-rush queue was the symptom).
+// Owner composable is noted per key so this list stays discoverable.
+const PLANNER_STATE_KEYS = [
+  'awaken-planner-queue', // useAwakenGoals / AwakenRushPlanner — awaken-rush queue
+  'awaken-planner-boosters-excluded', // useAwakenBoosterRoster — booster roster overrides
+  'awaken-planner-boosters-included', // useAwakenBoosterRoster — booster roster overrides
+  'awaken-hands-free-fingerprint', // useAwakenHandsFree — "already calculated" gate
+  'awaken-sim-added', // useAwakenSimulation — Awaken Tree simulated purchases
+  'awaken-sim-removed', // useAwakenSimulation — Awaken Tree simulated removals
+  'sanctuary-target-tiers', // useSanctuary — sanctuary target-tier goals
+  'fabrication-simulated', // useCraftPlanner — simulated fabrication amounts
+  'planner-expedition-tier-selections', // useExpeditionTierSelections — expedition scope overrides
+  'planner-include-all-expeditions', // useExpeditionTierSelections — include-all toggle
+] as const
+
+/**
+ * Clear every save-scoped planner/simulation key. Each key is cleared through
+ * `writeStorageKey`, which fires a same-tab `storage` event so any already-mounted
+ * `useLocalStorage` ref reverts to its default.
+ */
+export function resetPlannerState(): void {
+  for (const key of PLANNER_STATE_KEYS) writeStorageKey(key, null)
+}

--- a/src/utils/save/writeStorageKey.ts
+++ b/src/utils/save/writeStorageKey.ts
@@ -1,0 +1,15 @@
+/**
+ * Write (or clear, when `value` is null) a localStorage key and fire a same-tab `storage`
+ * event so `useLocalStorage` refs elsewhere in the page pick up the change immediately —
+ * a native `storage` event only reaches other tabs, so same-tab consumers need this nudge.
+ * A null `newValue` makes those refs revert to their in-code default.
+ */
+export function writeStorageKey(key: string, value: string | null): void {
+  if (typeof localStorage === 'undefined' || typeof window === 'undefined') return
+  const oldValue = localStorage.getItem(key)
+  if (value === null) localStorage.removeItem(key)
+  else localStorage.setItem(key, value)
+  window.dispatchEvent(
+    new StorageEvent('storage', { key, oldValue, newValue: value, storageArea: localStorage }),
+  )
+}

--- a/src/views/ConfigsView.vue
+++ b/src/views/ConfigsView.vue
@@ -34,6 +34,7 @@ import { getCreatureImage } from '@/utils/images/creatureImages'
 import { getItemImage } from '@/utils/images/itemImages'
 import { decryptSave } from '@/utils/save/decrypt'
 import { extractSaveConfig, type SaveConfig } from '@/utils/save/parseSave'
+import { resetPlannerState } from '@/utils/save/resetPlannerState'
 
 const { t } = useI18n()
 
@@ -461,8 +462,10 @@ function applyAll() {
   applySaveConfig(save)
 
 
-  // A fresh save invalidates the old summon plan.
+  // A fresh save invalidates the old summon plan and any save-scoped planner state
+  // (awaken queue, boosters, sim, sanctuary targets, fabrication sim, expedition scope).
   clearSummoningPlannerSelection()
+  resetPlannerState()
 
 
   appliedSections.value = {
@@ -488,6 +491,9 @@ function resetAll() {
   resetCollection()
   resetGarden()
   clearSummoningPlannerSelection()
+  // Planner/simulation state each planner persists to its own key (awaken queue,
+  // boosters, sim, sanctuary targets, fabrication sim, expedition scope).
+  resetPlannerState()
   saveConfig.value = null
   saveFileName.value = ''
   savedAtMs.value = 0

--- a/src/views/LevelPlanner.vue
+++ b/src/views/LevelPlanner.vue
@@ -25,7 +25,7 @@ const route = useRoute()
 const router = useRouter()
 const { creatures } = useCreatures()
 const { ownedCreatureIds, getLevel, isAwakened } = useCreatureCollection()
-const { excludedCreatureIds, sanctuaryCreatureIds } = useGameConfig()
+const { excludedCreatureIds } = useGameConfig()
 const {
   expeditionTierOverrides,
   includeAllExpeditions,
@@ -398,7 +398,6 @@ const headingSubtitle = computed(() => {
       :creature-map="creatureMap"
       :overrideable-creatures="overrideableCreatures"
       :excluded-creature-ids="excludedCreatureIds"
-      :sanctuary-creature-ids="sanctuaryCreatureIds"
       :get-level="getLevel"
       :is-awakened="isAwakened"
       :creature-overrides="creatureOverrides"


### PR DESCRIPTION
## Description

Three independent planner fixes surfaced while working through a save file. The Awaken hands-free planner was stacking several creatures onto the same expedition at the same time (something the game can't actually run in parallel), "Reset all" left a pile of planner state behind pointing at a save that no longer existed, and the Prestige loop was auto-including Sanctuary-seated creatures that aren't really idle.

## Summary

- **Awaken hands-free:** spread each queued creature onto its own expedition instead of stacking solo runs on one lane. The lowest-level (bottleneck) creature picks the best expedition first and reserves it; later creatures re-plan with taken expeditions excluded, so each graduates on its own expedition. Makespan is unchanged in the common case since the bottleneck keeps the best expedition.
- **Reset / save import:** `ConfigsView` only cleared `useGameConfig`-owned state, so each planner's own `localStorage` keys survived a reset — the awaken queue, booster roster, awaken-tree sim, sanctuary targets, fabrication sim, and expedition scope. A new `resetPlannerState` wipes them on both Reset All and save import, `resetDungeonStorage` now also clears the dungeon focus/tier keys, and the same-tab storage sync is factored into a shared `writeStorageKey` helper.
- **Prestige loop:** Sanctuary-seated creatures were carved out of the excluded basis and auto-added to the roster, even though seating them forfeits their job-tier bonus. They're now treated like every other deployment — excluded from the auto-roster by default, still toggleable back in via the picker. Removes the now-dead `globalExcludedIds` param and `sanctuaryCreatureIds` prop.

Adds unit/integration coverage for all three (`useAwakenHandsFree`, `resetPlannerState`, `usePrestigeLoopPlanner`, plus a `dominantExpeditionId` case).
