### PR TITLE
Fix creature drawer's awaken button and seed its queue

### DIFF
--- a/src/components/beastiary/CreatureDetail.vue
+++ b/src/components/beastiary/CreatureDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Sparkles, TrendingUp, X } from 'lucide-vue-next'
+import { Sparkles, Target, X } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -253,11 +253,12 @@ function statHighlight(creature: Creature, statKey: keyof CreatureStats): string
           </div>
 
           <router-link
+            v-if="!isAwakened(creature.id)"
             :to="{ name: 'planner-creature', query: { tab: 'awaken', creature: creature.id } }"
             class="focus-ring bg-primary/12 hover:bg-primary/18 flex w-full items-center justify-center gap-2 rounded-lg border border-primary/35 px-4 py-2.5 text-sm font-semibold text-primary transition"
           >
-            <TrendingUp class="size-4" />
-            {{ t('beastiary.detail.planLeveling') }}
+            <Target class="size-4" />
+            {{ t('beastiary.detail.planAwakening') }}
           </router-link>
 
           <router-link

--- a/src/components/level-planner/AwakenRushPlanner.vue
+++ b/src/components/level-planner/AwakenRushPlanner.vue
@@ -37,6 +37,7 @@ import { isRunPartyStep } from '@/types'
 import type { Creature, PartyLevelingPlan, PlannerStrategy, PlannerTimeBudget } from '@/types'
 import { formatDuration, formatNumber } from '@/utils/format/format'
 import { getCreatureImage } from '@/utils/images/creatureImages'
+import { seedAwakenQueue } from '@/utils/planner/awakenQueue'
 import { expeditions as allExpeditions } from '@/utils/save/precomputedTables'
 
 const AWAKEN_TARGET = 70
@@ -161,16 +162,15 @@ const awakenSingle = computed(() => isAwaken.value && awakenQueue.value.length =
 const awakenMulti = computed(() => isAwaken.value && awakenQueue.value.length >= 2)
 
 
-// A creature routed in from its drawer's "Plan Awakening" button (?creature=<id>, mirrored
-// into creatureId by the parent) seeds the queue: append it when it's an eligible, not-yet-
-// queued awaken target. Registered before the queue→creatureId mirror below so a pre-existing
-// single-creature queue can't overwrite the routed id before it lands. The has() guard makes
-// the mirror's write-back a no-op here, so the two watchers don't loop.
+// Seed the queue from a creature routed in via the drawer's "Plan Awakening" button
+// (?creature=<id>, mirrored into creatureId by the parent). Registered before the
+// queue→creatureId mirror below so a pre-existing single-creature queue can't overwrite the
+// routed id before it lands; seedAwakenQueue returns the same array on a no-op, so the mirror's
+// write-back doesn't loop back through here.
 watch(
   creatureId,
   (id) => {
-    if (!id || awakenQueueSet.value.has(id) || !awakenEligibleIds.value.has(id)) return
-    awakenQueue.value = [...awakenQueue.value, id]
+    awakenQueue.value = seedAwakenQueue(awakenQueue.value, id, awakenEligibleIds.value)
   },
   { immediate: true },
 )

--- a/src/components/level-planner/AwakenRushPlanner.vue
+++ b/src/components/level-planner/AwakenRushPlanner.vue
@@ -161,6 +161,21 @@ const awakenSingle = computed(() => isAwaken.value && awakenQueue.value.length =
 const awakenMulti = computed(() => isAwaken.value && awakenQueue.value.length >= 2)
 
 
+// A creature routed in from its drawer's "Plan Awakening" button (?creature=<id>, mirrored
+// into creatureId by the parent) seeds the queue: append it when it's an eligible, not-yet-
+// queued awaken target. Registered before the queue→creatureId mirror below so a pre-existing
+// single-creature queue can't overwrite the routed id before it lands. The has() guard makes
+// the mirror's write-back a no-op here, so the two watchers don't loop.
+watch(
+  creatureId,
+  (id) => {
+    if (!id || awakenQueueSet.value.has(id) || !awakenEligibleIds.value.has(id)) return
+    awakenQueue.value = [...awakenQueue.value, id]
+  },
+  { immediate: true },
+)
+
+
 // Mirror the lone queued creature into the single planner's creature id.
 watch(
   [awakenSingle, awakenQueue],

--- a/src/locales/de/ui.json
+++ b/src/locales/de/ui.json
@@ -240,7 +240,7 @@
       "decreaseCreatureLevel": "Kreaturstufe verringern",
       "increaseCreatureLevel": "Kreaturstufe erhöhen",
       "creatureLevel": "Kreaturstufe",
-      "planLeveling": "Aufstieg planen",
+      "planAwakening": "Awakening planen",
       "stats": "Werte",
       "jobLevels": "Berufsstufen",
       "bestExpeditions": "Beste Expeditionen",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -240,7 +240,7 @@
       "decreaseCreatureLevel": "Decrease creature level",
       "increaseCreatureLevel": "Increase creature level",
       "creatureLevel": "Creature level",
-      "planLeveling": "Plan Leveling",
+      "planAwakening": "Plan Awakening",
       "stats": "Stats",
       "jobLevels": "Job Levels",
       "bestExpeditions": "Best Expeditions",

--- a/src/locales/es/ui.json
+++ b/src/locales/es/ui.json
@@ -240,7 +240,7 @@
       "decreaseCreatureLevel": "Reducir nivel de criatura",
       "increaseCreatureLevel": "Aumentar nivel de criatura",
       "creatureLevel": "Nivel de criatura",
-      "planLeveling": "Planificar subida de nivel",
+      "planAwakening": "Planificar Awakening",
       "stats": "Estadísticas",
       "jobLevels": "Niveles de trabajo",
       "bestExpeditions": "Mejores expediciones",

--- a/src/locales/fr/ui.json
+++ b/src/locales/fr/ui.json
@@ -240,7 +240,7 @@
       "decreaseCreatureLevel": "Diminuer le niveau de la créature",
       "increaseCreatureLevel": "Augmenter le niveau de la créature",
       "creatureLevel": "Niveau de la créature",
-      "planLeveling": "Planifier la montée",
+      "planAwakening": "Planifier Awakening",
       "stats": "Statistiques",
       "jobLevels": "Niveaux de travail",
       "bestExpeditions": "Meilleures expéditions",

--- a/src/locales/tr/ui.json
+++ b/src/locales/tr/ui.json
@@ -240,7 +240,7 @@
       "decreaseCreatureLevel": "Yaratık seviyesini azalt",
       "increaseCreatureLevel": "Yaratık seviyesini artır",
       "creatureLevel": "Yaratık seviyesi",
-      "planLeveling": "Seviye Planla",
+      "planAwakening": "Awakening Planla",
       "stats": "İstatistikler",
       "jobLevels": "İş Seviyeleri",
       "bestExpeditions": "En İyi Seferler",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -240,7 +240,7 @@
       "decreaseCreatureLevel": "降低生物等級",
       "increaseCreatureLevel": "提升生物等級",
       "creatureLevel": "生物等級",
-      "planLeveling": "規劃升級",
+      "planAwakening": "規劃 Awakening",
       "stats": "屬性",
       "jobLevels": "工作等級",
       "bestExpeditions": "最佳遠征",

--- a/src/utils/__tests__/awakenQueue.test.ts
+++ b/src/utils/__tests__/awakenQueue.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'vitest'
+
+import { seedAwakenQueue } from '@/utils/planner/awakenQueue'
+
+const eligible = (...ids: string[]) => new Set(ids)
+
+describe('seedAwakenQueue', () => {
+  test('appends an eligible, not-yet-queued creature to an empty queue', () => {
+    expect(seedAwakenQueue([], 'pudge', eligible('pudge', 'finn'))).toEqual(['pudge'])
+  })
+
+  test('appends to the end of a non-empty queue, preserving order', () => {
+    expect(seedAwakenQueue(['finn'], 'pudge', eligible('pudge', 'finn'))).toEqual(['finn', 'pudge'])
+  })
+
+  test('does not mutate the input queue', () => {
+    const queue = ['finn']
+    seedAwakenQueue(queue, 'pudge', eligible('pudge', 'finn'))
+    expect(queue).toEqual(['finn'])
+  })
+
+  test('is a no-op when the creature is already queued (same reference)', () => {
+    const queue = ['pudge', 'finn']
+    const next = seedAwakenQueue(queue, 'pudge', eligible('pudge', 'finn'))
+    expect(next).toBe(queue)
+  })
+
+  test('is a no-op when the creature is not an eligible awaken target (same reference)', () => {
+    const queue = ['finn']
+    // e.g. already awakened / not owned → not in the eligible set
+    const next = seedAwakenQueue(queue, 'pudge', eligible('finn'))
+    expect(next).toBe(queue)
+  })
+
+  test('is a no-op for an empty id (no creature routed in)', () => {
+    const queue = ['finn']
+    expect(seedAwakenQueue(queue, '', eligible('pudge', 'finn'))).toBe(queue)
+  })
+
+  test('is a no-op for an undefined id', () => {
+    const queue = ['finn']
+    expect(seedAwakenQueue(queue, undefined, eligible('pudge', 'finn'))).toBe(queue)
+  })
+})

--- a/src/utils/planner/awakenQueue.ts
+++ b/src/utils/planner/awakenQueue.ts
@@ -1,0 +1,22 @@
+/**
+ * Awaken-rush queue seeding.
+ *
+ * The creature drawer's "Plan Awakening" button routes to the Awaken tab with
+ * ?creature=<id>, which the planner mirrors into `creatureId`. The tab itself is
+ * driven by a persisted queue, so a routed creature only reaches the plan once it's
+ * appended to that queue. This computes the next queue: append the routed id when it's
+ * a valid, not-yet-queued awaken target; otherwise return the queue unchanged.
+ *
+ * The no-op path returns the SAME array reference so the reactive caller's assignment
+ * is a genuine no-op (no spurious localStorage write, no watcher loop).
+ *
+ * Pure + unit-tested.
+ */
+export function seedAwakenQueue(
+  queue: string[],
+  id: string | undefined,
+  eligibleIds: ReadonlySet<string>,
+): string[] {
+  if (!id || queue.includes(id) || !eligibleIds.has(id)) return queue
+  return [...queue, id]
+}


### PR DESCRIPTION
## Description

The creature drawer's "Plan Leveling" button was mislabeled and inert. It linked to the planner's Awaken tab with `?creature=<id>`, but that tab is driven by a persisted queue whose data only flowed one way (queue → `creatureId`), so the routed creature never actually entered the plan. It also rendered for already-awakened creatures, where awakening is a no-op. This renames and repurposes it as "Plan Awakening", gates it to creatures that still need awakening, and makes it seed the Awaken tab's queue so the creature you clicked shows up in the plan. Fixes #143.

## Summary

- Rename the drawer button from "Plan Leveling" to "Plan Awakening" and swap its leveling icon (`TrendingUp`) for the Awaken tab's `Target` icon in `CreatureDetail.vue`.
- Gate the button to unawakened creatures (`v-if="!isAwakened(creature.id)"`), mirroring how the sibling "Plan Summoning" button is gated.
- Seed the Awaken queue from the routed creature: `AwakenRushPlanner` now appends an eligible, not-yet-queued `creatureId` to the persisted `awaken-planner-queue`, registered before the queue → `creatureId` mirror so a pre-existing single-creature queue can't clobber the routed id.
- Extract the seeding decision into a pure `seedAwakenQueue()` helper (`utils/planner/awakenQueue.ts`) and cover it with unit tests (append to empty/non-empty queue, same-reference no-op for empty/undefined/already-queued/ineligible ids, input immutability).
- Localize the "Plan" verb per locale while keeping "Awakening" in English as a game term, consistent with the frozen-term policy; update the i18n identical-value allowlist accordingly.

